### PR TITLE
docs(planning): frontend milestones M6-M10 + alignment with M1-M5

### DIFF
--- a/docs/hackathon/README.md
+++ b/docs/hackathon/README.md
@@ -1,0 +1,15 @@
+# Built with Opus 4.7: a Claude Code hackathon
+
+## About Event
+
+Join us again for Built with Opus 4.7: a Claude Code virtual hackathon!
+
+Opus 4.7 is our most capable model yet, and we’re excited for you to push the limits of what it can do. Whether you’re a seasoned engineer or newly a builder, show us what you can build in one week with Claude Code.
+
+Some projects will start from what you already know — show us the thing only you'd know to build, the problem in your work or community that takes weeks but should take hours. Others will start from what's next — show us something that's easier to demo than to explain, an idea that doesn't exist yet but should.
+
+We’ll select 500 participants and give each one $500 in Claude API credits to build for a week. Compete to win $100k in Claude API credits.
+
+Judges include Boris Cherny, Cat Wu, Thariq Shihipar, Lydia Hallie, Ado Kukic, and Jason Bigman from the Claude team.
+
+Note: This event is fully virtual. Space is limited to 500 participants. Maximum team size is two. All participants must submit an application for approval.

--- a/docs/hackathon/rules.md
+++ b/docs/hackathon/rules.md
@@ -1,0 +1,250 @@
+# **Participant Resources**
+
+Thank you for being part of the [Built with Opus 4.7: a Claude Code hackathon](https://cerebralvalley.ai/events/~/e/built-with-4-7-hackathon) as a builder 👋 This document contains all the key details you’ll need to make the most of the event.
+
+## **1. Discord Server Information**
+
+Join the hackathon Discord server here: [https://anthropic.com/discord](https://anthropic.com/discord)
+
+Please note: We will assign a custom role to your discord handle so you will be able to see the hackathon specific channels.
+
+## **2. Hackathon Schedule**
+
+- **Tuesday, April 21st**
+
+  - **12:00 PM (EST):** Virtual Kickoff – rules, prizes, judging, technical talks
+
+  - **12:30 PM (EST):** Hacking officially begins; team formation on Discord
+
+  - **5:00–6:00 PM (EST):** Anthropic office hours (#office-hours)
+
+- **Wednesday, April 22nd**
+
+  - **12:00–1:00 PM (EST):** Live Session One - AMA with [Thariq Shihipar](https://x.com/trq212), Member of Technical Staff at Anthropic (Claude Code)
+
+  - **5:00–6:00 PM (EST):** Anthropic office hours (#office-hours)
+
+- **Thursday, April 23rd**
+
+  - **All Day:** Hacking continues
+
+  - **11:00 AM–12:00 PM (EST):** Live Session Two - Overview of how to use Claude Managed Agents with [Michael Cohen](https://www.linkedin.com/in/michael-cohen1995/), Member of the Technical Staff at Claude Labs
+
+  - **5:00–6:00 PM (EST):** Anthropic office hours (#office-hours)
+
+- **Friday, April 24th**
+
+  - **12:00–1:00 PM (EST):** Live Session Three - with Mike Brown, 1st place winner of Built with Opus 4.6: insights, learnings, and where is he now?
+
+  - **5:00–6:00 PM (EST):** Anthropic office hours (#office-hours)
+
+- **Saturday, April 25th**
+
+  - **All Day:** Hacking continues
+
+  - **5:00–6:00 PM (EST):** Anthropic office hours (#office-hours)
+
+- **Sunday, April 26th**
+
+  - **12:00–1:00 PM (EST):** Live Session Four - Michal Nedoszytko, 3rd place winner of Built with Opus 4.6: insights, learnings, and where is he now?
+
+  - **5:00–6:00 PM (EST):** Anthropic office hours (#office-hours)
+
+  - **8:00 PM (EST):** Submissions due via CV platform
+
+- **Monday, April 27th**
+
+  - **All Day:** First Round Judging (asynchronous)
+
+- **Tuesday, April 28th**
+
+  - **12:00 PM (EST): Final Round Judging**
+
+    - Top 6 teams announced (#announcements)
+
+    - Final round Judging
+
+  - **12:45 PM (EST): Closing Ceremony**
+
+    - Top 3 revealed, celebration & closing remarks
+
+## **3. Hackathon Rules**
+
+To keep things fair and aligned with our goals, all teams must follow these rules:
+
+- **Open Source:** Everything shown in the demo must be fully open source. This includes every component - backend, frontend, models, and any other parts of the project - published under an approved open source license.
+
+- **New Work Only:** All projects must be started from scratch during the hackathon with no previous work.
+
+- **Team Size:** Teams may have up to **2** members.
+
+- **Banned Projects:** Projects will be disqualified if they: violate legal, ethical, or platform policies, use code, data, or assets you do not have the rights to.
+
+## **4. Problem Statements**
+
+### **1. Build From What You Know**
+
+Start from a real problem in a real place: your work, your community, a field you're close to. The process that takes weeks and should take hours. The thing someone you know still does by hand. Domain expertise beats credentials — show us the thing only you'd know to build.
+
+*Looks like:* the process that takes weeks and should take hours. The decision was made on gut because the data's too scattered to use. The thing someone you know still does by hand.
+
+### **2. Build For What's Next**
+
+Start from something that doesn't exist yet: a new way to work, learn, or make that only makes sense now that the tools have changed. An interface without a name. A workflow from a few years out. The best projects here are easier to demo than to explain
+
+*Looks like:* an interface that doesn't have a name yet. A workflow that changes how you do the thing, not just how fast. A first draft of how this will work in a few years when Claude is even more capable. 
+
+## **5. Anthropic-Provided Resources**
+
+### **Quickstarts**
+
+[Claude Code Quickstart](https://code.claude.com/docs/en/quickstart)
+
+[Claude API Quickstart](https://platform.claude.com/docs/en/get-started)
+
+[Claude Models Overview](https://platform.claude.com/docs/en/about-claude/models/overview)
+
+### **Docs**
+
+[Claude Code Docs](https://code.claude.com/docs)
+
+[Claude API Docs](https://platform.claude.com/docs/en/home)
+
+[MCP Docs](https://modelcontextprotocol.io/docs/getting-started/intro)
+
+[Agent Skills Docs](https://agentskills.io/home)
+
+### **Claude Managed Agents**
+
+[Docs](https://platform.claude.com/docs/en/managed-agents/overview)
+
+[Overview video](https://www.youtube.com/watch?v=NLWiIj47IdI)
+
+[Claude Managed Agents: get to production 10x faster](https://claude.com/blog/claude-managed-agents) (*blog*)
+
+[Scaling Managed Agents: Decoupling the brain from the hands](https://www.anthropic.com/engineering/managed-agents) (*blog*)
+
+### **Blogs**
+
+[Claude Code Best Practices](https://code.claude.com/docs/en/best-practices)
+
+[Building Effective Agents](https://www.anthropic.com/engineering/building-effective-agents)
+
+[Building Agents with the Claude Agent SDK](https://claude.com/blog/building-agents-with-the-claude-agent-sdk)
+
+[Building multi-agent systems: when and how to use them](https://claude.com/blog/building-multi-agent-systems-when-and-how-to-use-them)
+
+[Best practices for prompt engineering](https://claude.com/blog/best-practices-for-prompt-engineering)
+
+[Effective Context Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
+
+[Extending Claude’s capabilities with skills and MCP servers](https://claude.com/blog/extending-claude-capabilities-with-skills-mcp-servers)
+
+[Skills explained: How Skills compares to prompts, Projects, MCP, and subagents](https://claude.com/blog/skills-explained)
+
+[Building agents with Skills: Equipping agents for specialized work](https://claude.com/blog/building-agents-with-skills-equipping-agents-for-specialized-work)
+
+[Claude Code power user customization: How to configure hooks](https://claude.com/blog/how-to-configure-hooks)
+
+### **Courses**
+
+[Claude Code in Action](https://anthropic.skilljar.com/claude-code-in-action)
+
+[Agent Skills with Anthropic](https://www.deeplearning.ai/short-courses/agent-skills-with-anthropic/)
+
+[Claude Code Courses GitHub](https://github.com/anthropics/courses)
+
+### **Other**
+
+[Claude Quickstarts](https://github.com/anthropics/claude-quickstarts) - A collection of projects designed to help developers quickly get started with building deployable applications using the Claude API 
+
+[A Complete Guide to Building Skills for Claude (eBook)](https://claude.com/blog/complete-guide-to-building-skills-for-claude)
+
+[Claude Cookbooks](https://platform.claude.com/cookbook/) and [Cookbooks Github Repo](https://github.com/anthropics/claude-cookbooks)
+
+[Agent Skills Github Repo](https://github.com/anthropics/skills)
+
+## **6. Judging**
+
+Judging for the Anthropic Virtual Hackathon happens in **two stages**:
+
+### **Stage 1 – Asynchronous Judging**
+
+- **Date:** April 26th - April 27th
+
+- **How it works:**
+
+  - Judges review your **submitted projects asynchronously** via the judging platform.
+
+  - Each team will have uploaded:
+
+    1. A **short demo video** (3 minute maximum)
+
+    2. Open Source Project repository / code
+
+    3. Written summary (100–200 words)
+
+  - Judges independently evaluate projects using **standardized criteria**.\
+    **Judging Criteria:**
+
+    1. **Impact (30%) -** What's the real-world potential here? Who benefits, and how much does it matter? Could this actually become something people use? Does it fit into one of the problem statements listed above?
+
+    2. **Demo (25%) *—*** Is this a working, impressive demo? Does it hold up live? Is it genuinely cool to watch?
+
+    3. **Opus 4.7 Use (25%) -** How creatively did this team use Opus 4.7? Did they go beyond a basic integration? Did they surface capabilities that surprised even us?
+
+    4. **Depth & Execution (20%) —** Did the team push past their first idea? Is the engineering sound and thoughtfully refined? Does this feel like something that was wrestled with — real craft, not just a quick hack?
+
+  - After evaluation, the **team aggregates scores** to determine the **Top 6 projects** for the final round
+
+### **Stage 2 – Final Round Live Judging**
+
+- **Date & Time:** April 28th, 12:00PM EST
+
+- **Format:**
+
+  - During the live session, **pre-recorded demos** from each team will be played (3 minutes per team).
+
+  - Judges will deliberate after all demos to determine the 1st, 2nd, and 3rd place along with extra prizes.
+
+  - **The top three and special prize winners** will be announced during the closing ceremony at **1:45PM EST.**
+
+## **7. Submission Instructions**
+
+- Submit your project below:
+
+  [linkEmbed]
+
+- Required for submission:
+
+  - **3-minute demo video** (YouTube, Loom, or similar)
+
+  - **GitHub repository or code link**
+
+  - **Written description / summary**
+
+- **Deadline:** April 26th, 8:00 PM EST
+
+- Make sure your project was **built entirely during the hackathon**; no pre-existing work is allowed.
+
+## **8. Prizes**
+
+- **1st Place:** $50,000 in Claude API Credits
+
+- **2nd Place:** $30,000 in Claude API Credits
+
+- **3rd Place:** $10,000 in Claude API Credits
+
+- **Most Creative Opus 4.7 Exploration**: $5,000 in Claude API Credits
+
+  - For the project that treated Opus 4.7 as a creative medium, not just a tool. We're looking for the project with a voice, a point of view — something expressive, playful, strange, or alive. The one that made us feel something.
+
+- **The “Keep Thinking” Prize**: $5,000 in Claude API Credits
+
+  - For the project that didn't stop at the first idea — and landed somewhere nobody saw coming. We're looking for the team that found a real-world problem nobody thought to point Claude at. The one that changes how we think about where this technology belongs.
+
+- **Best use of Claude Managed Agents:** $5,000 in Claude API Credits
+
+  - For the team that leveraged the Claude platform the best. We're looking for the project that best uses Managed Agents to hand off meaningful, long-running tasks — not just a demo, but something you'd actually ship.
+
+## **❓If you have any questions, please ping in #questions on Discord or reach out to moderators.**

--- a/docs/planning/ALIGNMENT.md
+++ b/docs/planning/ALIGNMENT.md
@@ -79,11 +79,14 @@ corréler tous les events d'un même tour agentique dans l'Activity Feed / Inspe
 
 ---
 
-## Les 4 issues à ajouter dans le plan backend pour sécuriser les prix
+## Les 4 issues backend critiques pour sécuriser les prix
 
-Ces 4 issues manquent actuellement dans M1–M5 et bloquent des features de l'UI qui
-sont critiques pour les prix "Best Managed Agents $5k" et "Opus 4.7 Use" (25% de
-la note).
+> ℹ️ Ces 4 issues ont été **ajoutées directement dans les milestones backend**
+> par cette PR (M2.9 dans M2, M4.5 + M4.6 + M4.7 dans M4, M5.4 dans M5). Cette
+> section reste comme vue synthétique et rappel du "pourquoi critique".
+
+Les 4 issues `🔴` + 1 bonus `🟡`, toutes nécessaires pour les prix "Best Managed
+Agents \$5k" et "Opus 4.7 Use" (25% de la note).
 
 ### 🔴 Issue M4.5 (nouveau) — Extended thinking sur Investigator
 

--- a/docs/planning/ALIGNMENT.md
+++ b/docs/planning/ALIGNMENT.md
@@ -1,0 +1,323 @@
+# Alignment — Backend × Frontend plans
+
+> Document de référence croisé entre les milestones backend (M1→M5 par @zestones) et
+> frontend (M6→M10 par @vgtray).
+>
+> **À lire par les deux devs avant de commencer J3.**
+
+---
+
+## Répartition des lanes
+
+| Lane | Owner | Milestones |
+|------|-------|------------|
+| Backend (MCP, agents, orchestration, WS broadcast) | zestones | M1, M2, M3, M4, M5 |
+| Frontend (shell, control room, chat, artifacts, onboarding, WO console) | vgtray | M6, M7, M8, M9 |
+| Shared (E2E rehearsal, submission) | les deux | M10 |
+
+**Zéro overlap de fichiers.** Backend touche `backend/*`, frontend touche `frontend/*`.
+Les deux côtés parlent via :
+1. REST existant (`/api/v1/hierarchy`, `/signals/current`, `/monitoring/status/current`, `/kpi/*`, `/work-orders`, `/logbook`, `/shifts/current`, `/kb/*`)
+2. REST nouveaux pour KB Builder (`/kb/equipment/{cell_id}/upload`, `/kb/equipment/{cell_id}/onboarding/*`)
+3. **WebSocket unique** `/api/v1/events` (broadcast global) + `/api/v1/agent/chat` (Q&A stateful)
+
+---
+
+## Contrat WebSocket events (v1)
+
+Décidé après review du plan backend. Deux endpoints WS :
+
+### `WS /api/v1/events` — broadcast global (cf. M4.1)
+
+Envoyé par le backend à tous les clients connectés. Filtrage côté frontend par
+`cell_id` dans le payload. Utilisé par l'Anomaly Banner, l'Activity Feed, le dashboard.
+
+| Event type | Payload | Émis par |
+|------------|---------|----------|
+| `anomaly_detected` | `{cell_id, signal_def_id, value, threshold, work_order_id, time}` | Sentinel |
+| `tool_call_started` | `{agent, tool_name, args, turn_id}` | Investigator / Q&A / WO Gen |
+| `tool_call_completed` | `{agent, tool_name, duration_ms, turn_id}` | idem |
+| `agent_handoff` ⭐ | `{from_agent, to_agent, reason, turn_id}` | orchestrator on `ask_*` tool call |
+| `thinking_delta` ⭐ | `{agent, content, turn_id}` | Investigator (extended thinking) |
+| `rca_ready` | `{work_order_id, rca_summary, confidence, turn_id}` | Investigator |
+| `work_order_ready` | `{work_order_id}` | Work Order Generator |
+| `ui_render` ⭐ | `{agent, component, props, turn_id}` | n'importe quel agent |
+| `agent_start` | `{agent, turn_id}` | orchestrator |
+| `agent_end` | `{agent, turn_id, finish_reason}` | orchestrator |
+
+⭐ = ajouts par rapport au M4.1 initial, nécessaires pour les prix (voir gaps ci-dessous).
+
+### `WS /api/v1/agent/chat` — Q&A stateful (cf. M5.2)
+
+Connexion persistante par session user. Flux bidirectionnel.
+
+**Client → serveur :**
+```json
+{"type": "user", "content": "Pourquoi P-02 a vibré hier soir ?"}
+```
+
+**Serveur → client :**
+```json
+{"type": "text_delta", "content": "Je regarde..."}
+{"type": "thinking_delta", "content": "L'anomalie date de..."}         // Opus 4.7
+{"type": "tool_call", "name": "get_signal_trends", "args": {...}}
+{"type": "tool_result", "name": "get_signal_trends", "summary": "..."}
+{"type": "ui_render", "component": "SignalChart", "props": {...}}      // generative UI
+{"type": "agent_handoff", "from": "qa", "to": "investigator", "reason": "..."}
+{"type": "done"}
+```
+
+### Règle de sérialisation
+
+Tous les events JSON sur une seule ligne. Pas d'event type `error` côté stream —
+les erreurs transit via HTTP status ou un `{"type": "done", "error": "..."}` final.
+
+### `turn_id`
+
+Généré par le backend à chaque `agent_start` (UUID v4). Permet au frontend de
+corréler tous les events d'un même tour agentique dans l'Activity Feed / Inspector.
+
+---
+
+## Les 4 issues à ajouter dans le plan backend pour sécuriser les prix
+
+Ces 4 issues manquent actuellement dans M1–M5 et bloquent des features de l'UI qui
+sont critiques pour les prix "Best Managed Agents $5k" et "Opus 4.7 Use" (25% de
+la note).
+
+### 🔴 Issue M4.5 (nouveau) — Extended thinking sur Investigator
+
+**Scope.** Activer `thinking` sur l'agent loop Investigator (cf. M4.3).
+
+```python
+response = await anthropic.messages.create(
+    model=model_for("agent"),
+    thinking={"type": "enabled", "budget_tokens": 10000},
+    system=INVESTIGATOR_SYSTEM,
+    messages=messages,
+    tools=tools_schema,
+    stream=True,
+)
+```
+
+**Streaming des `thinking_delta`.** À chaque chunk `thinking_delta` reçu de
+l'Anthropic API, broadcaster via WSManager :
+```python
+await ws_manager.broadcast("thinking_delta", {
+    "agent": "investigator",
+    "content": chunk.thinking_delta.text,
+    "turn_id": turn_id,
+})
+```
+
+**Décision.** Budget 10k tokens suffit pour un RCA. Coûte ~5¢ par exécution avec
+Opus 4.7. Activé uniquement sur Investigator (pas les autres agents — pas besoin).
+
+**Pourquoi critique.** C'est la feature flagship Opus 4.7 vs Sonnet/Opus 4.6.
+Sans ça, les juges ne voient pas de différence "pourquoi Opus 4.7 plutôt que
+Sonnet ?". Le frontend (M8.5 Agent Inspector) streame le thinking en direct dans
+un panel dédié → le juge **voit** Opus réfléchir. C'est LE wow factor.
+
+**Acceptance.**
+- [ ] `thinking_delta` events streamés pendant un run Investigator
+- [ ] Frontend peut afficher le thinking en live (vérifié avec M8.5)
+
+**Bloque.** Frontend M8.5 (Agent Inspector thinking tab).
+
+---
+
+### 🔴 Issue M4.6 (nouveau) — Agent-as-tool pattern (handoffs dynamiques)
+
+**Scope.** Déclarer les autres agents comme tools que Investigator peut appeler.
+
+**Problème actuel.** M4.3 propose `asyncio.create_task(run_work_order_generator(...))`
+en fin d'Investigator — c'est un pipeline scripté. Les juges voient "orchestration
+Python", pas "multi-agent".
+
+**Décision.** Déclarer 2 tools locaux côté Investigator :
+
+```python
+ASK_KB_BUILDER_TOOL = {
+  "name": "ask_kb_builder",
+  "description": "Consulte le KB Builder pour obtenir un détail constructeur "
+                 "non présent dans la KB actuelle (ex: torque max d'un boulon, "
+                 "référence pièce introuvable).",
+  "input_schema": {"type": "object", "properties": {
+    "question": {"type": "string"},
+    "cell_id": {"type": "integer"}
+  }, "required": ["question", "cell_id"]}
+}
+```
+
+Quand Investigator appelle `ask_kb_builder` :
+1. `ws_manager.broadcast("agent_handoff", {from: "investigator", to: "kb_builder", reason: args.question})`
+2. Spawn une session KB Builder courte (Messages API loop, system prompt spécialisé
+   "tu réponds factuellement à une question de collègue agent")
+3. Retourne la réponse comme `tool_result` à Investigator
+4. `ws_manager.broadcast("agent_end", {agent: "kb_builder", ...})`
+
+**Idem côté Q&A (M5.2).** Déclarer `ask_investigator` pour que Q&A délègue
+les questions diagnostiques pointues.
+
+**Pourquoi critique.** Sans ce pattern, le multi-agent est un workflow scripté.
+Avec, les handoffs sont **décidés par les agents** via tool call. C'est le
+critère différenciant pour le prix "Best Managed Agents".
+
+**Minimum démo.** Au moins 2 handoffs dynamiques visibles :
+- Scène 3 (Investigation) : Investigator → KB Builder pour chercher une référence pièce
+- Scène 5 (Q&A) : Q&A → Investigator pour une question diagnostique
+
+**Acceptance.**
+- [ ] Investigator peut appeler `ask_kb_builder` et reçoit une réponse structurée
+- [ ] Event `agent_handoff` broadcasté visible dans le WS stream
+- [ ] Scénario démo P-02 fait au moins 1 handoff dynamique
+
+**Bloque.** Pitch "Best Managed Agents" crédible.
+
+---
+
+### 🔴 Issue M5.4 (nouveau) — Q&A migration vers Claude Managed Agents
+
+**Scope.** Remplacer l'agent loop Messages API du M5.2 par **Claude Managed Agents**.
+
+**Problème actuel.** M5.2 implémente Q&A en Messages API loop classique. Or on vise
+le prix **Best Managed Agents $5k** — il faut l'utiliser.
+
+**Décision.** Q&A = seul agent en Managed Agents. Les 4 autres (Sentinel,
+Investigator, KB Builder, Work Order Gen) restent Messages API + orchestrateur
+maison + agent-as-tool. Raison : Q&A est interactif, stateful, long-running — le
+cas d'usage idéal pour Managed Agents. Les autres n'en ont pas besoin.
+
+**Implémentation.**
+- Utiliser la Managed Agents SDK (custom tools)
+- Tools exposés : les 14 MCP tools + `ask_investigator` (agent-as-tool)
+- Streaming via WebSocket (voir contrat `WS /api/v1/agent/chat`)
+
+**Fallback (M5.3 actuel).** Si Managed Agents instable → switch vers l'agent loop
+Messages API écrit dans M5.2. 10 min de switch. Prévoir un feature flag
+`USE_MANAGED_AGENTS=true/false` pour bascule rapide.
+
+**Pourquoi critique.** Sans Managed Agents sur au moins 1 agent, aucune chance de
+gagner le prix $5k dédié. L'implémentation est modérée (30–60 min de code).
+
+**Acceptance.**
+- [ ] Q&A répond via Managed Agents, streaming visible côté WS
+- [ ] Fallback feature flag testé (switch OK en <5 min)
+- [ ] Tools MCP accessibles depuis le Managed Agent
+
+**Bloque.** Prix "Best Managed Agents $5k".
+
+---
+
+### 🔴 Issue M2.9 (nouveau) — UI tools generative (`render_*`) déclarés dans les agents
+
+**Scope.** Ajouter dans les tools déclarés aux agents (en plus des 14 MCP tools
+data) 9 tools "generative UI" que les agents invoquent pour émettre des
+`ui_render` events visibles dans le chat.
+
+**Pas d'implémentation Python.** Ces tools n'ont pas de code backend — ils sont
+des **schémas** passés au LLM. Quand l'agent décide d'appeler `render_signal_chart`,
+l'orchestrateur capture le `tool_use`, broadcast un event `ui_render`, et retourne
+immédiatement un `tool_result` `"rendered"` sans effet de bord.
+
+**Les 9 tools (cf. M8 frontend) :**
+
+| Tool name | Used by | Props schema (summary) |
+|---|---|---|
+| `render_signal_chart` | Investigator, Q&A | `{signal_def_id, window_hours, mark_anomaly_at?, threshold?}` |
+| `render_equipment_kb_card` | KB Builder, Q&A | `{cell_id, highlight_fields?}` |
+| `render_work_order_card` | Work Order Gen | `{work_order_id, printable: true}` |
+| `render_diagnostic_card` | Investigator | `{title, confidence, root_cause, contributing_factors[], pattern_match_id?}` |
+| `render_correlation_matrix` | Investigator | `{sources[], impact_matrix[][]}` |
+| `render_pattern_match` | Investigator | `{current_event, past_event_ref, similarity}` |
+| `render_bar_chart` | Q&A | `{title, x_label, y_label, bars[]}` |
+| `render_alert_banner` | Sentinel (auto-emit) | `{severity, cell_id, message, anomaly_id}` |
+| `render_kb_progress` | KB Builder | `{steps[{label, status}]}` |
+
+**Pourquoi critique.** Sans ces tools, Q&A / Investigator répondent en markdown
+texte uniquement. Avec, le chat affiche inline des graphes, cards, diagnostics
+**rendus par l'agent lui-même** — c'est le pattern Generative UI / Claude artifacts.
+C'est ce qui rend la démo visuellement agentique et distingue ARIA d'un chatbot
+classique.
+
+**Implémentation.**
+- Ajouter dans `backend/agents/ui_tools.py` les 9 schémas (type `dict`)
+- Dans chaque agent loop, concaténer : `tools = mcp_tools + ui_tools + submit_tool`
+- Dans le handler de `tool_use` : si `tool_name.startswith("render_")` →
+  `ws_manager.broadcast("ui_render", {...})` + immédiatement `tool_result={"content": "rendered"}`
+
+**Pattern d'intégration dans le system prompt de chaque agent :**
+```
+Pour rendre visuels tes résultats, tu peux appeler :
+- render_signal_chart(...) pour afficher une courbe
+- render_diagnostic_card(...) pour afficher ton diagnostic final
+- ...
+Appelle-les quand c'est plus parlant qu'une réponse texte.
+```
+
+**Acceptance.**
+- [ ] Investigator émet `ui_render` pour `render_diagnostic_card` à la fin du RCA
+- [ ] Q&A émet `ui_render` pour `render_signal_chart` si la question porte sur un signal
+- [ ] Frontend (M7.5 + M8.1–M8.3) rend les composants correctement
+
+**Bloque.** Frontend M7.5 (artifact registry), M8.1–M8.3 (artifacts individuels).
+
+---
+
+### 🟡 Bonus — Issue M4.7 (nouveau, P1) — Memory flex scene
+
+**Scope.** L'Investigator doit charger `failure_history` du cell dans son contexte
+et produire un RCA **visiblement plus rapide/précis au 2e diagnostic similaire**.
+
+**Implémentation.**
+- Au début du run Investigator : `past_failures = await get_failure_history(cell_id, limit=5)`
+- Injecter dans le system prompt : "Pannes précédentes : {past_failures}. Si le
+  pattern actuel matche une panne précédente, cite-la explicitement."
+- Dans le RCA output, remplir `similar_past_failure` avec l'id du match
+
+**Scène démo dédiée.** Route backend `POST /api/v1/demo/trigger-memory-scene` qui :
+1. Insert une fausse entrée `failure_history` datée de 3 mois (pattern P-02)
+2. Trigger une anomalie P-02 actuelle
+3. L'Investigator match → RCA cite la panne passée
+
+**Pourquoi intéressant.** Feature "l'agent apprend" mise en scène visuellement.
+Prouve que la KB sert vraiment.
+
+**Priorité.** P1 — bonus si reste du temps J6 PM. Si serré : skip, l'essentiel
+c'est que l'Investigator utilise `failure_history` en contexte.
+
+---
+
+## Issues frontend — résumé
+
+Les 4 milestones frontend (voir fichiers dédiés dans `docs/planning/M6-*/` à
+`M9-*/`) dépendent directement de :
+
+| Frontend issue | Dépend de backend |
+|---|---|
+| M6.4 WS client typé | M4.1 (WSManager) |
+| M6.5 Chat shell mocké | aucun (mock) |
+| M7.3 Anomaly banner | M4.1 + M4.2 (events `anomaly_detected`) |
+| M7.4 Wire chat réel | M5.2 + M5.4 (WS /agent/chat) |
+| M7.5 Artifact registry | M2.9 (ui_render tools déclarés) |
+| M8.1–M8.3 Artifacts | M2.9 |
+| M8.4 Activity Feed | M4.1 + M4.6 (handoffs) |
+| M8.5 Agent Inspector + thinking | M4.5 (extended thinking) ⭐ |
+| M8.6 Onboarding wizard | M3.2 + M3.3 (upload + session) |
+| M9.3 Memory scene | M4.7 |
+
+---
+
+## Checklist décisions à valider ensemble J3 matin
+
+Avant que l'un ou l'autre commence à coder, les deux doivent confirmer :
+
+- [ ] **Architecture agents** : Q&A en Managed Agents + 4 autres en Messages API + orchestrateur maison — OK pour les deux ?
+- [ ] **Agent-as-tool pattern** : Investigator a `ask_kb_builder`, Q&A a `ask_investigator` — OK ?
+- [ ] **Extended thinking** : activé sur Investigator (budget 10k tokens) — OK ?
+- [ ] **UI tools generative** : 9 `render_*` tools déclarés dans les agents — OK ?
+- [ ] **Transport** : WebSocket pour `/events` et `/agent/chat` — OK ? (Décision retenue, cf. M4.1 et M5.2)
+- [ ] **Event names** : liste finale ci-dessus — OK ou on ajoute/retire ?
+- [ ] **Memory flex scene** : P1 bonus, skip si serré — OK ?
+
+Une fois ces 7 points cochés, chacun code sa lane sans se bloquer.

--- a/docs/planning/M10-submission/issues.md
+++ b/docs/planning/M10-submission/issues.md
@@ -1,0 +1,87 @@
+# M10 — Submission (J7, 26/04, deadline 20h EST)
+
+> Objectif : livrer avant 20h EST le 26/04. README final, vidéo 3 min scénarisée,
+> package submission rempli.
+> Shared milestone — les deux devs contribuent.
+
+---
+
+## Issue M10.1 — README + DEMO.md final polish
+
+**Scope.** Le README est la première chose que les juges lisent avant la vidéo.
+Doit être tight.
+
+**Fichiers.**
+- `README.md` : hero image (existe déjà), pitch 2 lignes, section "Why agentic",
+  les 5 agents illustrés, diagramme archi, quickstart `make up`
+- `docs/DEMO.md` : script scène-par-scène avec screenshots
+
+**Owner.** Adam (vgtray) principal, zestones relit.
+
+**Acceptance.**
+- [ ] README rend correctement sur GitHub (preview)
+- [ ] Lien vidéo démo en haut
+- [ ] 5 agents + capabilities documentés
+- [ ] Diagramme archi à jour (agents + MCP + Managed Agents sur Q&A)
+
+---
+
+## Issue M10.2 — Vidéo démo 3 minutes
+
+**Scope.** Vidéo = 60% de ce que les juges évaluent. Script tight.
+
+**Procédure.**
+- Screen recording OBS ou Loom, 1920×1080 60fps
+- Voice-over (English) scripté depuis `docs/DEMO.md`
+- Outro : noms de l'équipe + stack credits
+- Export MP4 <100 MB
+- Upload YouTube unlisted → shareable link
+
+**Script recommandé (English).**
+- 0:00–0:15 Hook : "95% of industrial sites can't access predictive maintenance.
+  Here's why, and what we built."
+- 0:15–1:00 Scene 1 Onboarding (PDF upload, KB Builder multi-turn, equipment ready)
+- 1:00–1:45 Scenes 2 + 3 Anomaly → Investigator thinking stream (show Opus 4.7
+  extended thinking explicitly) → handoff to KB Builder → RCA
+- 1:45–2:15 Scene 4 Work Order printable
+- 2:15–2:40 Scene 5 Q&A + memory flex (optional)
+- 2:40–3:00 Recap "team of autonomous agents, zero config, 2 hours to first prediction"
+
+**Owner.** Les deux.
+
+**Acceptance.**
+- [ ] Sous 3 minutes
+- [ ] 5 scènes visibles + thinking stream Opus 4.7 clairement mis en avant
+- [ ] Audio clair, pas de silence
+- [ ] YouTube link dans README
+
+---
+
+## Issue M10.3 — Submission package
+
+**Scope.** Submission hackathon avant 19h EST (buffer 1h).
+
+**Contenu submission form.**
+- Repo URL `https://github.com/zestones/ARIA`
+- Vidéo URL (YouTube unlisted)
+- Written summary ~150 mots (adapter depuis `idea.md` §12)
+- Tags : `managed-agents`, `opus-4-7`, `vision`, `extended-thinking`, `mcp`,
+  `industrial`, `generative-ui`
+- Screenshots (3–5) : control room P&ID, chat avec thinking stream, diagnostic
+  card, work order printable, onboarding wizard
+
+**Owner.** Les deux.
+
+**Acceptance.**
+- [ ] Submission envoyée avant 19h EST
+- [ ] Email de confirmation reçu
+
+---
+
+## Bloque
+
+- Rien (terminal)
+
+## Bloqué par
+
+- M9 (démo polie), backend M5 (tous les agents live)

--- a/docs/planning/M2-mcp-server/issues.md
+++ b/docs/planning/M2-mcp-server/issues.md
@@ -170,8 +170,65 @@ un agent loop est un cauchemar.
 
 ---
 
+## Issue M2.9 🔴 — UI tools generative (`render_*`)
+
+**Scope.** Déclarer 9 tools "generative UI" que les agents invoquent pour émettre
+des events `ui_render` rendus inline dans le chat / le dashboard. C'est ce qui
+transforme ARIA d'un chatbot markdown en interface agentique visuelle (cf.
+Claude artifacts). Sans ces tools, Q&A et Investigator n'ont que du texte à
+offrir.
+
+**Pas d'implémentation Python.** Ces tools n'ont pas de code backend — ce sont
+des **schémas** passés au LLM. Le handler de `tool_use` dans chaque agent loop
+doit détecter `tool_name.startswith("render_")` et :
+1. `ws_manager.broadcast("ui_render", {agent, component, props, turn_id})`
+2. Retourner immédiatement `tool_result={"content": "rendered"}` — pas d'effet
+   de bord, pas d'attente
+
+**Fichier.** `backend/agents/ui_tools.py` — expose une liste `UI_TOOLS: list[dict]`
+et une const `UI_TOOL_NAMES: set[str]` pour le dispatch.
+
+**Les 9 tools.**
+
+| Tool name                   | Used by              | Props schema (résumé)                                                        |
+|-----------------------------|----------------------|------------------------------------------------------------------------------|
+| `render_signal_chart`       | Investigator, Q&A    | `{signal_def_id, window_hours, mark_anomaly_at?, threshold?}`                |
+| `render_equipment_kb_card`  | KB Builder, Q&A      | `{cell_id, highlight_fields?}`                                               |
+| `render_work_order_card`    | Work Order Gen       | `{work_order_id, printable: true}`                                           |
+| `render_diagnostic_card`    | Investigator         | `{title, confidence, root_cause, contributing_factors[], pattern_match_id?}` |
+| `render_correlation_matrix` | Investigator         | `{sources[], impact_matrix[][]}`                                             |
+| `render_pattern_match`      | Investigator         | `{current_event, past_event_ref, similarity}`                                |
+| `render_bar_chart`          | Q&A                  | `{title, x_label, y_label, bars[]}`                                          |
+| `render_alert_banner`       | Sentinel (auto-emit) | `{severity, cell_id, message, anomaly_id}`                                   |
+| `render_kb_progress`        | KB Builder           | `{steps[{label, status}]}`                                                   |
+
+**Intégration agent.** Dans chaque agent loop :
+```python
+tools = await mcp_client.get_tools_schema() + UI_TOOLS + [SUBMIT_TOOL]
+```
+
+**Pattern dans le system prompt de chaque agent qui les utilise :**
+```
+Pour rendre tes résultats visuels, tu peux appeler :
+- render_signal_chart(...) pour afficher une courbe
+- render_diagnostic_card(...) pour afficher ton diagnostic final
+- ...
+Appelle-les quand c'est plus parlant qu'une réponse texte.
+```
+
+**Acceptance.**
+- [ ] `UI_TOOLS` importé et concaténé dans Investigator + Q&A + WO Gen + KB Builder
+- [ ] Investigator émet `ui_render` pour `render_diagnostic_card` à la fin du RCA
+- [ ] Q&A émet `ui_render` pour `render_signal_chart` si la question porte sur un signal
+- [ ] Aucun `tool_call` `render_*` ne génère d'appel DB ou d'attente > 5ms
+
+**Bloque.** Frontend M7.5 (artifact registry), M8.1–M8.3 (artifacts individuels).
+
+---
+
 ## Bloque
 
 - M3 (KB Builder utilise `update_equipment_kb` indirectement)
 - M4 (Sentinel lit signaux + KB ; Investigator a besoin des 14 tools)
 - M5 (Q&A consomme les 14 tools)
+- M7.5, M8.1–M8.3 (artifact registry et composants — via M2.9)

--- a/docs/planning/M2-mcp-server/issues.md
+++ b/docs/planning/M2-mcp-server/issues.md
@@ -170,59 +170,73 @@ un agent loop est un cauchemar.
 
 ---
 
-## Issue M2.9 🔴 — UI tools generative (`render_*`)
+## Issue M2.9 — UI tools generative (`render_*`) déclarés dans les agents
 
-**Scope.** Déclarer 9 tools "generative UI" que les agents invoquent pour émettre
-des events `ui_render` rendus inline dans le chat / le dashboard. C'est ce qui
-transforme ARIA d'un chatbot markdown en interface agentique visuelle (cf.
-Claude artifacts). Sans ces tools, Q&A et Investigator n'ont que du texte à
-offrir.
+> Ajoutée après alignement front/back. Contexte complet dans `docs/planning/ALIGNMENT.md`.
 
-**Pas d'implémentation Python.** Ces tools n'ont pas de code backend — ce sont
-des **schémas** passés au LLM. Le handler de `tool_use` dans chaque agent loop
-doit détecter `tool_name.startswith("render_")` et :
-1. `ws_manager.broadcast("ui_render", {agent, component, props, turn_id})`
-2. Retourner immédiatement `tool_result={"content": "rendered"}` — pas d'effet
-   de bord, pas d'attente
+**Scope.** En plus des 14 data tools MCP, exposer 9 tools `render_*` aux agents
+pour qu'ils puissent émettre des events `ui_render` consommés par le frontend
+(generative UI inline dans le chat).
 
-**Fichier.** `backend/agents/ui_tools.py` — expose une liste `UI_TOOLS: list[dict]`
-et une const `UI_TOOL_NAMES: set[str]` pour le dispatch.
+**Pas d'implémentation Python.** Ces tools n'ont **pas** de code métier — ce sont
+juste des schémas passés au LLM. Quand un agent appelle `render_signal_chart`,
+l'orchestrateur capture le `tool_use`, broadcast un event `ui_render` via WSManager,
+et retourne immédiatement un `tool_result = "rendered"` sans effet DB.
+
+**Fichier.** `backend/agents/ui_tools.py` — module avec les 9 schémas + helper.
 
 **Les 9 tools.**
 
-| Tool name                   | Used by              | Props schema (résumé)                                                        |
-|-----------------------------|----------------------|------------------------------------------------------------------------------|
-| `render_signal_chart`       | Investigator, Q&A    | `{signal_def_id, window_hours, mark_anomaly_at?, threshold?}`                |
-| `render_equipment_kb_card`  | KB Builder, Q&A      | `{cell_id, highlight_fields?}`                                               |
-| `render_work_order_card`    | Work Order Gen       | `{work_order_id, printable: true}`                                           |
-| `render_diagnostic_card`    | Investigator         | `{title, confidence, root_cause, contributing_factors[], pattern_match_id?}` |
-| `render_correlation_matrix` | Investigator         | `{sources[], impact_matrix[][]}`                                             |
-| `render_pattern_match`      | Investigator         | `{current_event, past_event_ref, similarity}`                                |
-| `render_bar_chart`          | Q&A                  | `{title, x_label, y_label, bars[]}`                                          |
-| `render_alert_banner`       | Sentinel (auto-emit) | `{severity, cell_id, message, anomaly_id}`                                   |
-| `render_kb_progress`        | KB Builder           | `{steps[{label, status}]}`                                                   |
+| Tool name | Used by | Props schema (résumé) |
+|---|---|---|
+| `render_signal_chart` | Investigator, Q&A | `{signal_def_id, window_hours, mark_anomaly_at?, threshold?}` |
+| `render_equipment_kb_card` | KB Builder, Q&A | `{cell_id, highlight_fields?}` |
+| `render_work_order_card` | Work Order Gen | `{work_order_id, printable}` |
+| `render_diagnostic_card` | Investigator | `{title, confidence, root_cause, contributing_factors[], pattern_match_id?}` |
+| `render_correlation_matrix` | Investigator | `{sources[], impact_matrix[][]}` |
+| `render_pattern_match` | Investigator | `{current_event, past_event_ref, similarity}` |
+| `render_bar_chart` | Q&A | `{title, x_label, y_label, bars[]}` |
+| `render_alert_banner` | Sentinel (auto-emit) | `{severity, cell_id, message, anomaly_id}` |
+| `render_kb_progress` | KB Builder | `{steps[{label, status}]}` |
 
-**Intégration agent.** Dans chaque agent loop :
-```python
-tools = await mcp_client.get_tools_schema() + UI_TOOLS + [SUBMIT_TOOL]
-```
+✅ **DÉCIDÉ — tools locaux agent, pas via FastMCP.** Même règle que `submit_rca`
+(cf. M4.3) : tool d'output structuré = local, tool de lecture/écriture DB = MCP.
+Les `render_*` sont déclarés inline dans chaque agent concerné et concaténés à
+`tools_schema` avant l'appel Anthropic.
 
-**Pattern dans le system prompt de chaque agent qui les utilise :**
+**Pattern d'intégration dans le system prompt de chaque agent.**
 ```
-Pour rendre tes résultats visuels, tu peux appeler :
+Pour rendre visuels tes résultats, tu peux appeler :
 - render_signal_chart(...) pour afficher une courbe
 - render_diagnostic_card(...) pour afficher ton diagnostic final
-- ...
-Appelle-les quand c'est plus parlant qu'une réponse texte.
+- render_work_order_card(...) pour afficher un WO
+Appelle-les quand c'est plus parlant qu'une réponse texte seule.
 ```
 
-**Acceptance.**
-- [ ] `UI_TOOLS` importé et concaténé dans Investigator + Q&A + WO Gen + KB Builder
-- [ ] Investigator émet `ui_render` pour `render_diagnostic_card` à la fin du RCA
-- [ ] Q&A émet `ui_render` pour `render_signal_chart` si la question porte sur un signal
-- [ ] Aucun `tool_call` `render_*` ne génère d'appel DB ou d'attente > 5ms
+**Handler orchestrateur.**
+```python
+if tool_name.startswith("render_"):
+    await ws_manager.broadcast("ui_render", {
+        "agent": agent_id,
+        "component": tool_name.removeprefix("render_"),  # SignalChart, DiagnosticCard, ...
+        "props": args,
+        "turn_id": turn_id,
+    })
+    tool_result = {"type": "tool_result", "tool_use_id": tu_id, "content": "rendered"}
+    # pas de persistence DB, pas de side-effect
+```
 
-**Bloque.** Frontend M7.5 (artifact registry), M8.1–M8.3 (artifacts individuels).
+**Pourquoi critique.** Sans ces tools, Q&A/Investigator répondent en markdown texte
+uniquement. Avec, le chat affiche inline des graphes, cards, diagnostics **rendus
+par l'agent lui-même** — pattern Generative UI / Claude artifacts. C'est ce qui
+rend la démo visuellement agentique et distingue ARIA d'un chatbot classique.
+
+**Acceptance.**
+- [ ] Investigator émet `ui_render` pour `render_diagnostic_card` à la fin du RCA
+- [ ] Q&A émet `ui_render` pour `render_signal_chart` sur question relative à un signal
+- [ ] Frontend (M7.5 + M8.1–M8.3) rend les composants correctement
+
+**Bloque.** Frontend M7.5 (artifact registry), M8.1 / M8.2 / M8.3 (artifacts).
 
 ---
 
@@ -231,4 +245,3 @@ Appelle-les quand c'est plus parlant qu'une réponse texte.
 - M3 (KB Builder utilise `update_equipment_kb` indirectement)
 - M4 (Sentinel lit signaux + KB ; Investigator a besoin des 14 tools)
 - M5 (Q&A consomme les 14 tools)
-- M7.5, M8.1–M8.3 (artifact registry et composants — via M2.9)

--- a/docs/planning/M3-kb-builder/issues.md
+++ b/docs/planning/M3-kb-builder/issues.md
@@ -117,12 +117,86 @@ chaque upsert pour rafraîchir le score.
 
 ---
 
+## Issue M3.5 🔴 — KB Builder en mode "agent appelé" (`ask_kb_builder` handler)
+
+**Scope.** Le KB Builder n'est pas seulement orchestré par les endpoints d'onboarding
+(M3.2/M3.3) — il est aussi **appelable comme tool** par l'Investigator via
+`ask_kb_builder` (cf. M4.6). Cette issue implémente le handler partagé.
+
+**Fichier.** `backend/agents/kb_builder.py` :
+```python
+async def answer_kb_question(cell_id: int, question: str) -> dict:
+    """Mini-session Messages API pour répondre factuellement à un agent collègue."""
+    kb = await mcp_client.call_tool("get_equipment_kb", {"cell_id": cell_id})
+    system = (
+        "Tu réponds factuellement à un agent collègue qui investigue une panne. "
+        "Utilise la KB ci-dessous. Si l'info manque, dis 'inconnu' — ne devine pas. "
+        "Réponse concise, JSON: {answer, source, confidence}."
+    )
+    user = f"KB équipement: {kb}\n\nQuestion: {question}"
+    response = await anthropic.messages.create(
+        model=model_for("agent"),
+        max_tokens=1024,
+        system=system,
+        messages=[{"role": "user", "content": user}],
+    )
+    return parse_json_response(response)
+```
+
+**Appelé depuis.** Le handler `ask_kb_builder` dans `backend/agents/investigator.py`
+(cf. M4.6). Différent du flow onboarding (M3.2/M3.3) : pas de session multi-turn,
+pas d'écriture KB, juste lecture + réponse.
+
+**Acceptance.**
+- [ ] `await answer_kb_question(2, "Quel torque max boulons turbine ?")` retourne
+  `{answer, source, confidence}`
+- [ ] Latence < 5s (Sonnet en dev)
+- [ ] Si info absente → `answer="inconnu"`, pas d'hallucination
+
+**Bloque.** M4.6 (handoff dynamique Investigator → KB Builder).
+
+---
+
+## Issue M3.6 🟡 — UI tools pour KB Builder onboarding
+
+**Scope.** Pendant l'onboarding (M3.3), le KB Builder émet des `ui_render` events
+pour rendre le flow visuel côté frontend.
+
+**Tools utilisés** (déclarés dans `UI_TOOLS` cf. M2.9) :
+- `render_kb_progress(steps[{label, status}])` — émit à chaque étape de
+  l'onboarding ("Lecture du manuel...", "Extraction des seuils...", "Question 1/4...")
+- `render_equipment_kb_card(cell_id, highlight_fields)` — émit à la fin pour
+  afficher la KB complète avec les champs nouvellement remplis surlignés
+
+**Pattern d'émission (sans agent loop).** Pour les 2 tools ci-dessus, le KB Builder
+n'a pas besoin de raisonner — c'est l'orchestrateur d'onboarding qui broadcast
+directement :
+```python
+await ws_manager.broadcast("ui_render", {
+    "agent": "kb_builder",
+    "component": "render_kb_progress",
+    "props": {"steps": [...]},
+    "turn_id": current_turn_id,
+})
+```
+
+**Acceptance.**
+- [ ] PDF upload → 5 events `ui_render` `render_kb_progress` (1 par phase)
+- [ ] Fin onboarding → 1 event `ui_render` `render_equipment_kb_card`
+- [ ] Frontend M8.6 (Onboarding wizard) consomme correctement
+
+**Bloque.** Frontend M8.6 onboarding wizard.
+
+---
+
 ## Bloque
 
 - Scène 1 de la démo (Onboarding)
-- Frontend page Onboarding (M6)
+- Frontend page Onboarding (M8.6)
+- M4.6 (handoff Investigator → KB Builder — via M3.5)
 
 ## Bloqué par
 
 - M1 (kb_schema, migration 007)
 - M2.5 (tool `update_equipment_kb`) et M2.7 (`MCPClient`)
+- M2.9 (UI_TOOLS déclarés — pour M3.6)

--- a/docs/planning/M4-sentinel-investigator/issues.md
+++ b/docs/planning/M4-sentinel-investigator/issues.md
@@ -63,6 +63,10 @@ HTTP status ou `{type: "done", error: "..."}` final côté `/agent/chat`.
        trigger_anomaly_time=value_time, triggered_by_signal_def_id=...,
        title="Anomalie détectée — <signal>", priority='high')`
      - `ws_manager.broadcast("anomaly_detected", ...)`
+     - Broadcast `ui_render` avec `render_alert_banner` (cf. M2.9) pour afficher
+       le banner inline dans le dashboard/chat :
+       `ws_manager.broadcast("ui_render", {agent: "sentinel", component: "render_alert_banner",
+        props: {severity, cell_id, message, anomaly_id: work_order_id}, turn_id: ...})`
      - `asyncio.create_task(run_investigator(work_order_id))`
 
 **Démarrage.** Lancer dans le `lifespan` de `main.py` :

--- a/docs/planning/M4-sentinel-investigator/issues.md
+++ b/docs/planning/M4-sentinel-investigator/issues.md
@@ -15,12 +15,28 @@
   ignore les sockets fermés
 - Singleton module-level `ws_manager = WSManager()`
 
-**Events utilisés.**
-- `anomaly_detected` : `{cell_id, signal_def_id, value, threshold, work_order_id}`
-- `tool_call_started` : `{agent, tool_name, args}` (cf. UX `technical.md` §3.1)
-- `tool_call_completed` : `{agent, tool_name, duration_ms}`
-- `rca_ready` : `{work_order_id, rca_summary, confidence}`
-- `work_order_ready` : `{work_order_id}`
+**Events utilisés** (contrat aligné avec frontend, cf. `docs/planning/ALIGNMENT.md`).
+
+| Event type            | Payload                                                           | Émis par                          |
+|-----------------------|-------------------------------------------------------------------|-----------------------------------|
+| `anomaly_detected`    | `{cell_id, signal_def_id, value, threshold, work_order_id, time}` | Sentinel                          |
+| `agent_start`         | `{agent, turn_id}`                                                | orchestrator                      |
+| `agent_end`           | `{agent, turn_id, finish_reason}`                                 | orchestrator                      |
+| `tool_call_started`   | `{agent, tool_name, args, turn_id}`                               | Investigator / Q&A / WO Gen       |
+| `tool_call_completed` | `{agent, tool_name, duration_ms, turn_id}`                        | idem                              |
+| `agent_handoff`       | `{from_agent, to_agent, reason, turn_id}` (cf. M4.6)              | orchestrator on `ask_*` tool call |
+| `thinking_delta`      | `{agent, content, turn_id}` (cf. M4.5)                            | Investigator (extended thinking)  |
+| `ui_render`           | `{agent, component, props, turn_id}` (cf. M2.9)                   | tout agent appelant un `render_*` |
+| `rca_ready`           | `{work_order_id, rca_summary, confidence, turn_id}`               | Investigator                      |
+| `work_order_ready`    | `{work_order_id}`                                                 | Work Order Generator              |
+
+**`turn_id`.** UUID v4 généré par l'orchestrateur à chaque `agent_start`.
+Corrèle tous les events d'un même tour agentique côté frontend (Activity Feed,
+Agent Inspector). Stocker dans une `ContextVar` Python pour ne pas le passer
+explicitement à chaque `ws_manager.broadcast()`.
+
+**Sérialisation.** JSON une ligne par event. Pas d'event `error` — erreurs via
+HTTP status ou `{type: "done", error: "..."}` final côté `/agent/chat`.
 
 > ✅ **DÉCIDÉ — un seul topic global.** Le frontend filtre côté client par
 > `cell_id` dans le payload. Pour la démo on a 1 site, 5 cells, 1 opérateur connecté
@@ -91,10 +107,15 @@ sentinel_task.cancel()
   quoi consulter, dans quel ordre. Produis ensuite un RCA structuré au format JSON :
   `{root_cause, confidence, contributing_factors, similar_past_failure, recommended_action}`."
 - Boucle agent (cf. pattern `technical.md` §2.2 mais avec `MCPClient`) :
-  - `tools_schema = await mcp_client.get_tools_schema()`
+  - `tools_schema = await mcp_client.get_tools_schema() + UI_TOOLS + [SUBMIT_RCA_TOOL, ASK_KB_BUILDER_TOOL]`
+    (UI_TOOLS cf. M2.9, ASK_KB_BUILDER_TOOL cf. M4.6)
   - while not end_turn :
     - `messages.create(...)` avec model agent + tools
-    - pour chaque `tool_use` block : broadcast `tool_call_started` → `mcp_client.call_tool()` → broadcast `tool_call_completed`
+    - pour chaque `tool_use` block :
+      - si `tool_name.startswith("render_")` → broadcast `ui_render` + tool_result "rendered" (cf. M2.9)
+      - si `tool_name == "ask_kb_builder"` → spawn mini-session KB Builder (cf. M3.5) + tool_result
+      - si `tool_name == "submit_rca"` → capture args, break loop
+      - sinon → broadcast `tool_call_started` → `mcp_client.call_tool()` → broadcast `tool_call_completed`
     - append assistant + tool_results à messages
 - À end_turn : extract le bloc JSON RCA du dernier message texte
 - UPDATE `work_order SET rca_summary=..., status='analyzed'`
@@ -159,3 +180,119 @@ sentinel_task.cancel()
 - M1 (`work_order` colonnes)
 - M2 (tools, MCPClient)
 - M3 (KB doit exister pour que Sentinel ait des seuils)
+
+---
+
+## Issue M4.5 🔴 — Extended thinking sur Investigator (Opus 4.7 wow factor)
+
+**Scope.** Activer `thinking` sur l'agent loop Investigator. C'est le seul argument
+visible "pourquoi Opus 4.7 vs Sonnet" pour les juges.
+
+```python
+response = await anthropic.messages.create(
+    model=model_for("agent"),
+    thinking={"type": "enabled", "budget_tokens": 10000},
+    system=INVESTIGATOR_SYSTEM,
+    messages=messages,
+    tools=tools_schema,
+    stream=True,
+)
+```
+
+**Streaming.** À chaque chunk `thinking_delta` reçu du SDK Anthropic, broadcast :
+```python
+await ws_manager.broadcast("thinking_delta", {
+    "agent": "investigator",
+    "content": chunk.thinking_delta.text,
+    "turn_id": turn_id,
+})
+```
+
+**Périmètre.** Activé **uniquement** sur Investigator. Budget 10k tokens ≈ 5¢ par
+run avec Opus 4.7, négligeable. Les autres agents n'en ont pas besoin (et économie
+coûts).
+
+**Pourquoi critique.** Le frontend (M8.5 Agent Inspector) streame le thinking en
+live dans un panel dédié → le juge **voit** Opus réfléchir. Sans ça, *"pourquoi
+Opus 4.7 ?"* n'a pas de réponse visuelle. 25% de la note.
+
+**Acceptance.**
+- [ ] `thinking_delta` events streamed pendant un run Investigator
+- [ ] Frontend M8.5 affiche le thinking en live (vérifié J6)
+- [ ] Latence end-to-end Investigator reste < 60s avec thinking activé
+
+**Bloque.** Frontend M8.5, prix "Opus 4.7 Use".
+
+---
+
+## Issue M4.6 🔴 — Agent-as-tool (handoffs dynamiques)
+
+**Scope.** Remplacer le pipeline scripted (`asyncio.create_task(run_work_order_generator)`
+en fin de M4.3) par des handoffs **décidés par l'agent** via tool call. Sans ça, le
+"multi-agent" est juste un workflow Python aux yeux des juges.
+
+**Décision — garder les deux chemins.**
+- Pipeline scripted RCA → WO Gen reste en place (chemin garanti pour la démo)
+- En plus, l'Investigator a des tools `ask_*` qu'il peut choisir d'appeler en
+  cours de raisonnement (chemin wow factor)
+
+**Tools à déclarer (locaux, pas via FastMCP).**
+```python
+ASK_KB_BUILDER_TOOL = {
+  "name": "ask_kb_builder",
+  "description": "Consulte le KB Builder pour un détail constructeur absent de la "
+                 "KB courante (ex: torque max d'un boulon, réf pièce introuvable).",
+  "input_schema": {"type": "object", "properties": {
+    "question": {"type": "string"},
+    "cell_id": {"type": "integer"}
+  }, "required": ["question", "cell_id"]}
+}
+```
+
+**Handler.** Quand Investigator appelle `ask_kb_builder` :
+1. `ws_manager.broadcast("agent_handoff", {from: "investigator", to: "kb_builder", reason: args.question, turn_id})`
+2. `ws_manager.broadcast("agent_start", {agent: "kb_builder", turn_id: new_turn_id})`
+3. Spawn une mini-session KB Builder (Messages API loop, system prompt spécialisé
+   "réponds factuellement à un collègue agent, format JSON")
+4. `ws_manager.broadcast("agent_end", {agent: "kb_builder", turn_id, finish_reason: "end_turn"})`
+5. Retour comme `tool_result` à Investigator
+
+**Symétrique côté Q&A (M5.2/M5.4).** Déclarer `ask_investigator` pour que Q&A
+délègue les questions diagnostiques pointues.
+
+**Scénarios démo (au moins 2 handoffs visibles).**
+- Scène 3 (Investigation) : Investigator → KB Builder pour chercher une réf pièce
+- Scène 5 (Q&A) : Q&A → Investigator pour une question diagnostique poussée
+
+**Acceptance.**
+- [ ] Investigator peut appeler `ask_kb_builder` et reçoit une réponse structurée
+- [ ] Event `agent_handoff` visible dans le WS stream
+- [ ] Scénario démo P-02 déclenche au moins 1 handoff dynamique
+
+**Bloque.** Pitch "Best Managed Agents" crédible.
+
+---
+
+## Issue M4.7 🟡 (P1 bonus) — Memory flex scene
+
+**Scope.** L'Investigator charge `failure_history` du cell dans son contexte initial
+et produit un RCA visiblement plus rapide/précis au 2e diagnostic similaire.
+
+**Implem.**
+- Début du run : `past_failures = await mcp_client.call_tool("get_failure_history", {cell_id, limit: 5})`
+- Inject dans le system prompt : *"Pannes précédentes de cet équipement : {past_failures}.
+  Si le pattern actuel matche une panne passée, cite-la explicitement dans `similar_past_failure`."*
+- Le tool `submit_rca` (cf. M4.3) accepte déjà `similar_past_failure` → rien à
+  changer côté schema
+
+**Scène démo dédiée.** `POST /api/v1/demo/trigger-memory-scene` :
+1. INSERT une fausse `failure_history` datée de 3 mois (pattern P-02 similaire)
+2. Trigger une anomalie P-02 actuelle
+3. L'Investigator match → RCA cite la panne passée → scène flex "l'agent apprend"
+
+**Priorité.** P1. Skip si serré J6 PM. Si skipé, l'essentiel reste : Investigator
+utilise `failure_history` en contexte (sans la scène scénarisée).
+
+**Acceptance.**
+- [ ] Investigator cite la panne passée dans son RCA si pattern matche
+- [ ] Endpoint demo `/trigger-memory-scene` rejouable autant de fois que voulu

--- a/docs/planning/M4-sentinel-investigator/issues.md
+++ b/docs/planning/M4-sentinel-investigator/issues.md
@@ -170,19 +170,6 @@ sentinel_task.cancel()
 
 ---
 
-## Bloque
-
-- Scène 2 (anomalie live) et Scène 3 (RCA) de la démo
-- M5 (le Work Order Generator est triggered par l'Investigator)
-
-## Bloqué par
-
-- M1 (`work_order` colonnes)
-- M2 (tools, MCPClient)
-- M3 (KB doit exister pour que Sentinel ait des seuils)
-
----
-
 ## Issue M4.5 🔴 — Extended thinking sur Investigator (Opus 4.7 wow factor)
 
 **Scope.** Activer `thinking` sur l'agent loop Investigator. C'est le seul argument
@@ -209,7 +196,7 @@ await ws_manager.broadcast("thinking_delta", {
 ```
 
 **Périmètre.** Activé **uniquement** sur Investigator. Budget 10k tokens ≈ 5¢ par
-run avec Opus 4.7, négligeable. Les autres agents n'en ont pas besoin (et économie
+run avec Opus 4.7, négligeable. Les autres agents n'en ont pas besoin (et économie
 coûts).
 
 **Pourquoi critique.** Le frontend (M8.5 Agent Inspector) streame le thinking en
@@ -296,3 +283,16 @@ utilise `failure_history` en contexte (sans la scène scénarisée).
 **Acceptance.**
 - [ ] Investigator cite la panne passée dans son RCA si pattern matche
 - [ ] Endpoint demo `/trigger-memory-scene` rejouable autant de fois que voulu
+
+---
+
+## Bloque
+
+- Scène 2 (anomalie live) et Scène 3 (RCA) de la démo
+- M5 (le Work Order Generator est triggered par l'Investigator)
+
+## Bloqué par
+
+- M1 (`work_order` colonnes)
+- M2 (tools, MCPClient, M2.9 UI tools)
+- M3 (KB doit exister pour que Sentinel ait des seuils)

--- a/docs/planning/M5-workorder-qa/issues.md
+++ b/docs/planning/M5-workorder-qa/issues.md
@@ -14,10 +14,8 @@
   KB de l'équipement (procedures + parts disponibles)."
 - System prompt : "Tu génères des work orders de maintenance. Tu as accès à la KB
   équipement via tools. Output JSON via `submit_work_order(...)` :
-  `{title, description, recommended_actions: [step1, step2, ...], parts_required: [{ref, qty}], priority, estimated_duration_min, suggested_window_start, suggested_window_end}`. Après soumission, appelle `render_work_order_card(work_order_id, printable: true)` pour l'afficher en chat."
-- Tools : `tools = await mcp_client.get_tools_schema() + UI_TOOLS + [SUBMIT_WORK_ORDER_TOOL]`
-  (UI_TOOLS cf. M2.9 — utilise `render_work_order_card` ; SUBMIT_WORK_ORDER_TOOL déclaré inline comme `SUBMIT_RCA_TOOL`)
-- Agent loop (court — typiquement 2–3 tool calls : `get_equipment_kb` + `submit_work_order` + `render_work_order_card`)
+  `{title, description, recommended_actions: [step1, step2, ...], parts_required: [{ref, qty}], priority, estimated_duration_min, suggested_window_start, suggested_window_end}`"
+- Agent loop (court — typiquement 2 tool calls : `get_equipment_kb` + `submit_work_order`)
 - UPDATE work_order avec les champs structurés
 - `ws_manager.broadcast("work_order_ready", ...)`
 
@@ -91,56 +89,61 @@ et retourne `{response, tool_calls: [...]}`.
 
 ---
 
-## Issue M5.4 🔴 — Q&A migration vers Claude Managed Agents
+## Issue M5.4 — Q&A migration vers Claude Managed Agents
 
-**Scope.** Remplacer l'agent loop Messages API du M5.2 par **Claude Managed
-Agents** sur le seul agent Q&A. Sans ça, aucune chance de gagner le prix dédié
-**Best Managed Agents $5k**.
+> Ajoutée après alignement front/back. Contexte complet dans `docs/planning/ALIGNMENT.md`.
 
-**Périmètre clair.**
-- Q&A = seul agent en Managed Agents (interactif, stateful, long-running —
-  cas d'usage idéal)
-- Sentinel, Investigator, KB Builder, Work Order Gen restent en Messages API
-  + orchestrateur maison + agent-as-tool (cf. M4.6)
+**Scope.** Remplacer l'agent loop Messages API du **M5.2** par **Claude Managed
+Agents** (custom tools). Le M5.2 actuel devient le fallback (M5.3 carte de triche).
+
+**Problème actuel.** M5.2 implémente Q&A en agent loop classique Messages API +
+streaming Anthropic standard. Correct mais on rate le prix **Best Managed Agents
+\$5k** qui est la raison d'être du pattern. Il faut au minimum 1 agent en
+Managed Agents pour cocher la case.
+
+**Décision.** Q&A = **seul** agent en Managed Agents. Les 4 autres (Sentinel,
+Investigator, KB Builder, Work Order Gen) restent en Messages API + orchestrateur
+maison + agent-as-tool (cf. M4.6). Raison : Q&A est interactif, stateful,
+long-running — cas d'usage idéal. Les autres n'en ont pas besoin.
 
 **Implémentation.**
-- Utiliser la Managed Agents SDK (custom tools)
-- Tools exposés : les 14 MCP tools + `UI_TOOLS` (cf. M2.9) + `ask_investigator`
-  (cf. M4.6)
-- Streaming via WebSocket `/api/v1/agent/chat` (même contrat que M5.2)
-- L'état conversationnel est géré par Managed Agents côté Anthropic — plus
-  besoin du dict `messages` per-connection en mémoire
+- Utiliser la Claude Managed Agents SDK (custom tools)
+- Tools exposés au Managed Agent :
+  - Les 14 MCP tools (via `mcp_client.get_tools_schema()`)
+  - `ask_investigator` (agent-as-tool cf. M4.6)
+  - Les `render_*` generative UI tools (cf. M2.9)
+- Streaming vers le frontend via `WS /api/v1/agent/chat` (cf. contrat `ALIGNMENT.md`)
+- System prompt : identique à M5.2 ("Tu es ARIA, assistant maintenance...")
+- Session stateful maintenue côté Managed Agents (plus besoin de `messages: list` manuel)
 
-**Feature flag.** `USE_MANAGED_AGENTS=true|false` dans `core/config.py`.
-- `true` (défaut J6) → route `/agent/chat` utilise Managed Agents
-- `false` → route `/agent/chat` utilise l'impl Messages API du M5.2
+**Fallback.** Feature flag `USE_MANAGED_AGENTS=true/false` dans `.env`. Si Managed
+Agents KO en démo → bascule à `false` → Q&A retombe sur l'agent loop M5.2
+(code pas supprimé, juste contourné). Switch testable en <5 min.
 
-Le handler WS choisit l'impl au runtime. Switch testable en < 5 min : changer
-l'env var, restart backend.
+✅ **DÉCIDÉ — Managed Agents pour Q&A uniquement.** Pas les 4 autres. Faire tourner
+5 agents en Managed Agents est over-engineered et risqué. 1 seul Managed Agent +
+4 agents loop Messages API + pattern agent-as-tool = le bon compromis (cf.
+discussion Discord J3 13h45).
 
-**Pourquoi M5.2 reste implémenté.** M5.2 = filet de sécurité garanti.
-Managed Agents est nouveau dans l'écosystème — si bug, instabilité SDK, ou
-rate limit pendant la démo, on bascule en 1 commande.
+**Pourquoi critique.** Sans ça, aucune chance de gagner le prix **Best Managed
+Agents \$5k**. L'implémentation est modérée (30–60 min) et le fallback existe
+déjà (M5.2 devient le plan B).
 
 **Acceptance.**
-- [ ] Q&A répond via Managed Agents avec streaming WS visible
-- [ ] Tools MCP accessibles depuis le Managed Agent (au moins 1 tool call par
-  question complexe)
-- [ ] Feature flag testé → switch Managed Agents ↔ Messages API en < 5 min
-- [ ] Latence p50 réponse complète < 8s pour question type "OEE pompe P-02 ?"
+- [ ] Q&A répond via Managed Agents, streaming visible côté WS
+- [ ] Fallback testé : `USE_MANAGED_AGENTS=false` → Q&A tourne sur M5.2 sans break
+- [ ] Les 14 MCP tools accessibles depuis le Managed Agent
+- [ ] `ask_investigator` appelable par le Managed Agent (vérifié avec M4.6)
 
-**Bloque.** Prix "Best Managed Agents $5k".
+**Bloque.** Éligibilité prix "Best Managed Agents \$5k".
 
 ---
 
 ## Bloque
 
 - Scènes 4 (work order imprimable) et 5 (Q&A) de la démo
-- Frontend Chat (M6)
-- Prix "Best Managed Agents" (via M5.4)
+- Frontend Chat (M7.4 wire vrai WS)
 
 ## Bloqué par
 
-- M1, M2, M4 (chaîne RCA → WO)
-- M2.9 (UI tools pour Q&A enrichi)
-- M4.6 (`ask_investigator` agent-as-tool pour handoffs Q&A → Investigator)
+- M1, M2, M4 (chaîne RCA → WO, M4.6 pour `ask_investigator`, M2.9 pour UI tools)

--- a/docs/planning/M5-workorder-qa/issues.md
+++ b/docs/planning/M5-workorder-qa/issues.md
@@ -37,13 +37,18 @@
 **Scope.** `backend/agents/qa_agent.py` + route dans `main.py` :
 - `WS /api/v1/agent/chat`
 - Stateful per connection : maintient `messages: list` côté serveur
+- Tools : `tools = await mcp_client.get_tools_schema() + UI_TOOLS + [ASK_INVESTIGATOR_TOOL]`
+  (M5.2 est le fallback impl des M5.4 Managed Agents — même toolset)
 - Sur message client `{type: "user", content: str}` :
   - Append au history
-  - Lance agent loop avec `MCPClient` tools + Anthropic streaming
+  - Lance agent loop avec tools + Anthropic streaming
   - Pour chaque event reçu de l'API Anthropic :
     - Si `content_block_delta` text → envoie `{type: "text_delta", content: ...}` au client
-    - Si `tool_use` block → envoie `{type: "tool_call", name, args}` puis appelle
-      `mcp_client.call_tool()` puis envoie `{type: "tool_result", name, ...}`
+    - Si `tool_use` block avec `render_*` → broadcast `ui_render` + envoie `{type: "ui_render", component, props}` au client
+    - Si `tool_use` block avec `ask_investigator` → broadcast `agent_handoff` + spawn mini-session Investigator
+      + envoie `{type: "agent_handoff", from: "qa", to: "investigator", reason}` au client
+    - Si `tool_use` autre → envoie `{type: "tool_call", name, args}` + appelle `mcp_client.call_tool()`
+      + envoie `{type: "tool_result", name, ...}`
   - À end_turn → envoie `{type: "done"}`
 
 **System prompt.** "Tu es ARIA, assistant maintenance. Réponds aux questions de

--- a/docs/planning/M5-workorder-qa/issues.md
+++ b/docs/planning/M5-workorder-qa/issues.md
@@ -14,8 +14,10 @@
   KB de l'équipement (procedures + parts disponibles)."
 - System prompt : "Tu génères des work orders de maintenance. Tu as accès à la KB
   équipement via tools. Output JSON via `submit_work_order(...)` :
-  `{title, description, recommended_actions: [step1, step2, ...], parts_required: [{ref, qty}], priority, estimated_duration_min, suggested_window_start, suggested_window_end}`"
-- Agent loop (court — typiquement 2 tool calls : `get_equipment_kb` + `submit_work_order`)
+  `{title, description, recommended_actions: [step1, step2, ...], parts_required: [{ref, qty}], priority, estimated_duration_min, suggested_window_start, suggested_window_end}`. Après soumission, appelle `render_work_order_card(work_order_id, printable: true)` pour l'afficher en chat."
+- Tools : `tools = await mcp_client.get_tools_schema() + UI_TOOLS + [SUBMIT_WORK_ORDER_TOOL]`
+  (UI_TOOLS cf. M2.9 — utilise `render_work_order_card` ; SUBMIT_WORK_ORDER_TOOL déclaré inline comme `SUBMIT_RCA_TOOL`)
+- Agent loop (court — typiquement 2–3 tool calls : `get_equipment_kb` + `submit_work_order` + `render_work_order_card`)
 - UPDATE work_order avec les champs structurés
 - `ws_manager.broadcast("work_order_ready", ...)`
 
@@ -89,11 +91,56 @@ et retourne `{response, tool_calls: [...]}`.
 
 ---
 
+## Issue M5.4 🔴 — Q&A migration vers Claude Managed Agents
+
+**Scope.** Remplacer l'agent loop Messages API du M5.2 par **Claude Managed
+Agents** sur le seul agent Q&A. Sans ça, aucune chance de gagner le prix dédié
+**Best Managed Agents $5k**.
+
+**Périmètre clair.**
+- Q&A = seul agent en Managed Agents (interactif, stateful, long-running —
+  cas d'usage idéal)
+- Sentinel, Investigator, KB Builder, Work Order Gen restent en Messages API
+  + orchestrateur maison + agent-as-tool (cf. M4.6)
+
+**Implémentation.**
+- Utiliser la Managed Agents SDK (custom tools)
+- Tools exposés : les 14 MCP tools + `UI_TOOLS` (cf. M2.9) + `ask_investigator`
+  (cf. M4.6)
+- Streaming via WebSocket `/api/v1/agent/chat` (même contrat que M5.2)
+- L'état conversationnel est géré par Managed Agents côté Anthropic — plus
+  besoin du dict `messages` per-connection en mémoire
+
+**Feature flag.** `USE_MANAGED_AGENTS=true|false` dans `core/config.py`.
+- `true` (défaut J6) → route `/agent/chat` utilise Managed Agents
+- `false` → route `/agent/chat` utilise l'impl Messages API du M5.2
+
+Le handler WS choisit l'impl au runtime. Switch testable en < 5 min : changer
+l'env var, restart backend.
+
+**Pourquoi M5.2 reste implémenté.** M5.2 = filet de sécurité garanti.
+Managed Agents est nouveau dans l'écosystème — si bug, instabilité SDK, ou
+rate limit pendant la démo, on bascule en 1 commande.
+
+**Acceptance.**
+- [ ] Q&A répond via Managed Agents avec streaming WS visible
+- [ ] Tools MCP accessibles depuis le Managed Agent (au moins 1 tool call par
+  question complexe)
+- [ ] Feature flag testé → switch Managed Agents ↔ Messages API en < 5 min
+- [ ] Latence p50 réponse complète < 8s pour question type "OEE pompe P-02 ?"
+
+**Bloque.** Prix "Best Managed Agents $5k".
+
+---
+
 ## Bloque
 
 - Scènes 4 (work order imprimable) et 5 (Q&A) de la démo
 - Frontend Chat (M6)
+- Prix "Best Managed Agents" (via M5.4)
 
 ## Bloqué par
 
 - M1, M2, M4 (chaîne RCA → WO)
+- M2.9 (UI tools pour Q&A enrichi)
+- M4.6 (`ask_investigator` agent-as-tool pour handoffs Q&A → Investigator)

--- a/docs/planning/M6-frontend-foundation/issues.md
+++ b/docs/planning/M6-frontend-foundation/issues.md
@@ -1,0 +1,241 @@
+# M6 — Frontend Foundation (J3)
+
+> Objectif : poser les fondations du frontend (design system, app shell,
+> WS client, chat shell mocké, upload PDF). Fin J3 = chat UI qui stream du
+> contenu mocké, layout définitif, fondations réutilisables.
+> Bloquant pour M7, M8, M9.
+
+---
+
+## Issue M6.1 — Installer les libs UI manquantes
+
+**Scope.** Ajouter les dépendances nécessaires aux features J4–J6 : charts,
+animation, markdown, PDF, state management.
+
+**Dépendances.**
+- `recharts` — charts (SignalChart, BarChart, sparklines KPI)
+- `framer-motion` — animations (streaming, transitions, artifacts reveal)
+- `react-markdown` + `remark-gfm` — rendu markdown dans les bulles chat
+- `pdfjs-dist` — preview PDF dans OnboardingWizard
+- `zustand` — store client (chat session, agents actifs, activity feed)
+- `lucide-react` — icônes
+- `qrcode` — QR code sur les work orders imprimables (dynamic import)
+
+**Fichier.** `frontend/package.json` + `frontend/vite.config.ts` (worker pdfjs)
+
+**Acceptance.**
+- [ ] `npm run build` vert
+- [ ] `npm run typecheck` vert
+- [ ] `pdfjs` worker charge en dev
+- [ ] `npm audit` sans warning critique
+
+**Bloque.** M6.2 à M9.*
+
+---
+
+## Issue M6.2 — Design system foundation
+
+**Scope.** Créer le système de design unique du projet : tokens CSS, fonts,
+motion primitives, composants primitifs. **Dark mode uniquement pour v1.**
+
+**Fichiers.**
+- `frontend/src/design-system/tokens.css` — CSS vars (bg, fg, accent, status, agents)
+- `frontend/src/design-system/motion.ts` — variants framer-motion
+- `frontend/src/design-system/{Button,Card,Badge,Drawer,Tabs,StatusDot,KbdKey}.tsx` — primitives
+- `frontend/src/design-system/icons.tsx` — re-export lucide
+- `frontend/src/styles/index.css` — `@theme` Tailwind v4 bindings
+
+**Tokens (valeurs retenues).**
+```
+--bg-base: #0a0e14        /* deep slate */
+--bg-surface: #121821
+--bg-elevated: #1a2130
+--border: #232d3f
+--fg-primary: #e4e9f2
+--fg-muted: #8491a8
+--fg-subtle: #52627a
+
+--accent: #00d4ff          /* ARIA cyan industriel */
+--accent-glow: #00d4ff40
+
+--status-nominal: #10b981
+--status-warning: #f59e0b
+--status-critical: #ef4444
+
+--agent-sentinel: #60a5fa
+--agent-investigator: #a78bfa
+--agent-kb-builder: #34d399
+--agent-work-order: #fbbf24
+--agent-qa: #f472b6
+```
+
+**Fonts.** Geist Sans (UI) + JetBrains Mono (data). `font-display: swap`.
+
+**Motion variants.** `fadeInUp`, `streamToken`, `artifactReveal`, `anomalyPulse`,
+`handoffSweep`. Timing commun : 220ms ease-out pour les entrées, respect
+`prefers-reduced-motion`.
+
+✅ **DÉCIDÉ — pas de Storybook.** Route debug `/design` qui liste les primitives
+dans tous leurs états. Suffisant pour 5 jours de dev.
+
+**Acceptance.**
+- [ ] Zéro hex literal dans les composants (tous via vars)
+- [ ] `/design` montre toutes les primitives
+- [ ] `prefers-reduced-motion` coupe les animations destructrices (ripple, shake)
+
+**Bloque.** Tout le reste du frontend.
+
+---
+
+## Issue M6.3 — App shell (topbar + control room area + chat drawer)
+
+**Scope.** Layout unique qui héberge toute la démo.
+
+**Structure.**
+- Topbar fixe : logo ARIA, sélecteur équipement (P-01, P-02, Tank, …), `KpiBar`
+  (placeholder ici, rempli M7.2), indicateur shift
+- Main grid : control room (gauche) + chat drawer (droite, resizable 360–640px, collapsible)
+- Drawer state persisté `localStorage`
+- Keyboard shortcut : `cmd+k` toggle drawer / focus input
+- Routes existantes conservées : `/login`, `/data` (admin debug)
+- Nouvelle route par défaut : `/` redirect vers `/control-room`
+
+**Fichiers.**
+- `frontend/src/app/AppShell.tsx`
+- `frontend/src/app/TopBar.tsx`
+- `frontend/src/app/Drawer.tsx`
+- `frontend/src/app/routes.tsx` (modifier)
+
+**Acceptance.**
+- [ ] Resize drawer persist entre reloads
+- [ ] Toggle `cmd+k` fonctionne
+- [ ] Viewport min 1280×800 supporté (machine démo)
+- [ ] Topbar ne scroll jamais
+
+**Bloque.** M7.1, M6.5
+
+---
+
+## Issue M6.4 — WebSocket client typé (dispatcher + reconnect)
+
+**Scope.** Un client WS réutilisable pour les 2 endpoints backend (`WS /api/v1/events`
+et `WS /api/v1/agent/chat`). Typé, avec reconnect exponentiel et cleanup propre.
+
+**Fichiers.**
+- `frontend/src/lib/ws.ts` — factory générique
+- `frontend/src/lib/ws.types.ts` — event maps typés (cf. `docs/planning/ALIGNMENT.md`)
+- `frontend/src/lib/ws.test.ts` — tests unit
+
+**API cible.**
+```ts
+const events = createWsClient<EventBusMap>({
+  url: "/api/v1/events",
+  onEvent: (type, payload) => { ... },
+  onError: (err) => { ... },
+})
+events.close() // cleanup
+```
+
+**Comportement.**
+- Auto-reconnect exponentiel, max 3 retries, reset après 30s stable
+- Abort propre sur unmount (`AbortController`)
+- Parse JSON par message, dispatch sur `type` field
+- Types forts : `EventBusMap` pour `/events`, `ChatMap` pour `/agent/chat`
+
+✅ **DÉCIDÉ — auth via cookie.** Le navigateur envoie automatiquement `access_token`
+dans le handshake WS (cf. M5.2). Pas de gestion token côté client ici.
+
+**Acceptance.**
+- [ ] Test : parse fixture multi-event → events typés corrects
+- [ ] Test : reconnect déclenché après déconnexion
+- [ ] Test : pas de leak (listeners nettoyés)
+
+**Bloque.** M6.5, M7.3, M7.4, M8.4
+
+---
+
+## Issue M6.5 — Chat shell avec WS mocké
+
+**Scope.** Construire le `ChatPanel` complet en bas du drawer (cf. M6.3) contre
+un mock WS. Fin J3 = chat fonctionnel visuellement, prêt à brancher J4.
+
+**Fichiers.**
+- `frontend/src/features/chat/ChatPanel.tsx`
+- `frontend/src/features/chat/MessageList.tsx`
+- `frontend/src/features/chat/Message.tsx`
+- `frontend/src/features/chat/ChatInput.tsx`
+- `frontend/src/features/chat/mockWs.ts`
+- `frontend/src/store/chat.ts`
+
+**Composants.**
+- `MessageList` : auto-scroll bottom, bouton "scroll to bottom" si l'user a scroll up
+- `Message` : bulle user vs bulle agent ; badge agent coloré par `--agent-*`
+- Streaming token-by-token fluide (rAF batching, pas de re-render par caractère)
+- Markdown via `react-markdown` + `remark-gfm` (tables, code, blockquote)
+- `ChatInput` : textarea auto-resize, enter send, shift+enter newline
+- Mock WS : générateur local qui émet `agent_start`, `thinking_delta`, `text_delta`,
+  `ui_render` (placeholder), `tool_call`, `done` avec timings réalistes
+
+**Store zustand `chat.ts`.**
+```
+session_id: string
+messages: ChatMessage[]
+activeAgent: AgentId | null
+isStreaming: boolean
+```
+
+**Scope OUT.**
+- Pas encore d'artifact rendering (placeholder `[artifact: SignalChart]`)
+- Pas encore de drawer thinking (text + thinking inline en 2 couleurs)
+- Pas encore de vrai endpoint `/agent/chat` (mock seulement)
+
+**Acceptance.**
+- [ ] Envoi message → réponse streamée avec délais réalistes
+- [ ] Tables markdown rendues
+- [ ] Auto-scroll suit bottom sauf si user a scroll up
+- [ ] Badge agent coloré
+- [ ] `cmd+k` focus input
+
+**Bloque.** M7.4 (wire vrai WS)
+
+---
+
+## Issue M6.6 — PDF upload component (shell)
+
+**Scope.** Composant d'upload PDF minimal pour Scène 1 Onboarding. Le flux
+complet (wizard multi-step) vient J5 avec M8.6.
+
+**Fichiers.**
+- `frontend/src/features/onboarding/PdfUpload.tsx`
+- Route stub `/onboarding/:session_id` dans `routes.tsx`
+
+**Fonctions.**
+- Drag & drop + click to browse
+- Validation : `.pdf` uniquement, 50 MB max (cf. limite backend M3.2)
+- Preview première page via `pdfjs-dist`
+- `POST /api/v1/kb/equipment/{cell_id}/upload` (multipart, field `file`)
+- Sur succès : `navigate('/onboarding/{session_id}')`
+- États : idle / uploading (spinner + abort) / error (message clair)
+
+**Scope OUT.** Le wizard multi-step est M8.6.
+
+**Acceptance.**
+- [ ] Drop un PDF → preview → POST → redirect
+- [ ] Rejet clair des non-PDF
+- [ ] Spinner + abort pendant l'upload
+
+**Bloqué par.** M3.2 (endpoint backend upload)
+
+**Bloque.** M8.6 (wizard complet)
+
+---
+
+## Bloque
+
+- M7 (control room, wire chat réel)
+- M8 (artifacts, agentic UI)
+- M9 (polish, E2E)
+
+## Bloqué par
+
+- Aucun (fondation)

--- a/docs/planning/M6-frontend-foundation/issues.md
+++ b/docs/planning/M6-frontend-foundation/issues.md
@@ -126,6 +126,34 @@ et `WS /api/v1/agent/chat`). Typé, avec reconnect exponentiel et cleanup propre
 - `frontend/src/lib/ws.types.ts` — event maps typés (cf. `docs/planning/ALIGNMENT.md`)
 - `frontend/src/lib/ws.test.ts` — tests unit
 
+**`EventBusMap` — typage complet (`WS /api/v1/events`).**
+```ts
+type EventBusMap = {
+  anomaly_detected:    { cell_id: number; signal_def_id: number; value: number; threshold: number; work_order_id: number; time: string }
+  tool_call_started:   { agent: string; tool_name: string; args: Record<string, unknown>; turn_id: string }
+  tool_call_completed: { agent: string; tool_name: string; duration_ms: number; turn_id: string }
+  agent_handoff:       { from_agent: string; to_agent: string; reason: string; turn_id: string }
+  thinking_delta:      { agent: string; content: string; turn_id: string }
+  rca_ready:           { work_order_id: number; rca_summary: string; confidence: number; turn_id: string }
+  work_order_ready:    { work_order_id: number }
+  ui_render:           { agent: string; component: string; props: Record<string, unknown>; turn_id: string }
+  agent_start:         { agent: string; turn_id: string }
+  agent_end:           { agent: string; turn_id: string; finish_reason: string }
+}
+```
+
+**`ChatMap` — typage complet (`WS /api/v1/agent/chat`).**
+```ts
+type ChatMap =
+  | { type: 'text_delta';   content: string }
+  | { type: 'thinking_delta'; content: string }
+  | { type: 'tool_call';    name: string; args: Record<string, unknown> }
+  | { type: 'tool_result';  name: string; summary: string }
+  | { type: 'ui_render';    component: string; props: Record<string, unknown> }
+  | { type: 'agent_handoff'; from: string; to: string; reason: string }
+  | { type: 'done';         error?: string }
+```
+
 **API cible.**
 ```ts
 const events = createWsClient<EventBusMap>({

--- a/docs/planning/M7-control-room/issues.md
+++ b/docs/planning/M7-control-room/issues.md
@@ -1,0 +1,171 @@
+# M7 — Control Room & Backend Wire (J4)
+
+> Objectif : le P&ID industriel est animé et live, les KPIs tournent, le chat
+> parle au vrai backend, et le dispatcher d'artifacts generative UI est prêt
+> à rendre les composants émis par les agents.
+> Fin J4 = control room vivante + premier artifact rendu depuis un vrai agent.
+
+---
+
+## Issue M7.1 — P&ID diagram animé (SVG)
+
+**Scope.** Canvas principal de la salle de contrôle : diagramme Piping &
+Instrumentation (SVG pur) représentant la ligne P-02 réelle.
+
+**Fichiers.**
+- `frontend/src/features/control-room/PidDiagram.tsx`
+- `frontend/src/features/control-room/EquipmentNode.tsx`
+- `frontend/src/features/control-room/FlowEdge.tsx`
+- `frontend/src/features/control-room/EquipmentInspector.tsx`
+
+**Éléments visuels.**
+- Nodes : Tank, P-01, P-02, Valve, Outlet (cohérent avec seed P-02 / scénario démo)
+- Edges animées : `stroke-dashoffset` keyframes → effet "flux qui coule"
+- Status par node : nominal (glow emerald) / warning (pulse amber) / critical (ripple red + shake)
+- Click node → `EquipmentInspector` drawer gauche : signaux 10 derniers points, KB badge, derniers WO
+
+**Data sources.**
+- `GET /api/v1/monitoring/status/current` (poll 2s via TanStack Query)
+- `GET /api/v1/signals/current`
+- Sur `anomaly_detected` event (WS `/events`) → node concerné passe `critical` + `anomalyPulse`
+
+✅ **DÉCIDÉ — SVG pur, pas de three.js.** Décision validée Discord J3 matin avec
+zestones (risque 3D trop haut pour 1 journée). Langage visuel P&ID = ce que les
+vrais opérateurs industriels connaissent → argument crédibilité pour les juges.
+
+**Acceptance.**
+- [ ] 5 nodes rendent et s'update depuis l'API live
+- [ ] Flow edges s'animent en continu
+- [ ] Anomalie P-02 → état rouge visible + ripple
+- [ ] Click node → inspector affiche signaux + KB badge
+- [ ] 60fps sur MacBook 2020 (vérifié DevTools Performance)
+
+**Bloqué par.** M6.2 (design system), M6.3 (app shell)
+
+**Bloque.** Démo Scène 2.
+
+---
+
+## Issue M7.2 — KPI bar live (OEE, MTBF, MTTR, anomalies 24h)
+
+**Scope.** Strip de KPIs dans la topbar. Tourne 24/7 → preuve "système vivant".
+
+**Fichier.** `frontend/src/features/control-room/KpiBar.tsx`
+
+**Contenu.**
+- 4 tuiles compactes : OEE %, MTBF h, MTTR min, Anomalies 24h
+- Chaque tuile : label + valeur + sparkline recharts (dernières 24h)
+- Refresh 15s via TanStack Query
+- Flash subtil accent color sur changement de valeur
+
+**Data sources.**
+- `GET /api/v1/kpi/oee`, `/kpi/mtbf`, `/kpi/mttr`
+- `GET /api/v1/signals/anomalies?window=24h` (ou équivalent existant)
+
+**Acceptance.**
+- [ ] 4 tuiles visibles dans topbar
+- [ ] Sparklines rendent
+- [ ] Values update sans flicker de re-render
+
+**Bloqué par.** M6.3
+
+---
+
+## Issue M7.3 — Anomaly banner real-time
+
+**Scope.** Banner sticky sous la topbar quand anomalie active. Sentinel doit être
+visible en < 500ms dès détection.
+
+**Fichier.** `frontend/src/features/control-room/AnomalyBanner.tsx`
+
+**Comportement.**
+- Écoute `WS /api/v1/events` → event `anomaly_detected`
+- Affichage : severity color (amber/red), nom équipement, message court,
+  timestamp relatif ("just now", "2 min ago")
+- CTA "Investigate" → ouvre chat drawer + prefill input + envoi auto
+- Dismiss (×) masque localement, revient si nouvel event
+- Multi-anomalies : banner affiche le dernier + compteur "+2 more"
+
+**Bloqué par.** M6.4 (WS client), M4.1 + M4.2 (WSManager + Sentinel broadcast)
+
+**Acceptance.**
+- [ ] Event Sentinel → banner apparaît
+- [ ] CTA Investigate déclenche chat session pré-contextualisée
+- [ ] Compteur "+N more" si anomalies multiples
+
+**Bloque.** Démo Scène 2.
+
+---
+
+## Issue M7.4 — Wire ChatPanel au vrai WS `/api/v1/agent/chat`
+
+**Scope.** Remplacer le mock WS (M6.5) par la connexion réelle Q&A backend.
+
+**Fichiers modifiés.**
+- `frontend/src/features/chat/ChatPanel.tsx`
+- `frontend/src/store/chat.ts`
+
+**Fichiers supprimés.**
+- `frontend/src/features/chat/mockWs.ts`
+
+**Comportement.**
+- Ouvre connexion WS au mount du ChatPanel (auth cookie auto via handshake)
+- Handle tous les event types du contrat `ALIGNMENT.md` : `user`, `text_delta`,
+  `thinking_delta`, `tool_call`, `tool_result`, `ui_render`, `agent_handoff`, `done`
+- Error handling : network drop → reconnect exponentiel M6.4 / 401 → refresh token
+- `session_id` persisté zustand + localStorage
+
+**Scope OUT.**
+- Rendering des artifacts reste placeholder jusqu'à M7.5
+
+**Acceptance.**
+- [ ] Message envoyé → stream réel backend reçu
+- [ ] Agent name badge se met à jour sur `agent_start` / `agent_handoff`
+- [ ] Tous les events loggés en dev console
+
+**Bloqué par.** M6.5 (shell chat), M5.2 + M5.4 (WS `/agent/chat` live)
+
+---
+
+## Issue M7.5 — Artifact registry + dispatcher
+
+**Scope.** Infrastructure qui permet au chat d'afficher des composants React
+inline quand le backend émet un event `ui_render`. C'est le cœur de la
+Generative UI d'ARIA.
+
+**Fichiers.**
+- `frontend/src/artifacts/registry.ts` — map `{componentName: ReactFC}`
+- `frontend/src/artifacts/ArtifactRenderer.tsx` — lookup + error boundary
+- `frontend/src/artifacts/schemas.ts` — Zod schemas pour chaque artifact props
+
+**Comportement.**
+- Reçoit `ui_render` event `{component, props, turn_id}` depuis WS
+- Look up dans le registry → rend le composant (error boundary)
+- Validation Zod des props à runtime → fallback "artifact error" si invalide
+- Unknown component → fallback "unknown artifact: X"
+- Chaque artifact wrappé dans `artifactReveal` motion variant
+- Placement dans `Message` : les artifacts s'insèrent inline dans l'ordre d'arrivée
+  entre les `text_delta` bubbles
+
+**Scope OUT.**
+- Les 9 artifacts individuels sont les issues M8.1 à M8.3
+
+**Bloqué par.** M2.9 (tools `render_*` déclarés backend)
+
+**Acceptance.**
+- [ ] Backend émet `ui_render` avec nom enregistré → artifact rend
+- [ ] Nom inconnu → fallback, chat ne crash pas
+- [ ] Props invalides → error boundary, session continue
+- [ ] Artifacts s'animent en entrée
+
+**Bloque.** M8.1, M8.2, M8.3
+
+---
+
+## Bloque
+
+- M8 (artifacts rendering), M9 (polish E2E)
+
+## Bloqué par
+
+- M6 (foundation), M2.9 (ui_render tools backend), M4.1 (WSManager), M5.4 (Q&A Managed Agents)

--- a/docs/planning/M8-agentic-workspace/issues.md
+++ b/docs/planning/M8-agentic-workspace/issues.md
@@ -1,0 +1,216 @@
+# M8 — Agentic Workspace (J5)
+
+> Objectif : le cœur visuel du multi-agent — les 9 artifacts generative UI
+> rendent, l'Activity Feed montre les agents collaborer, l'Agent Inspector
+> streame le thinking d'Opus 4.7 en direct, l'onboarding wizard est complet.
+> Fin J5 = flow démo cliquable end-to-end en local.
+
+---
+
+## Issue M8.1 — Artifact `SignalChart`
+
+**Scope.** Composant graphique recharts rendu inline quand un agent émet
+`ui_render(SignalChart, {...})`.
+
+**Fichier.** `frontend/src/artifacts/SignalChart.tsx`
+
+**Props.** `{signal_def_id: int, window_hours: int, mark_anomaly_at?: string, threshold?: number}`
+
+**Comportement.**
+- Fetch data via `GET /api/v1/signals/{signal_def_id}/trends?window=X` (TanStack Query)
+- Recharts `AreaChart` avec :
+  - Reference line threshold (dashed red)
+  - Anomaly marker (X rouge) au timestamp `mark_anomaly_at`
+  - Axis labels depuis unit KB (mm/s, °C, bar…)
+  - Tooltip hover avec valeur exacte + timestamp
+- Size compact (~320×180) fit dans une bulle chat
+- Skeleton loading, toast on error
+
+**Bloqué par.** M7.5 (registry)
+
+**Acceptance.**
+- [ ] Render via `ui_render` end-to-end
+- [ ] Threshold + anomaly marker visibles si props fournis
+- [ ] Skeleton pendant fetch, toast si échec
+
+---
+
+## Issue M8.2 — Artifact `EquipmentKbCard` (seuils éditables inline)
+
+**Scope.** Card fiche équipement avec seuils calibrables par l'opérateur directement
+dans le chat. **Démo clé** : claim "l'opérateur enrichit la KB".
+
+**Fichier.** `frontend/src/artifacts/EquipmentKbCard.tsx`
+
+**Props.** `{cell_id: int, highlight_fields?: string[]}`
+
+**Comportement.**
+- Fetch `GET /api/v1/equipment/{cell_id}/kb` (ou `/api/v1/kb/equipment/{cell_id}` selon route finale)
+- Affiche : nom équipement, specs constructeur, **thresholds calibrés**, procédures (collapsed par défaut)
+- Edit inline : click valeur → input → save via `PATCH` / `PUT` (route KB existante avec `structured_data` patch)
+- Optimistic update + rollback si échec
+- Fields dans `highlight_fields` → pulse ring accent
+
+**Bloqué par.** M1.5 (KB repo update), M7.5
+
+**Acceptance.**
+- [ ] Edit threshold → persisté
+- [ ] Highlight fields pulsent
+- [ ] Sections collapse/expand
+
+---
+
+## Issue M8.3 — Artifacts bundle (WorkOrderCard + DiagnosticCard + CorrelationMatrix + PatternMatch + BarChart + AlertBanner + KbProgress)
+
+**Scope.** 7 artifacts restants regroupés (pattern commun : card avec title + content + CTA optionnel).
+
+**Fichiers.**
+- `frontend/src/artifacts/WorkOrderCard.tsx`
+- `frontend/src/artifacts/DiagnosticCard.tsx`
+- `frontend/src/artifacts/CorrelationMatrix.tsx`
+- `frontend/src/artifacts/PatternMatch.tsx`
+- `frontend/src/artifacts/BarChart.tsx`
+- `frontend/src/artifacts/AlertBanner.tsx`
+- `frontend/src/artifacts/KbProgress.tsx`
+
+**Détails par artifact.**
+
+**WorkOrderCard** `{work_order_id, printable: true}` — résumé compact WO, badge priority, CTA "Open printable view" → nouvel onglet.
+
+**DiagnosticCard** `{title, confidence, root_cause, contributing_factors[], pattern_match_id?}` — header avec confidence ring, facteurs bulletés, CTA "Generate work order".
+
+**CorrelationMatrix** `{sources[], impact_matrix[][]}` — grid heatmap coloré par score.
+
+**PatternMatch** `{current_event, past_event_ref, similarity}` — split card "Current / Past" + similarity score.
+
+**BarChart** `{title, x_label, y_label, bars[]}` — recharts bar chart simple.
+
+**AlertBanner** `{severity, cell_id, message, anomaly_id}` — bandeau compact inline chat (vs le banner global M7.3 qui est dans la control room).
+
+**KbProgress** `{steps[{label, status}]}` — liste étapes avec spinner / checkmark (utilisé pendant parsing PDF).
+
+**Bloqué par.** M7.5
+
+**Acceptance.**
+- [ ] 7 artifacts rendent via `ui_render`
+- [ ] Respect tokens design system
+- [ ] WorkOrderCard CTA ouvre PrintableWorkOrder (M9.1)
+
+---
+
+## Issue M8.4 — Agent Activity Feed
+
+**Scope.** **Différenciateur agentic n°1.** Panel timeline temps réel qui montre
+les agents collaborer. C'est ce qui fait qu'un juge réalise "ce n'est pas un
+chatbot, c'est une équipe".
+
+**Fichier.** `frontend/src/features/agents/ActivityFeed.tsx`
+
+**Contenu.**
+- Column dans le drawer chat (toggleable) ou panel sous le chat
+- Row par event : agent color dot + name + action + timestamp
+- Actions affichées :
+  - `agent_start` → "{Agent} thinking..."
+  - `tool_call_started` → "{Agent} calls: {tool_name}"
+  - `tool_call_completed` → durée à côté
+  - `agent_handoff` → "{From} → {To}: {reason}" avec animation `handoffSweep`
+  - `agent_end` → finish reason
+  - `anomaly_detected` → "Sentinel: Anomaly on {cell}"
+- Rows persistent 5 min puis fade out
+- Filter chips : `All` / `Sentinel` / `Investigator` / `KB Builder` / `Work Order` / `Q&A`
+
+**Store.** `zustand frontend/src/store/agents.ts` — buffer circulaire des events.
+
+**Bloqué par.** M6.4 (WS client), M4.1 + M4.6 (events + handoffs)
+
+**Acceptance.**
+- [ ] Events stream live
+- [ ] Handoffs visuellement distincts (arrow sweep)
+- [ ] Filter chips fonctionnels
+
+---
+
+## Issue M8.5 — Agent Inspector + thinking stream ⭐
+
+**Scope.** **LA FEATURE WIN.** Panel drawer qui montre Opus 4.7 réfléchir en
+direct (extended thinking streamed). Aucune autre équipe ne le montrera.
+
+**Fichier.** `frontend/src/features/agents/AgentInspector.tsx`
+
+**Structure.**
+- Drawer bottom (40vh, ouvrable au click sur un agent row)
+- 4 tabs : `Thinking` / `Tools used` / `Inputs & outputs` / `Memory`
+
+**Thinking tab.**
+- Stream des `thinking_delta` events en temps réel
+- Rendu en font mono, couleur subtle grey-purple (différent du texte assistant)
+- Auto-scroll bottom
+- Spinner "thinking..." en fin de stream tant que l'agent n'a pas émis `agent_end`
+
+**Tools used tab.**
+- Liste des tool calls du turn : name, durée ms, expandable result
+
+**Inputs & outputs tab.**
+- JSON raw des messages passés à l'agent (dev-style, utile pour démo "inspect")
+
+**Memory tab.**
+- Liste des entries KB ou failure_history que l'agent a touché
+
+**Bloqué par.** M4.5 (extended thinking backend), M4.1 (WSManager)
+
+**Pourquoi critique.** C'est ce qui différencie Opus 4.7 vs Sonnet vs Opus 4.6
+pour les juges. Score "Opus 4.7 Use" = 25% de la note. Sans ça, invisible.
+
+**Acceptance.**
+- [ ] Click agent → inspector ouvre
+- [ ] Thinking streame live pendant un turn actif
+- [ ] Pas d'obstruction control room / chat
+- [ ] Close inspector n'interrompt pas l'agent
+
+---
+
+## Issue M8.6 — Onboarding wizard (PDF → KB Builder multi-turn → KB ready)
+
+**Scope.** Scène 1 de la démo. Flow complet d'enrôlement équipement.
+
+**Fichiers.**
+- `frontend/src/features/onboarding/OnboardingWizard.tsx`
+- `frontend/src/features/onboarding/MultiTurnDialog.tsx`
+
+**Steps.**
+1. **Parsing** — affiche `KbProgress` artifact pendant que KB Builder lit le PDF
+   (appelle `POST /api/v1/kb/equipment/{cell_id}/upload`, poll status ou WS)
+2. **Calibration** — dialogue multi-turn :
+   - Frontend appelle `POST /api/v1/kb/equipment/{cell_id}/onboarding/start`
+   - Backend retourne première question
+   - Opérateur répond → `POST /.../onboarding/message` → question suivante
+   - Répété 3–4 tours
+3. **Ready** — final `EquipmentKbCard` avec seuils calibrés, CTA "Return to control room"
+
+**Route.** `/onboarding/:session_id`
+
+**Back button** sur chaque step (préserve progression locale).
+
+**Bloqué par.** M6.6 (PdfUpload), M3.2 + M3.3 (endpoints backend onboarding)
+
+✅ **DÉCIDÉ — sync request/response OK.** Le backend M3.3 fait du request/response
+classique (pas de streaming des questions caractère par caractère). Acceptable
+pour la démo — les questions arrivent instantanément, l'UX reste propre.
+
+**Acceptance.**
+- [ ] Upload PDF → parsing progress visible
+- [ ] Questions multi-turn streamées, réponses POST back
+- [ ] Final KB card affichée
+- [ ] Return navigate vers `/control-room`
+
+**Bloque.** Démo Scène 1.
+
+---
+
+## Bloque
+
+- M9 (polish E2E, Scène 5)
+
+## Bloqué par
+
+- M7 (shell, registry, wire chat), backend M2.9 + M3.2 + M3.3 + M4.5 + M4.6 + M5.4

--- a/docs/planning/M9-polish-e2e/issues.md
+++ b/docs/planning/M9-polish-e2e/issues.md
@@ -20,6 +20,10 @@ un technicien repartir avec ce papier imprimé.
 
 **Fonctions.**
 - List : table avec filters priority/type/status/cell/date, sort par priority
+- **WS live update** : écoute `WS /api/v1/events` → event `work_order_ready` →
+  `queryClient.invalidateQueries(['work-orders'])` pour rafraîchir la liste en
+  temps réel sans reload. Event `rca_ready` → badge RCA disponible apparaît sur
+  la row concernée.
 - Detail : tous les champs depuis `GET /api/v1/work-orders/{id}` incluant `rca_summary`,
   `recommended_actions`, `parts_required`
 - Printable : CSS `@media print`, layout A4, QR code WO id (via `qrcode` dynamic import)
@@ -27,6 +31,8 @@ un technicien repartir avec ce papier imprimé.
 
 **Acceptance.**
 - [ ] Filtres et sort fonctionnels
+- [ ] Quand Sentinel crée un WO → apparaît dans la liste en < 5s (sans reload)
+- [ ] Quand Investigator finit → badge RCA s'affiche sur la row en live
 - [ ] Detail page rend tous les champs
 - [ ] Print preview pro (no chrome, black on white, hiérarchie claire)
 

--- a/docs/planning/M9-polish-e2e/issues.md
+++ b/docs/planning/M9-polish-e2e/issues.md
@@ -1,0 +1,124 @@
+# M9 — Polish & E2E (J6)
+
+> Objectif : la démo 5 scènes tourne end-to-end sans crash sous 3 minutes,
+> tout est poli visuellement, les fallbacks sont en place.
+> Fin J6 = prête à filmer J7.
+
+---
+
+## Issue M9.1 — Work Orders console (list + detail + printable)
+
+**Scope.** Le livrable tangible du système. Scène 4 de la démo : le juge imagine
+un technicien repartir avec ce papier imprimé.
+
+**Fichiers.**
+- `frontend/src/features/work-orders/WorkOrderList.tsx`
+- `frontend/src/features/work-orders/WorkOrderDetail.tsx`
+- `frontend/src/features/work-orders/PrintableWorkOrder.tsx`
+
+**Route.** `/work-orders` + `/work-orders/:id`
+
+**Fonctions.**
+- List : table avec filters priority/type/status/cell/date, sort par priority
+- Detail : tous les champs depuis `GET /api/v1/work-orders/{id}` incluant `rca_summary`,
+  `recommended_actions`, `parts_required`
+- Printable : CSS `@media print`, layout A4, QR code WO id (via `qrcode` dynamic import)
+- Bouton "Print" → `window.print()`
+
+**Acceptance.**
+- [ ] Filtres et sort fonctionnels
+- [ ] Detail page rend tous les champs
+- [ ] Print preview pro (no chrome, black on white, hiérarchie claire)
+
+**Bloqué par.** M1.2 + M1.6 (colonnes work_order), M5.1 (WO Gen backend)
+
+**Bloque.** Démo Scène 4.
+
+---
+
+## Issue M9.2 — Motion polish pass
+
+**Scope.** Pass complet sur le feel animations. C'est ce qui transforme
+"démo fonctionne" en "démo mémorable".
+
+**Audit à faire sur toutes les features.**
+- Streaming tokens chat : smooth token-by-token (rAF batching, pas de jitter)
+- Artifact reveal : `artifactReveal` variant, timing cohérent (220ms ease-out)
+- Agent handoff : `handoffSweep` arrow entre badges agents (Activity Feed)
+- Anomaly on P-02 : pulse + ripple + flash screen 150ms red (subtil)
+- Thinking stream : fade-in drawer Agent Inspector
+- Route transitions : View Transitions API (React 19) si supporté
+- `prefers-reduced-motion` respecté (kill ripple/shake, garde fades)
+
+**Acceptance.**
+- [ ] 60fps toutes scènes (DevTools Performance, no long task >50ms)
+- [ ] Reduced-motion testé
+- [ ] Pas de motion sickness (shakes <300ms, rien de destructif)
+
+**Priorité.** P1 — skip si J6 soir trop serré.
+
+---
+
+## Issue M9.3 — Memory flex scene (UI)
+
+**Scope.** Scène dédiée démo pour prouver que l'agent apprend. 2e diagnostic
+visiblement plus rapide grâce à `failure_history`.
+
+**Fichier.** `frontend/src/features/demo/MemoryScene.tsx`
+
+**Route (cachée).** `/demo/memory`
+
+**UI.**
+- Bouton "Replay" → POST vers endpoint backend M4.7 qui trigger le scénario
+- Split view : "Past event (3 months ago)" vs "Current event"
+- Investigator output side-by-side : 1er diagnostic time vs 2e diagnostic time
+- Badge "Pattern match: 92% similarity" avec lien vers l'entry `failure_history`
+
+**Bloqué par.** M4.7 (backend memory scene)
+
+**Priorité.** P1 — bonus si ok côté backend. Sinon scène coupée de la démo.
+
+**Acceptance.**
+- [ ] Bouton Replay déclenche le scénario backend
+- [ ] Split comparaison clair
+- [ ] Time-to-diagnosis visible plus bas au 2e run
+
+---
+
+## Issue M9.4 — E2E demo rehearsal (P-02 scripted)
+
+**Scope.** Jouer la démo 5 scènes en conditions réelles, chronométrer, noter
+les bugs, stabiliser.
+
+**Prérequis.** Simulator tourne en mode `demo` → scénario P-02 compressé ~4 min.
+
+**Procédure.**
+- Lancer les 5 scènes en séquence (cf. idea.md §8) :
+  1. Onboarding pump P-02 (45s target)
+  2. Anomaly detection (45s)
+  3. Investigation RCA (45s) — **scène clé, thinking stream visible**
+  4. Work order généré + printable (30s)
+  5. Q&A ("Night shift failures more frequent?") (15s)
+- Chaque scène sous son budget
+- Fallback par scène : si agent hang >15s, switch vers réponse pré-enregistrée
+
+**Livrable.** `docs/DEMO.md` — script scène-par-scène avec timings + captures + fallbacks.
+
+**Top 5 bugs** : noter et fixer en priorité.
+
+**Acceptance.**
+- [ ] Démo 5 scènes sous 3 minutes
+- [ ] Zéro crash
+- [ ] Fallback déclenché en simulant une panne backend
+
+**Bloque.** M10 (submission).
+
+---
+
+## Bloque
+
+- M10
+
+## Bloqué par
+
+- M7 + M8 (toutes les features UI), backend M4.7 (memory scene bonus)


### PR DESCRIPTION
## Summary

Frontend planning counterpart to @zestones' backend milestones (M1–M5 pushed earlier today in 2c93a9b).

### New milestones added
- **M6 Frontend Foundation** (J3) — design system, app shell, WS client, chat shell mocked, PDF upload
- **M7 Control Room** (J4) — P&ID animated SVG, KPI bar live, anomaly banner, wire chat to real WS, artifact registry
- **M8 Agentic Workspace** (J5) — 7 generative UI artifacts, Activity Feed, Agent Inspector with **extended-thinking stream** (Opus 4.7 flagship), onboarding wizard
- **M9 Polish & E2E** (J6) — work orders console, motion pass, memory flex scene, E2E rehearsal
- **M10 Submission** (J7) — README, 3-minute video, submission package (shared with @zestones)

### `ALIGNMENT.md` — must-read for both devs

Contains:
1. **Final WebSocket event contract** shared between backend (M4.1 WSManager, M5.2 Q&A WS) and frontend (M6.4 WS client). Extends the events listed in M4.1 with 3 new ones needed for the prizes: `thinking_delta`, `agent_handoff`, `ui_render`.
2. **4 new backend issues** to add under existing milestones, flagged 🔴 critical for the prizes:
   - **M4.5** Extended thinking on Investigator — Opus 4.7 flagship, streamed to UI → 25% "Opus 4.7 Use" score
   - **M4.6** Agent-as-tool pattern (dynamic handoffs via tool call) — replaces the asyncio-scripted pipeline → "Best Managed Agents \$5k" credibility
   - **M5.4** Migrate Q&A to Claude Managed Agents — direct eligibility for "Best Managed Agents \$5k"
   - **M2.9** Declare 9 generative UI `render_*` tools in agents — enables inline artifacts in chat (SignalChart, DiagnosticCard, WorkOrderCard, etc.)
3. **Bonus issue M4.7** (P1) — memory flex scene (Investigator uses `failure_history` to diagnose faster on repeat patterns)
4. **Lane split** (zero file overlap: backend owns `backend/*`, frontend owns `frontend/*`)
5. **Cross-team checklist** — 7 decisions to validate together before starting J3

### Why these 4 backend additions

The backend plan as pushed is technically solid (clean scoping, \`DÉCIDÉ\` markers, dependencies traced). But without these 4 additions, the multi-agent system would be an asyncio-scripted pipeline with no visible Opus 4.7 differentiator — losing the 2 most eligible \$5k prizes.

## Test plan
- [ ] @zestones reads `docs/planning/ALIGNMENT.md` and confirms the 4 new backend issues can be added under M2 / M4 / M5
- [ ] Both devs validate the 7-point checklist at the bottom of ALIGNMENT.md
- [ ] WebSocket event contract agreed (extends M4.1 with 3 new events)
- [ ] Merge before starting J3 coding tomorrow morning

Closes no issue (planning-only, no code).