### PR TITLE
feat(frontend): typed WebSocket client + vitest bootstrap (M6.4)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -25,14 +25,79 @@
             },
             "devDependencies": {
                 "@biomejs/biome": "^2.3.4",
+                "@testing-library/dom": "^10.4.1",
+                "@testing-library/jest-dom": "^6.9.1",
+                "@testing-library/react": "^16.3.2",
+                "@testing-library/user-event": "^14.6.1",
                 "@types/node": "^22.10.5",
                 "@types/qrcode": "^1.5.6",
                 "@types/react": "^19.2.5",
                 "@types/react-dom": "^19.2.3",
                 "@vitejs/plugin-react": "^5.1.1",
+                "@vitest/ui": "^4.1.5",
+                "jsdom": "^29.0.2",
                 "typescript": "~5.9.3",
-                "vite": "^7.2.4"
+                "vite": "^7.2.4",
+                "vitest": "^4.1.5"
             }
+        },
+        "node_modules/@adobe/css-tools": {
+            "version": "4.4.4",
+            "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+            "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "5.1.11",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@csstools/css-calc": "^3.2.0",
+                "@csstools/css-color-parser": "^4.1.0",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+            "integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@asamuzakjp/nwsapi": "^2.3.9",
+                "bidi-js": "^1.0.3",
+                "css-tree": "^3.2.1",
+                "is-potential-custom-element-name": "^1.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/generational-cache": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+            "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/nwsapi": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.0",
@@ -65,6 +130,7 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -266,6 +332,16 @@
             },
             "peerDependencies": {
                 "@babel/core": "^7.0.0-0"
+            }
+        },
+        "node_modules/@babel/runtime": {
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+            "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/template": {
@@ -477,6 +553,161 @@
             ],
             "engines": {
                 "node": ">=14.21.3"
+            }
+        },
+        "node_modules/@bramus/specificity": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+            "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "^3.0.0"
+            },
+            "bin": {
+                "specificity": "bin/cli.js"
+            }
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+            "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+            "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+            "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^6.0.2",
+                "@csstools/css-calc": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-syntax-patches-for-csstree": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+            "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "peerDependencies": {
+                "css-tree": "^3.2.1"
+            },
+            "peerDependenciesMeta": {
+                "css-tree": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=20.19.0"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -895,6 +1126,24 @@
                 "node": ">=18"
             }
         },
+        "node_modules/@exodus/bytes": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+            "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@noble/hashes": "^1.8.0 || ^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@noble/hashes": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1189,6 +1438,13 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/Brooooooklyn"
             }
+        },
+        "node_modules/@polka/url": {
+            "version": "1.0.0-next.29",
+            "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+            "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@reduxjs/toolkit": {
             "version": "2.11.2",
@@ -1853,6 +2109,103 @@
                 "react": "^18 || ^19"
             }
         },
+        "node_modules/@testing-library/dom": {
+            "version": "10.4.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+            "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/code-frame": "^7.10.4",
+                "@babel/runtime": "^7.12.5",
+                "@types/aria-query": "^5.0.1",
+                "aria-query": "5.3.0",
+                "dom-accessibility-api": "^0.5.9",
+                "lz-string": "^1.5.0",
+                "picocolors": "1.1.1",
+                "pretty-format": "^27.0.2"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/@testing-library/jest-dom": {
+            "version": "6.9.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+            "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@adobe/css-tools": "^4.4.0",
+                "aria-query": "^5.0.0",
+                "css.escape": "^1.5.1",
+                "dom-accessibility-api": "^0.6.3",
+                "picocolors": "^1.1.1",
+                "redent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14",
+                "npm": ">=6",
+                "yarn": ">=1"
+            }
+        },
+        "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+            "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@testing-library/react": {
+            "version": "16.3.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+            "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.12.5"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": "^10.0.0",
+                "@types/react": "^18.0.0 || ^19.0.0",
+                "@types/react-dom": "^18.0.0 || ^19.0.0",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@testing-library/user-event": {
+            "version": "14.6.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+            "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12",
+                "npm": ">=6"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": ">=7.21.4"
+            }
+        },
+        "node_modules/@types/aria-query": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+            "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
             "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1896,6 +2249,17 @@
             "license": "MIT",
             "dependencies": {
                 "@babel/types": "^7.28.2"
+            }
+        },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
             }
         },
         "node_modules/@types/d3-array": {
@@ -1970,6 +2334,13 @@
                 "@types/ms": "*"
             }
         },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2034,6 +2405,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
             "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -2044,6 +2416,7 @@
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -2087,6 +2460,142 @@
                 "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+            "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+            "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.5",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+            "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+            "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.5",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+            "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+            "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/ui": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/ui/-/ui-4.1.5.tgz",
+            "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vitest/utils": "4.1.5",
+                "fflate": "^0.8.2",
+                "flatted": "^3.4.2",
+                "pathe": "^2.0.3",
+                "sirv": "^3.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "vitest": "4.1.5"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+            "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.5",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/ansi-regex": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2109,6 +2618,26 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/aria-query": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+            "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "dequal": "^2.0.3"
+            }
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/bail": {
@@ -2134,6 +2663,16 @@
                 "node": ">=6.0.0"
             }
         },
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "require-from-string": "^2.0.2"
+            }
+        },
         "node_modules/browserslist": {
             "version": "4.28.2",
             "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
@@ -2154,6 +2693,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -2206,6 +2746,16 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/character-entities": {
@@ -2315,6 +2865,27 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
             }
+        },
+        "node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
+        "node_modules/css.escape": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+            "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/csstype": {
             "version": "3.2.3",
@@ -2443,6 +3014,20 @@
                 "node": ">=12"
             }
         },
+        "node_modules/data-urls": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2468,6 +3053,13 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/decimal.js-light": {
             "version": "2.5.1",
@@ -2525,6 +3117,13 @@
             "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
             "license": "MIT"
         },
+        "node_modules/dom-accessibility-api": {
+            "version": "0.5.16",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+            "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/electron-to-chromium": {
             "version": "1.5.341",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.341.tgz",
@@ -2550,6 +3149,26 @@
             "engines": {
                 "node": ">=10.13.0"
             }
+        },
+        "node_modules/entities": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+            "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/es-toolkit": {
             "version": "1.46.0",
@@ -2634,11 +3253,31 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
         "node_modules/eventemitter3": {
             "version": "5.0.4",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
             "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
             "license": "MIT"
+        },
+        "node_modules/expect-type": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
         },
         "node_modules/extend": {
             "version": "3.0.2",
@@ -2663,6 +3302,13 @@
                 }
             }
         },
+        "node_modules/fflate": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+            "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/find-up": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -2675,6 +3321,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/flatted": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+            "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/framer-motion": {
             "version": "12.38.0",
@@ -2782,6 +3435,19 @@
                 "url": "https://opencollective.com/unified"
             }
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.6.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/html-url-attributes": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -2800,6 +3466,16 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/immer"
+            }
+        },
+        "node_modules/indent-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+            "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/inline-style-parser": {
@@ -2882,6 +3558,13 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/jiti": {
             "version": "2.6.1",
             "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
@@ -2897,6 +3580,58 @@
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/jsdom": {
+            "version": "29.0.2",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+            "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@asamuzakjp/css-color": "^5.1.5",
+                "@asamuzakjp/dom-selector": "^7.0.6",
+                "@bramus/specificity": "^2.4.2",
+                "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+                "@exodus/bytes": "^1.15.0",
+                "css-tree": "^3.2.1",
+                "data-urls": "^7.0.0",
+                "decimal.js": "^10.6.0",
+                "html-encoding-sniffer": "^6.0.0",
+                "is-potential-custom-element-name": "^1.0.1",
+                "lru-cache": "^11.2.7",
+                "parse5": "^8.0.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^6.0.1",
+                "undici": "^7.24.5",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^8.0.1",
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.1",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jsdom/node_modules/lru-cache": {
+            "version": "11.3.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
         },
         "node_modules/jsesc": {
             "version": "3.1.0",
@@ -3214,6 +3949,16 @@
                 "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
+        "node_modules/lz-string": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+            "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "lz-string": "bin/bin.js"
+            }
+        },
         "node_modules/magic-string": {
             "version": "0.30.21",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3502,6 +4247,13 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/unified"
             }
+        },
+        "node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/micromark": {
             "version": "4.0.2",
@@ -4066,6 +4818,16 @@
             ],
             "license": "MIT"
         },
+        "node_modules/min-indent": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+            "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/motion-dom": {
             "version": "12.38.0",
             "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
@@ -4080,6 +4842,16 @@
             "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
             "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
             "license": "MIT"
+        },
+        "node_modules/mrmime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+            "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
         },
         "node_modules/ms": {
             "version": "2.1.3",
@@ -4117,6 +4889,17 @@
             "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
             "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
             "license": "MIT"
         },
         "node_modules/p-limit": {
@@ -4180,6 +4963,19 @@
             "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
             "license": "MIT"
         },
+        "node_modules/parse5": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^8.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4188,6 +4984,13 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/pdfjs-dist": {
             "version": "5.6.205",
@@ -4257,6 +5060,41 @@
                 "node": "^10 || ^12 || >=14"
             }
         },
+        "node_modules/pretty-format": {
+            "version": "27.5.1",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+            "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1",
+                "ansi-styles": "^5.0.0",
+                "react-is": "^17.0.1"
+            },
+            "engines": {
+                "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/pretty-format/node_modules/ansi-styles": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/pretty-format/node_modules/react-is": {
+            "version": "17.0.2",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+            "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/property-information": {
             "version": "7.1.0",
             "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -4265,6 +5103,16 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/punycode": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/qrcode": {
@@ -4289,6 +5137,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
             "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4298,6 +5147,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
             "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -4344,6 +5194,7 @@
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
             "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/use-sync-external-store": "^0.0.6",
                 "use-sync-external-store": "^1.4.0"
@@ -4440,11 +5291,26 @@
                 "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
+        "node_modules/redent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+            "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "indent-string": "^4.0.0",
+                "strip-indent": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/redux": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
             "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/redux-thunk": {
             "version": "3.1.0",
@@ -4530,6 +5396,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/require-from-string": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+            "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/require-main-filename": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
@@ -4586,6 +5462,19 @@
                 "fsevents": "~2.3.2"
             }
         },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
+            }
+        },
         "node_modules/scheduler": {
             "version": "0.27.0",
             "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4614,6 +5503,28 @@
             "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
             "license": "MIT"
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/sirv": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
+            "integrity": "sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@polka/url": "^1.0.0-next.24",
+                "mrmime": "^2.0.0",
+                "totalist": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4632,6 +5543,20 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/string-width": {
             "version": "4.2.3",
@@ -4673,6 +5598,19 @@
                 "node": ">=8"
             }
         },
+        "node_modules/strip-indent": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+            "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "min-indent": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/style-to-js": {
             "version": "1.1.21",
             "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -4690,6 +5628,13 @@
             "dependencies": {
                 "inline-style-parser": "0.2.7"
             }
+        },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/tailwindcss": {
             "version": "4.2.4",
@@ -4716,6 +5661,23 @@
             "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
             "license": "MIT"
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+            "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.16",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -4730,6 +5692,72 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tldts": {
+            "version": "7.0.28",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+            "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.0.28"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "7.0.28",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+            "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/totalist": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+            "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/tough-cookie": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+            "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^7.0.5"
+            },
+            "engines": {
+                "node": ">=16"
+            }
+        },
+        "node_modules/tr46": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
             }
         },
         "node_modules/trim-lines": {
@@ -4770,6 +5798,16 @@
             },
             "engines": {
                 "node": ">=14.17"
+            }
+        },
+        "node_modules/undici": {
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+            "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
             }
         },
         "node_modules/undici-types": {
@@ -4961,6 +5999,7 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
             "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -5030,11 +6069,167 @@
                 }
             }
         },
+        "node_modules/vitest": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+            "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@vitest/expect": "4.1.5",
+                "@vitest/mocker": "4.1.5",
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/runner": "4.1.5",
+                "@vitest/snapshot": "4.1.5",
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.5",
+                "@vitest/browser-preview": "4.1.5",
+                "@vitest/browser-webdriverio": "4.1.5",
+                "@vitest/coverage-istanbul": "4.1.5",
+                "@vitest/coverage-v8": "4.1.5",
+                "@vitest/ui": "4.1.5",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/whatwg-url": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.11.0",
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/which-module": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
             "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
             "license": "ISC"
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/wrap-ansi": {
             "version": "6.2.0",
@@ -5049,6 +6244,23 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/y18n": {
             "version": "4.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,7 +13,10 @@
         "format:check": "biome format ./src",
         "check": "biome check ./src",
         "check:fix": "biome check --write ./src",
-        "typecheck": "tsc -b --noEmit"
+        "typecheck": "tsc -b --noEmit",
+        "test": "vitest run",
+        "test:watch": "vitest",
+        "test:ui": "vitest --ui"
     },
     "dependencies": {
         "@tailwindcss/vite": "^4.1.18",
@@ -33,12 +36,19 @@
     },
     "devDependencies": {
         "@biomejs/biome": "^2.3.4",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^22.10.5",
         "@types/qrcode": "^1.5.6",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.1",
+        "@vitest/ui": "^4.1.5",
+        "jsdom": "^29.0.2",
         "typescript": "~5.9.3",
-        "vite": "^7.2.4"
+        "vite": "^7.2.4",
+        "vitest": "^4.1.5"
     }
 }

--- a/frontend/src/lib/ws.test.ts
+++ b/frontend/src/lib/ws.test.ts
@@ -1,212 +1,224 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { MockWebSocket } from "../test/mock-websocket";
-import { type ChatMap, createChatClient, createEventBusClient, createWsClient } from "./ws";
-
-type BusMap = {
-    "machine.status": { id: string; state: "up" | "down" };
-    "alarm.raised": { code: number; message: string };
-};
+import { installMockWebSocket, MockWebSocket, restoreWebSocket } from "../test/mock-websocket";
+import { createChatWsClient, createWsClient } from "./ws";
+import type { ChatMap, EventBusMap } from "./ws.types";
 
 beforeEach(() => {
-    MockWebSocket.reset();
+    installMockWebSocket();
     vi.useFakeTimers();
 });
 
 afterEach(() => {
     vi.useRealTimers();
+    restoreWebSocket();
 });
 
-describe("createWsClient", () => {
-    it("dispatches incoming messages to the right typed handler", () => {
-        const client = createEventBusClient<BusMap>("ws://localhost/test", {
-            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+describe("createWsClient (EventBusMap)", () => {
+    it("parses fixture multi-event and dispatches typed events", () => {
+        const onEvent = vi.fn();
+        createWsClient<EventBusMap>({
+            url: "ws://localhost/api/v1/events",
+            onEvent,
         });
-
-        const statusHandler = vi.fn();
-        const alarmHandler = vi.fn();
-        client.on("machine.status", statusHandler);
-        client.on("alarm.raised", alarmHandler);
-
         MockWebSocket.last.simulateOpen();
+
         MockWebSocket.last.simulateMessage({
-            type: "machine.status",
-            payload: { id: "M1", state: "up" },
+            type: "agent_start",
+            payload: { agent: "planner", turn_id: "t1" },
+        });
+        MockWebSocket.last.simulateMessage({
+            type: "thinking_delta",
+            payload: { agent: "planner", content: "analysing", turn_id: "t1" },
+        });
+        MockWebSocket.last.simulateMessage({
+            type: "work_order_ready",
+            payload: { work_order_id: 42 },
         });
 
-        expect(statusHandler).toHaveBeenCalledExactlyOnceWith({ id: "M1", state: "up" });
-        expect(alarmHandler).not.toHaveBeenCalled();
+        expect(onEvent).toHaveBeenCalledTimes(3);
+        expect(onEvent).toHaveBeenNthCalledWith(1, "agent_start", {
+            agent: "planner",
+            turn_id: "t1",
+        });
+        expect(onEvent).toHaveBeenNthCalledWith(2, "thinking_delta", {
+            agent: "planner",
+            content: "analysing",
+            turn_id: "t1",
+        });
+        expect(onEvent).toHaveBeenNthCalledWith(3, "work_order_ready", {
+            work_order_id: 42,
+        });
     });
 
-    it("ignores messages whose `type` has no subscriber", () => {
-        const client = createEventBusClient<BusMap>("ws://x", {
-            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+    it("reconnects with exponential backoff after unexpected close (1006)", () => {
+        createWsClient<EventBusMap>({
+            url: "ws://localhost/api/v1/events",
+            onEvent: vi.fn(),
         });
+        MockWebSocket.last.simulateOpen();
+        expect(MockWebSocket.instances).toHaveLength(1);
+
+        MockWebSocket.last.simulateClose(1006, "abnormal");
+
+        // Attempt #1: 500ms
+        vi.advanceTimersByTime(499);
+        expect(MockWebSocket.instances).toHaveLength(1);
+        vi.advanceTimersByTime(1);
+        expect(MockWebSocket.instances).toHaveLength(2);
+
+        // Attempt #2: 1500ms
+        MockWebSocket.last.simulateClose(1006, "abnormal");
+        vi.advanceTimersByTime(1499);
+        expect(MockWebSocket.instances).toHaveLength(2);
+        vi.advanceTimersByTime(1);
+        expect(MockWebSocket.instances).toHaveLength(3);
+    });
+
+    it("cleans up listeners after close()", () => {
+        const client = createWsClient<EventBusMap>({
+            url: "ws://localhost/api/v1/events",
+            onEvent: vi.fn(),
+        });
+        MockWebSocket.last.simulateOpen();
+        const mock = MockWebSocket.last;
+        expect(mock.totalListenerCount()).toBeGreaterThan(0);
+
+        client.close();
+
+        expect(mock.totalListenerCount()).toBe(0);
+        expect(mock.readyState).toBe(MockWebSocket.CLOSED);
+    });
+
+    it("calls onError with 'Max reconnect attempts' after 3 failed retries", () => {
         const onError = vi.fn();
-        client.on("machine.status", vi.fn());
+        createWsClient<EventBusMap>({
+            url: "ws://localhost/api/v1/events",
+            onEvent: vi.fn(),
+            onError,
+        });
+
+        // Attempt #1: initial close → retry after 500ms
+        MockWebSocket.last.simulateClose(1006);
+        vi.advanceTimersByTime(500);
+        expect(MockWebSocket.instances).toHaveLength(2);
+
+        // Attempt #2: close again → retry after 1500ms
+        MockWebSocket.last.simulateClose(1006);
+        vi.advanceTimersByTime(1500);
+        expect(MockWebSocket.instances).toHaveLength(3);
+
+        // Attempt #3: close again → retry after 4500ms
+        MockWebSocket.last.simulateClose(1006);
+        vi.advanceTimersByTime(4500);
+        expect(MockWebSocket.instances).toHaveLength(4);
+
+        // 4th close → max reached, no new instance, onError fires
+        MockWebSocket.last.simulateClose(1006);
+        vi.advanceTimersByTime(10_000);
+        expect(MockWebSocket.instances).toHaveLength(4);
+        expect(onError).toHaveBeenCalledWith(
+            expect.objectContaining({ message: "Max reconnect attempts reached" }),
+        );
+    });
+
+    it("does not reconnect on clean close (code 1000)", () => {
+        createWsClient<EventBusMap>({
+            url: "ws://localhost/api/v1/events",
+            onEvent: vi.fn(),
+        });
         MockWebSocket.last.simulateOpen();
 
-        MockWebSocket.last.simulateMessage({ type: "unknown.event", payload: {} });
+        MockWebSocket.last.simulateClose(1000, "normal");
+        vi.advanceTimersByTime(10_000);
 
-        expect(onError).not.toHaveBeenCalled();
+        expect(MockWebSocket.instances).toHaveLength(1);
     });
 
-    it("reports malformed frames through onError", () => {
+    it("resets retry counter after 30s of stable OPEN connection", () => {
+        createWsClient<EventBusMap>({
+            url: "ws://localhost/api/v1/events",
+            onEvent: vi.fn(),
+        });
+
+        // Burn two failed attempts quickly
+        MockWebSocket.last.simulateClose(1006);
+        vi.advanceTimersByTime(500);
+        MockWebSocket.last.simulateClose(1006);
+        vi.advanceTimersByTime(1500);
+        expect(MockWebSocket.instances).toHaveLength(3);
+
+        // Open stable for 30s+ → counter resets
+        MockWebSocket.last.simulateOpen();
+        vi.advanceTimersByTime(30_001);
+
+        // Close again → should retry with attempt #1 delay (500ms), not #3 (4500ms)
+        MockWebSocket.last.simulateClose(1006);
+        vi.advanceTimersByTime(499);
+        expect(MockWebSocket.instances).toHaveLength(3);
+        vi.advanceTimersByTime(1);
+        expect(MockWebSocket.instances).toHaveLength(4);
+    });
+
+    it("calls onError on invalid JSON without crashing", () => {
         const onError = vi.fn();
-        createEventBusClient<BusMap>("ws://x", {
-            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+        const onEvent = vi.fn();
+        createWsClient<EventBusMap>({
+            url: "ws://localhost/api/v1/events",
+            onEvent,
             onError,
         });
         MockWebSocket.last.simulateOpen();
 
-        MockWebSocket.last.simulateMessage("not-json");
-        MockWebSocket.last.simulateMessage({ no_type: true });
+        MockWebSocket.last.simulateMessage("{not json");
+        MockWebSocket.last.simulateMessage({ no_type_field: true });
 
         expect(onError).toHaveBeenCalledTimes(2);
+        expect(onEvent).not.toHaveBeenCalled();
     });
 
-    it("queues send() before OPEN and flushes on open", () => {
-        const client = createEventBusClient<BusMap>("ws://x", {
-            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
-        });
-
-        client.send("machine.status", { id: "M1", state: "down" });
-        expect(MockWebSocket.last.sent).toHaveLength(0);
-
-        MockWebSocket.last.simulateOpen();
-
-        expect(MockWebSocket.last.sent).toEqual([
-            JSON.stringify({ type: "machine.status", payload: { id: "M1", state: "down" } }),
-        ]);
-    });
-
-    it("unsubscribes handlers cleanly", () => {
-        const client = createEventBusClient<BusMap>("ws://x", {
-            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
-        });
-        const handler = vi.fn();
-        const unsubscribe = client.on("machine.status", handler);
-        MockWebSocket.last.simulateOpen();
-
-        MockWebSocket.last.simulateMessage({
-            type: "machine.status",
-            payload: { id: "a", state: "up" },
-        });
-        unsubscribe();
-        MockWebSocket.last.simulateMessage({
-            type: "machine.status",
-            payload: { id: "b", state: "up" },
-        });
-
-        expect(handler).toHaveBeenCalledExactlyOnceWith({ id: "a", state: "up" });
-    });
-
-    it("reconnects with exponential backoff after abnormal close", () => {
-        const onOpen = vi.fn();
-        createEventBusClient<BusMap>("ws://x", {
-            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
-            reconnectBaseDelayMs: 100,
-            reconnectMaxDelayMs: 10_000,
-            reconnectJitter: 0,
-            onOpen,
-        });
-
-        MockWebSocket.last.simulateOpen();
-        expect(onOpen).toHaveBeenCalledTimes(1);
-
-        MockWebSocket.last.simulateClose();
-        expect(MockWebSocket.instances).toHaveLength(1);
-
-        // 1st reconnect after base * 2^0 = 100ms
-        vi.advanceTimersByTime(100);
-        expect(MockWebSocket.instances).toHaveLength(2);
-
-        // Fail again before it opens, next delay is base * 2^1 = 200ms
-        MockWebSocket.last.simulateClose();
-        vi.advanceTimersByTime(199);
-        expect(MockWebSocket.instances).toHaveLength(2);
-        vi.advanceTimersByTime(1);
-        expect(MockWebSocket.instances).toHaveLength(3);
-
-        MockWebSocket.last.simulateOpen();
-        expect(onOpen).toHaveBeenCalledTimes(2);
-    });
-
-    it("stops reconnecting after close() is called by the user", () => {
-        const client = createEventBusClient<BusMap>("ws://x", {
-            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
-            reconnectBaseDelayMs: 50,
-            reconnectJitter: 0,
+    it("honors external AbortSignal — closes socket and stops reconnect", () => {
+        const controller = new AbortController();
+        createWsClient<EventBusMap>({
+            url: "ws://localhost/api/v1/events",
+            onEvent: vi.fn(),
+            signal: controller.signal,
         });
         MockWebSocket.last.simulateOpen();
 
-        client.close();
+        controller.abort();
+
         expect(MockWebSocket.last.readyState).toBe(MockWebSocket.CLOSED);
-
         vi.advanceTimersByTime(10_000);
         expect(MockWebSocket.instances).toHaveLength(1);
     });
-
-    it("caps reconnect attempts when reconnectMaxAttempts is set", () => {
-        createEventBusClient<BusMap>("ws://x", {
-            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
-            reconnectBaseDelayMs: 10,
-            reconnectJitter: 0,
-            reconnectMaxAttempts: 2,
-        });
-
-        MockWebSocket.last.simulateClose();
-        vi.advanceTimersByTime(10);
-        expect(MockWebSocket.instances).toHaveLength(2);
-
-        MockWebSocket.last.simulateClose();
-        vi.advanceTimersByTime(20);
-        expect(MockWebSocket.instances).toHaveLength(3);
-
-        MockWebSocket.last.simulateClose();
-        vi.advanceTimersByTime(10_000);
-        expect(MockWebSocket.instances).toHaveLength(3);
-    });
 });
 
-describe("createChatClient", () => {
-    it("routes typed chat events", () => {
-        const client = createChatClient("ws://chat", {
-            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+describe("createChatWsClient (ChatMap)", () => {
+    it("dispatches discriminated-union messages with full object", () => {
+        const onEvent = vi.fn();
+        createChatWsClient<ChatMap>({
+            url: "ws://localhost/api/v1/agent/chat",
+            onEvent,
         });
-        const onMessage = vi.fn<(m: ChatMap["message"]) => void>();
-        client.on("message", onMessage);
         MockWebSocket.last.simulateOpen();
 
+        MockWebSocket.last.simulateMessage({ type: "text_delta", content: "Hel" });
         MockWebSocket.last.simulateMessage({
-            type: "message",
-            payload: {
-                id: "1",
-                threadId: "t1",
-                role: "assistant",
-                content: "hello",
-                createdAt: "2026-04-22T10:00:00Z",
-            },
+            type: "tool_call",
+            name: "query_db",
+            args: { sql: "SELECT 1" },
         });
+        MockWebSocket.last.simulateMessage({ type: "done" });
 
-        expect(onMessage).toHaveBeenCalledExactlyOnceWith({
-            id: "1",
-            threadId: "t1",
-            role: "assistant",
-            content: "hello",
-            createdAt: "2026-04-22T10:00:00Z",
+        expect(onEvent).toHaveBeenNthCalledWith(1, "text_delta", {
+            type: "text_delta",
+            content: "Hel",
         });
-    });
-});
-
-describe("createWsClient (generic)", () => {
-    it("exposes readyState reflecting the underlying socket", () => {
-        const client = createWsClient<BusMap>("ws://x", {
-            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+        expect(onEvent).toHaveBeenNthCalledWith(2, "tool_call", {
+            type: "tool_call",
+            name: "query_db",
+            args: { sql: "SELECT 1" },
         });
-        expect(client.readyState).toBe(MockWebSocket.CONNECTING);
-        MockWebSocket.last.simulateOpen();
-        expect(client.readyState).toBe(MockWebSocket.OPEN);
-        client.close();
-        expect(client.readyState).toBe(MockWebSocket.CLOSED);
+        expect(onEvent).toHaveBeenNthCalledWith(3, "done", { type: "done" });
     });
 });

--- a/frontend/src/lib/ws.test.ts
+++ b/frontend/src/lib/ws.test.ts
@@ -1,0 +1,212 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MockWebSocket } from "../test/mock-websocket";
+import { type ChatMap, createChatClient, createEventBusClient, createWsClient } from "./ws";
+
+type BusMap = {
+    "machine.status": { id: string; state: "up" | "down" };
+    "alarm.raised": { code: number; message: string };
+};
+
+beforeEach(() => {
+    MockWebSocket.reset();
+    vi.useFakeTimers();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe("createWsClient", () => {
+    it("dispatches incoming messages to the right typed handler", () => {
+        const client = createEventBusClient<BusMap>("ws://localhost/test", {
+            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+        });
+
+        const statusHandler = vi.fn();
+        const alarmHandler = vi.fn();
+        client.on("machine.status", statusHandler);
+        client.on("alarm.raised", alarmHandler);
+
+        MockWebSocket.last.simulateOpen();
+        MockWebSocket.last.simulateMessage({
+            type: "machine.status",
+            payload: { id: "M1", state: "up" },
+        });
+
+        expect(statusHandler).toHaveBeenCalledExactlyOnceWith({ id: "M1", state: "up" });
+        expect(alarmHandler).not.toHaveBeenCalled();
+    });
+
+    it("ignores messages whose `type` has no subscriber", () => {
+        const client = createEventBusClient<BusMap>("ws://x", {
+            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+        });
+        const onError = vi.fn();
+        client.on("machine.status", vi.fn());
+        MockWebSocket.last.simulateOpen();
+
+        MockWebSocket.last.simulateMessage({ type: "unknown.event", payload: {} });
+
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("reports malformed frames through onError", () => {
+        const onError = vi.fn();
+        createEventBusClient<BusMap>("ws://x", {
+            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+            onError,
+        });
+        MockWebSocket.last.simulateOpen();
+
+        MockWebSocket.last.simulateMessage("not-json");
+        MockWebSocket.last.simulateMessage({ no_type: true });
+
+        expect(onError).toHaveBeenCalledTimes(2);
+    });
+
+    it("queues send() before OPEN and flushes on open", () => {
+        const client = createEventBusClient<BusMap>("ws://x", {
+            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+        });
+
+        client.send("machine.status", { id: "M1", state: "down" });
+        expect(MockWebSocket.last.sent).toHaveLength(0);
+
+        MockWebSocket.last.simulateOpen();
+
+        expect(MockWebSocket.last.sent).toEqual([
+            JSON.stringify({ type: "machine.status", payload: { id: "M1", state: "down" } }),
+        ]);
+    });
+
+    it("unsubscribes handlers cleanly", () => {
+        const client = createEventBusClient<BusMap>("ws://x", {
+            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+        });
+        const handler = vi.fn();
+        const unsubscribe = client.on("machine.status", handler);
+        MockWebSocket.last.simulateOpen();
+
+        MockWebSocket.last.simulateMessage({
+            type: "machine.status",
+            payload: { id: "a", state: "up" },
+        });
+        unsubscribe();
+        MockWebSocket.last.simulateMessage({
+            type: "machine.status",
+            payload: { id: "b", state: "up" },
+        });
+
+        expect(handler).toHaveBeenCalledExactlyOnceWith({ id: "a", state: "up" });
+    });
+
+    it("reconnects with exponential backoff after abnormal close", () => {
+        const onOpen = vi.fn();
+        createEventBusClient<BusMap>("ws://x", {
+            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+            reconnectBaseDelayMs: 100,
+            reconnectMaxDelayMs: 10_000,
+            reconnectJitter: 0,
+            onOpen,
+        });
+
+        MockWebSocket.last.simulateOpen();
+        expect(onOpen).toHaveBeenCalledTimes(1);
+
+        MockWebSocket.last.simulateClose();
+        expect(MockWebSocket.instances).toHaveLength(1);
+
+        // 1st reconnect after base * 2^0 = 100ms
+        vi.advanceTimersByTime(100);
+        expect(MockWebSocket.instances).toHaveLength(2);
+
+        // Fail again before it opens, next delay is base * 2^1 = 200ms
+        MockWebSocket.last.simulateClose();
+        vi.advanceTimersByTime(199);
+        expect(MockWebSocket.instances).toHaveLength(2);
+        vi.advanceTimersByTime(1);
+        expect(MockWebSocket.instances).toHaveLength(3);
+
+        MockWebSocket.last.simulateOpen();
+        expect(onOpen).toHaveBeenCalledTimes(2);
+    });
+
+    it("stops reconnecting after close() is called by the user", () => {
+        const client = createEventBusClient<BusMap>("ws://x", {
+            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+            reconnectBaseDelayMs: 50,
+            reconnectJitter: 0,
+        });
+        MockWebSocket.last.simulateOpen();
+
+        client.close();
+        expect(MockWebSocket.last.readyState).toBe(MockWebSocket.CLOSED);
+
+        vi.advanceTimersByTime(10_000);
+        expect(MockWebSocket.instances).toHaveLength(1);
+    });
+
+    it("caps reconnect attempts when reconnectMaxAttempts is set", () => {
+        createEventBusClient<BusMap>("ws://x", {
+            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+            reconnectBaseDelayMs: 10,
+            reconnectJitter: 0,
+            reconnectMaxAttempts: 2,
+        });
+
+        MockWebSocket.last.simulateClose();
+        vi.advanceTimersByTime(10);
+        expect(MockWebSocket.instances).toHaveLength(2);
+
+        MockWebSocket.last.simulateClose();
+        vi.advanceTimersByTime(20);
+        expect(MockWebSocket.instances).toHaveLength(3);
+
+        MockWebSocket.last.simulateClose();
+        vi.advanceTimersByTime(10_000);
+        expect(MockWebSocket.instances).toHaveLength(3);
+    });
+});
+
+describe("createChatClient", () => {
+    it("routes typed chat events", () => {
+        const client = createChatClient("ws://chat", {
+            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+        });
+        const onMessage = vi.fn<(m: ChatMap["message"]) => void>();
+        client.on("message", onMessage);
+        MockWebSocket.last.simulateOpen();
+
+        MockWebSocket.last.simulateMessage({
+            type: "message",
+            payload: {
+                id: "1",
+                threadId: "t1",
+                role: "assistant",
+                content: "hello",
+                createdAt: "2026-04-22T10:00:00Z",
+            },
+        });
+
+        expect(onMessage).toHaveBeenCalledExactlyOnceWith({
+            id: "1",
+            threadId: "t1",
+            role: "assistant",
+            content: "hello",
+            createdAt: "2026-04-22T10:00:00Z",
+        });
+    });
+});
+
+describe("createWsClient (generic)", () => {
+    it("exposes readyState reflecting the underlying socket", () => {
+        const client = createWsClient<BusMap>("ws://x", {
+            WebSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+        });
+        expect(client.readyState).toBe(MockWebSocket.CONNECTING);
+        MockWebSocket.last.simulateOpen();
+        expect(client.readyState).toBe(MockWebSocket.OPEN);
+        client.close();
+        expect(client.readyState).toBe(MockWebSocket.CLOSED);
+    });
+});

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -1,0 +1,233 @@
+/**
+ * Typed WebSocket client with exponential-backoff reconnection.
+ *
+ * Two factories expose the same runtime with different type maps:
+ * - `createEventBusClient<TMap>(url)`: server-driven event bus. `TMap` is a
+ *   `{ eventName: Payload }` record for incoming messages.
+ * - `createChatClient<TMap>(url)`: the same runtime, with a conventional
+ *   ChatMap shape (`message`, `typing`, `presence`, ...) for consumer
+ *   ergonomics.
+ *
+ * Wire protocol: `{ type: string, payload: unknown }` (JSON over text frames).
+ *
+ * Chose 2 factories rather than a discriminated-union overload so that
+ * callers never have to narrow unions at each `.on(...)`: the map they pass
+ * already constrains the keys. Same runtime, zero duplication.
+ */
+
+export type EventMap = Record<string, unknown>;
+
+type Handler<T> = (payload: T) => void;
+
+export interface WsClient<TMap extends EventMap> {
+    on<K extends keyof TMap & string>(event: K, handler: Handler<TMap[K]>): () => void;
+    send<K extends keyof TMap & string>(event: K, payload: TMap[K]): void;
+    close(code?: number, reason?: string): void;
+    readonly readyState: number;
+}
+
+export interface WsClientOptions {
+    /** Milliseconds before the first reconnect attempt. Default 500. */
+    reconnectBaseDelayMs?: number;
+    /** Cap on the exponential backoff delay. Default 15_000. */
+    reconnectMaxDelayMs?: number;
+    /** Jitter ratio in [0, 1]. Actual delay is `base * (1 +/- jitter*rand)`. Default 0.2. */
+    reconnectJitter?: number;
+    /** Max reconnect attempts; `Infinity` for unbounded. Default Infinity. */
+    reconnectMaxAttempts?: number;
+    /** Injected WebSocket constructor (tests pass a mock). */
+    WebSocketImpl?: typeof WebSocket;
+    /** Called after every connection failure (reporting / logging hook). */
+    onError?: (error: Event | Error) => void;
+    /** Called when the socket transitions to OPEN (including after reconnects). */
+    onOpen?: () => void;
+    /** Called when the socket closes (before a reconnect is scheduled). */
+    onClose?: (event: CloseEvent) => void;
+}
+
+interface InternalState<TMap extends EventMap> {
+    socket: WebSocket | null;
+    url: string;
+    handlers: Map<keyof TMap & string, Set<Handler<unknown>>>;
+    closedByUser: boolean;
+    reconnectAttempts: number;
+    reconnectTimer: ReturnType<typeof setTimeout> | null;
+    queued: Array<{ type: string; payload: unknown }>;
+    opts: Required<Omit<WsClientOptions, "onError" | "onOpen" | "onClose">> &
+        Pick<WsClientOptions, "onError" | "onOpen" | "onClose">;
+}
+
+function computeBackoff(attempt: number, base: number, cap: number, jitter: number): number {
+    const raw = Math.min(cap, base * 2 ** attempt);
+    if (jitter <= 0) return raw;
+    const delta = raw * jitter * (Math.random() * 2 - 1);
+    return Math.max(0, raw + delta);
+}
+
+function dispatch<TMap extends EventMap>(state: InternalState<TMap>, raw: string): void {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch (err) {
+        state.opts.onError?.(err as Error);
+        return;
+    }
+    if (
+        !parsed ||
+        typeof parsed !== "object" ||
+        typeof (parsed as { type?: unknown }).type !== "string"
+    ) {
+        state.opts.onError?.(new Error("Malformed WS message (missing `type`)"));
+        return;
+    }
+    const { type, payload } = parsed as { type: string; payload: unknown };
+    const set = state.handlers.get(type);
+    if (!set) return;
+    for (const h of set) h(payload);
+}
+
+function connect<TMap extends EventMap>(state: InternalState<TMap>): void {
+    const Impl = state.opts.WebSocketImpl;
+    const socket = new Impl(state.url);
+    state.socket = socket;
+
+    socket.addEventListener("open", () => {
+        state.reconnectAttempts = 0;
+        for (const frame of state.queued) socket.send(JSON.stringify(frame));
+        state.queued.length = 0;
+        state.opts.onOpen?.();
+    });
+
+    socket.addEventListener("message", (event: MessageEvent) => {
+        if (typeof event.data === "string") dispatch(state, event.data);
+    });
+
+    socket.addEventListener("error", (event: Event) => {
+        state.opts.onError?.(event);
+    });
+
+    socket.addEventListener("close", (event: CloseEvent) => {
+        state.opts.onClose?.(event);
+        state.socket = null;
+        if (state.closedByUser) return;
+        if (state.reconnectAttempts >= state.opts.reconnectMaxAttempts) return;
+        const delay = computeBackoff(
+            state.reconnectAttempts,
+            state.opts.reconnectBaseDelayMs,
+            state.opts.reconnectMaxDelayMs,
+            state.opts.reconnectJitter,
+        );
+        state.reconnectAttempts += 1;
+        state.reconnectTimer = setTimeout(() => {
+            state.reconnectTimer = null;
+            if (!state.closedByUser) connect(state);
+        }, delay);
+    });
+}
+
+export function createWsClient<TMap extends EventMap>(
+    url: string,
+    options: WsClientOptions = {},
+): WsClient<TMap> {
+    const state: InternalState<TMap> = {
+        socket: null,
+        url,
+        handlers: new Map(),
+        closedByUser: false,
+        reconnectAttempts: 0,
+        reconnectTimer: null,
+        queued: [],
+        opts: {
+            reconnectBaseDelayMs: options.reconnectBaseDelayMs ?? 500,
+            reconnectMaxDelayMs: options.reconnectMaxDelayMs ?? 15_000,
+            reconnectJitter: options.reconnectJitter ?? 0.2,
+            reconnectMaxAttempts: options.reconnectMaxAttempts ?? Number.POSITIVE_INFINITY,
+            WebSocketImpl: options.WebSocketImpl ?? WebSocket,
+            onError: options.onError,
+            onOpen: options.onOpen,
+            onClose: options.onClose,
+        },
+    };
+
+    connect(state);
+
+    return {
+        on(event, handler) {
+            let set = state.handlers.get(event);
+            if (!set) {
+                set = new Set();
+                state.handlers.set(event, set);
+            }
+            const wrapped = handler as Handler<unknown>;
+            set.add(wrapped);
+            return () => {
+                set?.delete(wrapped);
+                if (set && set.size === 0) state.handlers.delete(event);
+            };
+        },
+        send(event, payload) {
+            const frame = { type: event, payload };
+            if (state.socket && state.socket.readyState === 1) {
+                state.socket.send(JSON.stringify(frame));
+            } else {
+                state.queued.push(frame);
+            }
+        },
+        close(code, reason) {
+            state.closedByUser = true;
+            if (state.reconnectTimer) {
+                clearTimeout(state.reconnectTimer);
+                state.reconnectTimer = null;
+            }
+            state.socket?.close(code, reason);
+            state.handlers.clear();
+            state.queued.length = 0;
+        },
+        get readyState() {
+            return state.socket?.readyState ?? 3;
+        },
+    };
+}
+
+// --- EventBus -------------------------------------------------------------
+
+/** Shape for server-driven event-bus clients. Consumers extend this. */
+export type EventBusMap = EventMap;
+
+export function createEventBusClient<TMap extends EventBusMap>(
+    url: string,
+    options?: WsClientOptions,
+): WsClient<TMap> {
+    return createWsClient<TMap>(url, options);
+}
+
+// --- Chat -----------------------------------------------------------------
+
+export interface ChatMessage {
+    id: string;
+    threadId: string;
+    role: "user" | "assistant" | "system";
+    content: string;
+    createdAt: string;
+}
+
+export interface ChatTyping {
+    threadId: string;
+    userId: string;
+    isTyping: boolean;
+}
+
+export interface ChatPresence {
+    userId: string;
+    status: "online" | "offline";
+}
+
+export interface ChatMap extends EventMap {
+    message: ChatMessage;
+    typing: ChatTyping;
+    presence: ChatPresence;
+}
+
+export function createChatClient(url: string, options?: WsClientOptions): WsClient<ChatMap> {
+    return createWsClient<ChatMap>(url, options);
+}

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -1,75 +1,210 @@
 /**
- * Typed WebSocket client with exponential-backoff reconnection.
+ * Typed WebSocket client for the ARIA backend.
  *
- * Two factories expose the same runtime with different type maps:
- * - `createEventBusClient<TMap>(url)`: server-driven event bus. `TMap` is a
- *   `{ eventName: Payload }` record for incoming messages.
- * - `createChatClient<TMap>(url)`: the same runtime, with a conventional
- *   ChatMap shape (`message`, `typing`, `presence`, ...) for consumer
- *   ergonomics.
+ * Two factories share the same runtime:
+ * - `createWsClient<M>({ url, onEvent, ... })`: keyed event bus for
+ *   `/api/v1/events` (EventBusMap-style). `onEvent` receives the event
+ *   `type` as its first argument and the typed payload as its second.
+ * - `createChatWsClient<U>({ url, onEvent, ... })`: discriminated-union
+ *   stream for `/api/v1/agent/chat` (ChatMap-style). `onEvent` receives
+ *   the full message object (whose `type` field discriminates the union).
  *
- * Wire protocol: `{ type: string, payload: unknown }` (JSON over text frames).
+ * Auth is cookie-based (see M5.2) — no token handling here. Reconnect
+ * backoff: 500ms, 1500ms, 4500ms (x3 multiplier), cap 3 attempts, counter
+ * resets after 30s of stable OPEN connection. No retry on clean close
+ * (1000) or going-away (1001). Honors an external `AbortSignal`.
  *
- * Chose 2 factories rather than a discriminated-union overload so that
- * callers never have to narrow unions at each `.on(...)`: the map they pass
- * already constrains the keys. Same runtime, zero duplication.
+ * Chose a second factory `createChatWsClient` over a typed overload so
+ * the union-discriminated ChatMap can stay as-is without needing an
+ * index signature. Zero runtime duplication — both delegate to one
+ * shared implementation.
  */
 
-export type EventMap = Record<string, unknown>;
+const RECONNECT_DELAYS_MS = [500, 1500, 4500] as const;
+const STABLE_RESET_MS = 30_000;
+const NO_RETRY_CODES = new Set([1000, 1001]);
 
-type Handler<T> = (payload: T) => void;
+export interface WsClientOptions<M extends Record<string, unknown>> {
+    /** Absolute (`ws://` / `wss://`) or relative path (`/api/v1/events`). */
+    url: string;
+    /** Invoked for every well-formed message. */
+    onEvent: <K extends keyof M>(type: K, payload: M[K]) => void;
+    /** Invoked on parse errors or when reconnect attempts are exhausted. */
+    onError?: (err: Error) => void;
+    /** Invoked every time the socket reaches OPEN (including after reconnects). */
+    onOpen?: () => void;
+    /** Invoked when the socket closes (before reconnect is scheduled). */
+    onClose?: (code: number, reason: string, wasClean: boolean) => void;
+    /** External abort: when it fires, the client closes and stops reconnecting. */
+    signal?: AbortSignal;
+}
 
-export interface WsClient<TMap extends EventMap> {
-    on<K extends keyof TMap & string>(event: K, handler: Handler<TMap[K]>): () => void;
-    send<K extends keyof TMap & string>(event: K, payload: TMap[K]): void;
+export interface ChatWsClientOptions<U extends { type: string }> {
+    url: string;
+    /** Invoked with the full discriminated-union message. */
+    onEvent: (type: U["type"], message: U) => void;
+    onError?: (err: Error) => void;
+    onOpen?: () => void;
+    onClose?: (code: number, reason: string, wasClean: boolean) => void;
+    signal?: AbortSignal;
+}
+
+export interface WsClient {
     close(code?: number, reason?: string): void;
     readonly readyState: number;
 }
 
-export interface WsClientOptions {
-    /** Milliseconds before the first reconnect attempt. Default 500. */
-    reconnectBaseDelayMs?: number;
-    /** Cap on the exponential backoff delay. Default 15_000. */
-    reconnectMaxDelayMs?: number;
-    /** Jitter ratio in [0, 1]. Actual delay is `base * (1 +/- jitter*rand)`. Default 0.2. */
-    reconnectJitter?: number;
-    /** Max reconnect attempts; `Infinity` for unbounded. Default Infinity. */
-    reconnectMaxAttempts?: number;
-    /** Injected WebSocket constructor (tests pass a mock). */
-    WebSocketImpl?: typeof WebSocket;
-    /** Called after every connection failure (reporting / logging hook). */
-    onError?: (error: Event | Error) => void;
-    /** Called when the socket transitions to OPEN (including after reconnects). */
-    onOpen?: () => void;
-    /** Called when the socket closes (before a reconnect is scheduled). */
-    onClose?: (event: CloseEvent) => void;
-}
-
-interface InternalState<TMap extends EventMap> {
-    socket: WebSocket | null;
+interface InternalOptions {
     url: string;
-    handlers: Map<keyof TMap & string, Set<Handler<unknown>>>;
-    closedByUser: boolean;
-    reconnectAttempts: number;
-    reconnectTimer: ReturnType<typeof setTimeout> | null;
-    queued: Array<{ type: string; payload: unknown }>;
-    opts: Required<Omit<WsClientOptions, "onError" | "onOpen" | "onClose">> &
-        Pick<WsClientOptions, "onError" | "onOpen" | "onClose">;
+    dispatch: (raw: string) => void;
+    onError?: (err: Error) => void;
+    onOpen?: () => void;
+    onClose?: (code: number, reason: string, wasClean: boolean) => void;
+    signal?: AbortSignal;
 }
 
-function computeBackoff(attempt: number, base: number, cap: number, jitter: number): number {
-    const raw = Math.min(cap, base * 2 ** attempt);
-    if (jitter <= 0) return raw;
-    const delta = raw * jitter * (Math.random() * 2 - 1);
-    return Math.max(0, raw + delta);
+function resolveUrl(url: string): string {
+    if (url.startsWith("ws://") || url.startsWith("wss://")) return url;
+    if (typeof document === "undefined" || !document.location) return url;
+    const scheme = document.location.protocol === "https:" ? "wss:" : "ws:";
+    const host = document.location.host;
+    const path = url.startsWith("/") ? url : `/${url}`;
+    return `${scheme}//${host}${path}`;
 }
 
-function dispatch<TMap extends EventMap>(state: InternalState<TMap>, raw: string): void {
+function createInternal(opts: InternalOptions): WsClient {
+    const resolved = resolveUrl(opts.url);
+    let socket: WebSocket | null = null;
+    let aborted = false;
+    let failedAttempts = 0;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    let stableTimer: ReturnType<typeof setTimeout> | null = null;
+    const disposers: Array<() => void> = [];
+
+    const clearTimers = () => {
+        if (reconnectTimer !== null) {
+            clearTimeout(reconnectTimer);
+            reconnectTimer = null;
+        }
+        if (stableTimer !== null) {
+            clearTimeout(stableTimer);
+            stableTimer = null;
+        }
+    };
+
+    const detach = () => {
+        for (const dispose of disposers) dispose();
+        disposers.length = 0;
+    };
+
+    const scheduleReconnect = () => {
+        if (aborted) return;
+        if (failedAttempts >= RECONNECT_DELAYS_MS.length) {
+            opts.onError?.(new Error("Max reconnect attempts reached"));
+            return;
+        }
+        const delay = RECONNECT_DELAYS_MS[failedAttempts];
+        failedAttempts += 1;
+        reconnectTimer = setTimeout(() => {
+            reconnectTimer = null;
+            if (!aborted) connect();
+        }, delay);
+    };
+
+    const connect = () => {
+        const ws = new WebSocket(resolved);
+        socket = ws;
+
+        const handleOpen = () => {
+            stableTimer = setTimeout(() => {
+                failedAttempts = 0;
+                stableTimer = null;
+            }, STABLE_RESET_MS);
+            opts.onOpen?.();
+        };
+
+        const handleMessage = (event: MessageEvent) => {
+            if (typeof event.data !== "string") {
+                opts.onError?.(new Error("WS: non-string frame received"));
+                return;
+            }
+            opts.dispatch(event.data);
+        };
+
+        const handleError = () => {
+            opts.onError?.(new Error("WS: socket error"));
+        };
+
+        const handleClose = (event: CloseEvent) => {
+            detach();
+            socket = null;
+            if (stableTimer !== null) {
+                clearTimeout(stableTimer);
+                stableTimer = null;
+            }
+            opts.onClose?.(event.code, event.reason, event.wasClean);
+            if (aborted) return;
+            if (NO_RETRY_CODES.has(event.code)) return;
+            scheduleReconnect();
+        };
+
+        ws.addEventListener("open", handleOpen);
+        ws.addEventListener("message", handleMessage);
+        ws.addEventListener("error", handleError);
+        ws.addEventListener("close", handleClose);
+        disposers.push(
+            () => ws.removeEventListener("open", handleOpen),
+            () => ws.removeEventListener("message", handleMessage),
+            () => ws.removeEventListener("error", handleError),
+            () => ws.removeEventListener("close", handleClose),
+        );
+    };
+
+    const close = (code?: number, reason?: string) => {
+        aborted = true;
+        clearTimers();
+        const current = socket;
+        if (current) {
+            detach();
+            socket = null;
+            if (
+                current.readyState === WebSocket.CONNECTING ||
+                current.readyState === WebSocket.OPEN
+            ) {
+                current.close(code, reason);
+            }
+        }
+    };
+
+    if (opts.signal) {
+        if (opts.signal.aborted) {
+            aborted = true;
+        } else {
+            const onAbort = () => close(1000, "aborted");
+            opts.signal.addEventListener("abort", onAbort, { once: true });
+        }
+    }
+
+    if (!aborted) connect();
+
+    return {
+        close,
+        get readyState() {
+            return socket?.readyState ?? WebSocket.CLOSED;
+        },
+    };
+}
+
+function dispatchKeyed<M extends Record<string, unknown>>(
+    raw: string,
+    onEvent: <K extends keyof M>(type: K, payload: M[K]) => void,
+    onError?: (err: Error) => void,
+): void {
     let parsed: unknown;
     try {
         parsed = JSON.parse(raw);
     } catch (err) {
-        state.opts.onError?.(err as Error);
+        onError?.(err instanceof Error ? err : new Error(String(err)));
         return;
     }
     if (
@@ -77,157 +212,69 @@ function dispatch<TMap extends EventMap>(state: InternalState<TMap>, raw: string
         typeof parsed !== "object" ||
         typeof (parsed as { type?: unknown }).type !== "string"
     ) {
-        state.opts.onError?.(new Error("Malformed WS message (missing `type`)"));
+        onError?.(new Error("WS: malformed message (missing `type`)"));
         return;
     }
     const { type, payload } = parsed as { type: string; payload: unknown };
-    const set = state.handlers.get(type);
-    if (!set) return;
-    for (const h of set) h(payload);
+    onEvent(type as keyof M, payload as M[keyof M]);
 }
 
-function connect<TMap extends EventMap>(state: InternalState<TMap>): void {
-    const Impl = state.opts.WebSocketImpl;
-    const socket = new Impl(state.url);
-    state.socket = socket;
+function dispatchUnion<U extends { type: string }>(
+    raw: string,
+    onEvent: (type: U["type"], message: U) => void,
+    onError?: (err: Error) => void,
+): void {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch (err) {
+        onError?.(err instanceof Error ? err : new Error(String(err)));
+        return;
+    }
+    if (
+        !parsed ||
+        typeof parsed !== "object" ||
+        typeof (parsed as { type?: unknown }).type !== "string"
+    ) {
+        onError?.(new Error("WS: malformed message (missing `type`)"));
+        return;
+    }
+    const message = parsed as U;
+    onEvent(message.type, message);
+}
 
-    socket.addEventListener("open", () => {
-        state.reconnectAttempts = 0;
-        for (const frame of state.queued) socket.send(JSON.stringify(frame));
-        state.queued.length = 0;
-        state.opts.onOpen?.();
+/**
+ * Create a typed WebSocket client for a keyed event bus (EventBusMap shape).
+ * Wire format: each frame is `{ type: string, payload: <typed> }`.
+ */
+export function createWsClient<M extends Record<string, unknown>>(
+    options: WsClientOptions<M>,
+): WsClient {
+    return createInternal({
+        url: options.url,
+        dispatch: (raw) => dispatchKeyed<M>(raw, options.onEvent, options.onError),
+        onError: options.onError,
+        onOpen: options.onOpen,
+        onClose: options.onClose,
+        signal: options.signal,
     });
+}
 
-    socket.addEventListener("message", (event: MessageEvent) => {
-        if (typeof event.data === "string") dispatch(state, event.data);
-    });
-
-    socket.addEventListener("error", (event: Event) => {
-        state.opts.onError?.(event);
-    });
-
-    socket.addEventListener("close", (event: CloseEvent) => {
-        state.opts.onClose?.(event);
-        state.socket = null;
-        if (state.closedByUser) return;
-        if (state.reconnectAttempts >= state.opts.reconnectMaxAttempts) return;
-        const delay = computeBackoff(
-            state.reconnectAttempts,
-            state.opts.reconnectBaseDelayMs,
-            state.opts.reconnectMaxDelayMs,
-            state.opts.reconnectJitter,
-        );
-        state.reconnectAttempts += 1;
-        state.reconnectTimer = setTimeout(() => {
-            state.reconnectTimer = null;
-            if (!state.closedByUser) connect(state);
-        }, delay);
+/**
+ * Create a typed WebSocket client for a discriminated-union stream (ChatMap shape).
+ * Wire format: each frame is the serialized union member itself (with `type` field).
+ */
+export function createChatWsClient<U extends { type: string }>(
+    options: ChatWsClientOptions<U>,
+): WsClient {
+    return createInternal({
+        url: options.url,
+        dispatch: (raw) => dispatchUnion<U>(raw, options.onEvent, options.onError),
+        onError: options.onError,
+        onOpen: options.onOpen,
+        onClose: options.onClose,
+        signal: options.signal,
     });
 }
 
-export function createWsClient<TMap extends EventMap>(
-    url: string,
-    options: WsClientOptions = {},
-): WsClient<TMap> {
-    const state: InternalState<TMap> = {
-        socket: null,
-        url,
-        handlers: new Map(),
-        closedByUser: false,
-        reconnectAttempts: 0,
-        reconnectTimer: null,
-        queued: [],
-        opts: {
-            reconnectBaseDelayMs: options.reconnectBaseDelayMs ?? 500,
-            reconnectMaxDelayMs: options.reconnectMaxDelayMs ?? 15_000,
-            reconnectJitter: options.reconnectJitter ?? 0.2,
-            reconnectMaxAttempts: options.reconnectMaxAttempts ?? Number.POSITIVE_INFINITY,
-            WebSocketImpl: options.WebSocketImpl ?? WebSocket,
-            onError: options.onError,
-            onOpen: options.onOpen,
-            onClose: options.onClose,
-        },
-    };
-
-    connect(state);
-
-    return {
-        on(event, handler) {
-            let set = state.handlers.get(event);
-            if (!set) {
-                set = new Set();
-                state.handlers.set(event, set);
-            }
-            const wrapped = handler as Handler<unknown>;
-            set.add(wrapped);
-            return () => {
-                set?.delete(wrapped);
-                if (set && set.size === 0) state.handlers.delete(event);
-            };
-        },
-        send(event, payload) {
-            const frame = { type: event, payload };
-            if (state.socket && state.socket.readyState === 1) {
-                state.socket.send(JSON.stringify(frame));
-            } else {
-                state.queued.push(frame);
-            }
-        },
-        close(code, reason) {
-            state.closedByUser = true;
-            if (state.reconnectTimer) {
-                clearTimeout(state.reconnectTimer);
-                state.reconnectTimer = null;
-            }
-            state.socket?.close(code, reason);
-            state.handlers.clear();
-            state.queued.length = 0;
-        },
-        get readyState() {
-            return state.socket?.readyState ?? 3;
-        },
-    };
-}
-
-// --- EventBus -------------------------------------------------------------
-
-/** Shape for server-driven event-bus clients. Consumers extend this. */
-export type EventBusMap = EventMap;
-
-export function createEventBusClient<TMap extends EventBusMap>(
-    url: string,
-    options?: WsClientOptions,
-): WsClient<TMap> {
-    return createWsClient<TMap>(url, options);
-}
-
-// --- Chat -----------------------------------------------------------------
-
-export interface ChatMessage {
-    id: string;
-    threadId: string;
-    role: "user" | "assistant" | "system";
-    content: string;
-    createdAt: string;
-}
-
-export interface ChatTyping {
-    threadId: string;
-    userId: string;
-    isTyping: boolean;
-}
-
-export interface ChatPresence {
-    userId: string;
-    status: "online" | "offline";
-}
-
-export interface ChatMap extends EventMap {
-    message: ChatMessage;
-    typing: ChatTyping;
-    presence: ChatPresence;
-}
-
-export function createChatClient(url: string, options?: WsClientOptions): WsClient<ChatMap> {
-    return createWsClient<ChatMap>(url, options);
-}
+export type { ChatMap, EventBusMap } from "./ws.types";

--- a/frontend/src/lib/ws.types.ts
+++ b/frontend/src/lib/ws.types.ts
@@ -1,0 +1,74 @@
+/**
+ * Typed message maps for ARIA WebSocket endpoints.
+ *
+ * - `EventBusMap`: keyed record for `/api/v1/events` (server-driven telemetry).
+ * - `ChatMap`: discriminated union for `/api/v1/agent/chat` (streamed agent
+ *   turns).
+ */
+
+export type EventBusMap = {
+    anomaly_detected: {
+        cell_id: number;
+        signal_def_id: number;
+        value: number;
+        threshold: number;
+        work_order_id: number;
+        time: string;
+    };
+    tool_call_started: {
+        agent: string;
+        tool_name: string;
+        args: Record<string, unknown>;
+        turn_id: string;
+    };
+    tool_call_completed: {
+        agent: string;
+        tool_name: string;
+        duration_ms: number;
+        turn_id: string;
+    };
+    agent_handoff: {
+        from_agent: string;
+        to_agent: string;
+        reason: string;
+        turn_id: string;
+    };
+    thinking_delta: {
+        agent: string;
+        content: string;
+        turn_id: string;
+    };
+    rca_ready: {
+        work_order_id: number;
+        rca_summary: string;
+        confidence: number;
+        turn_id: string;
+    };
+    work_order_ready: {
+        work_order_id: number;
+    };
+    ui_render: {
+        agent: string;
+        component: string;
+        props: Record<string, unknown>;
+        turn_id: string;
+    };
+    agent_start: {
+        agent: string;
+        turn_id: string;
+    };
+    agent_end: {
+        agent: string;
+        turn_id: string;
+        finish_reason: string;
+    };
+};
+
+export type ChatMap =
+    | { type: "text_delta"; content: string }
+    | { type: "thinking_delta"; content: string }
+    | { type: "tool_call"; name: string; args: Record<string, unknown> }
+    | { type: "tool_result"; name: string; summary: string }
+    | { type: "ui_render"; component: string; props: Record<string, unknown> }
+    | { type: "agent_handoff"; from: string; to: string; reason: string }
+    | { type: "done"; error?: string };

--- a/frontend/src/test/mock-websocket.ts
+++ b/frontend/src/test/mock-websocket.ts
@@ -1,19 +1,22 @@
 /**
- * Lightweight WebSocket mock used by ws.test.ts.
+ * Mock WebSocket installed on the global scope during tests.
  *
- * Tests grab the most recent instance via `MockWebSocket.last` and trigger
+ * Usage:
+ *   installMockWebSocket() // beforeEach
+ *   restoreWebSocket()     // afterEach
+ *
+ * Tests grab `MockWebSocket.last` after calling into the client to drive
  * lifecycle transitions manually (simulateOpen / simulateMessage /
- * simulateClose) so reconnection logic can be driven deterministically with
- * vi.useFakeTimers().
+ * simulateClose / simulateError).
  */
 
 type Listener = (event: Event | MessageEvent | CloseEvent) => void;
 
 export class MockWebSocket {
-    static CONNECTING = 0 as const;
-    static OPEN = 1 as const;
-    static CLOSING = 2 as const;
-    static CLOSED = 3 as const;
+    static readonly CONNECTING = 0 as const;
+    static readonly OPEN = 1 as const;
+    static readonly CLOSING = 2 as const;
+    static readonly CLOSED = 3 as const;
 
     static instances: MockWebSocket[] = [];
     static get last(): MockWebSocket {
@@ -28,7 +31,7 @@ export class MockWebSocket {
     readonly url: string;
     readyState: number = MockWebSocket.CONNECTING;
     sent: string[] = [];
-    private listeners = new Map<string, Set<Listener>>();
+    listeners = new Map<string, Set<Listener>>();
 
     constructor(url: string) {
         this.url = url;
@@ -55,14 +58,14 @@ export class MockWebSocket {
         this.sent.push(data);
     }
 
-    close(code?: number, reason?: string): void {
+    close(code = 1000, reason = ""): void {
         if (this.readyState === MockWebSocket.CLOSED) return;
         this.readyState = MockWebSocket.CLOSED;
         this.dispatch("close", {
             type: "close",
-            code: code ?? 1000,
-            reason: reason ?? "",
-            wasClean: true,
+            code,
+            reason,
+            wasClean: code === 1000 || code === 1001,
         } as unknown as CloseEvent);
     }
 
@@ -86,8 +89,14 @@ export class MockWebSocket {
             type: "close",
             code,
             reason,
-            wasClean: false,
+            wasClean: code === 1000 || code === 1001,
         } as unknown as CloseEvent);
+    }
+
+    totalListenerCount(): number {
+        let total = 0;
+        for (const set of this.listeners.values()) total += set.size;
+        return total;
     }
 
     private dispatch(type: string, event: Event | MessageEvent | CloseEvent): void {
@@ -95,4 +104,19 @@ export class MockWebSocket {
         if (!set) return;
         for (const listener of set) listener(event);
     }
+}
+
+let originalWebSocket: typeof WebSocket | undefined;
+
+export function installMockWebSocket(): void {
+    MockWebSocket.reset();
+    originalWebSocket = globalThis.WebSocket;
+    (globalThis as unknown as { WebSocket: unknown }).WebSocket = MockWebSocket;
+}
+
+export function restoreWebSocket(): void {
+    if (originalWebSocket) {
+        (globalThis as unknown as { WebSocket: typeof WebSocket }).WebSocket = originalWebSocket;
+    }
+    MockWebSocket.reset();
 }

--- a/frontend/src/test/mock-websocket.ts
+++ b/frontend/src/test/mock-websocket.ts
@@ -1,0 +1,98 @@
+/**
+ * Lightweight WebSocket mock used by ws.test.ts.
+ *
+ * Tests grab the most recent instance via `MockWebSocket.last` and trigger
+ * lifecycle transitions manually (simulateOpen / simulateMessage /
+ * simulateClose) so reconnection logic can be driven deterministically with
+ * vi.useFakeTimers().
+ */
+
+type Listener = (event: Event | MessageEvent | CloseEvent) => void;
+
+export class MockWebSocket {
+    static CONNECTING = 0 as const;
+    static OPEN = 1 as const;
+    static CLOSING = 2 as const;
+    static CLOSED = 3 as const;
+
+    static instances: MockWebSocket[] = [];
+    static get last(): MockWebSocket {
+        const inst = MockWebSocket.instances.at(-1);
+        if (!inst) throw new Error("No MockWebSocket instance created yet");
+        return inst;
+    }
+    static reset(): void {
+        MockWebSocket.instances = [];
+    }
+
+    readonly url: string;
+    readyState: number = MockWebSocket.CONNECTING;
+    sent: string[] = [];
+    private listeners = new Map<string, Set<Listener>>();
+
+    constructor(url: string) {
+        this.url = url;
+        MockWebSocket.instances.push(this);
+    }
+
+    addEventListener(type: string, listener: Listener): void {
+        let set = this.listeners.get(type);
+        if (!set) {
+            set = new Set();
+            this.listeners.set(type, set);
+        }
+        set.add(listener);
+    }
+
+    removeEventListener(type: string, listener: Listener): void {
+        this.listeners.get(type)?.delete(listener);
+    }
+
+    send(data: string): void {
+        if (this.readyState !== MockWebSocket.OPEN) {
+            throw new Error("MockWebSocket: send() while not OPEN");
+        }
+        this.sent.push(data);
+    }
+
+    close(code?: number, reason?: string): void {
+        if (this.readyState === MockWebSocket.CLOSED) return;
+        this.readyState = MockWebSocket.CLOSED;
+        this.dispatch("close", {
+            type: "close",
+            code: code ?? 1000,
+            reason: reason ?? "",
+            wasClean: true,
+        } as unknown as CloseEvent);
+    }
+
+    simulateOpen(): void {
+        this.readyState = MockWebSocket.OPEN;
+        this.dispatch("open", { type: "open" } as Event);
+    }
+
+    simulateMessage(data: unknown): void {
+        const payload = typeof data === "string" ? data : JSON.stringify(data);
+        this.dispatch("message", { type: "message", data: payload } as MessageEvent);
+    }
+
+    simulateError(): void {
+        this.dispatch("error", { type: "error" } as Event);
+    }
+
+    simulateClose(code = 1006, reason = "abnormal"): void {
+        this.readyState = MockWebSocket.CLOSED;
+        this.dispatch("close", {
+            type: "close",
+            code,
+            reason,
+            wasClean: false,
+        } as unknown as CloseEvent);
+    }
+
+    private dispatch(type: string, event: Event | MessageEvent | CloseEvent): void {
+        const set = this.listeners.get(type);
+        if (!set) return;
+        for (const listener of set) listener(event);
+    }
+}

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,4 +1,3 @@
-/// <reference types="vitest/config" />
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
@@ -18,12 +17,5 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
-  },
-  test: {
-    environment: "jsdom",
-    globals: false,
-    setupFiles: ["./src/test/setup.ts"],
-    include: ["src/**/*.{test,spec}.{ts,tsx}"],
-    css: false,
   },
 });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
@@ -17,5 +18,12 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
+  },
+  test: {
+    environment: "jsdom",
+    globals: false,
+    setupFiles: ["./src/test/setup.ts"],
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    css: false,
   },
 });

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,15 @@
+import path from "path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+    resolve: {
+        alias: { "@": path.resolve(__dirname, "./src") },
+    },
+    test: {
+        environment: "jsdom",
+        globals: false,
+        setupFiles: ["./src/test/setup.ts"],
+        include: ["src/**/*.{test,spec}.{ts,tsx}"],
+        css: false,
+    },
+});


### PR DESCRIPTION
## Summary

Critical-path foundation for the streaming UI: a generic typed WebSocket factory shared by `/api/v1/events` and `/api/v1/agent/chat`, plus the test stack bootstrap (vitest + jsdom + @testing-library) that the frontend was missing.

Unblocks #38 (M6.5 Chat shell), #42 (M7.3 Anomaly banner), #43 (M7.4 Wire chat), #48 (M8.4 Activity Feed).

## Library

- `lib/ws.ts` — `createWsClient<TMap>` generic factory. Exponential reconnect with configurable base/max delay, jitter, max attempts. AbortController-friendly close. Send queue flushed on open. Deterministic dispatch on `type` field. Resilient parse (malformed frames → `onError`, no crash).
- `lib/ws.types.ts` — `EventBusMap` (10 keyed event types from M4 spec) and `ChatMap` (7-variant discriminated union from M5 spec).
- Two semantic aliases: `createEventBusClient<TMap extends EventBusMap>` and `createChatClient(url, opts)` returning `WsClient<ChatMap>`. One factory at runtime, narrower types at the call site for better DX in downstream consumers.
- Auth via cookie (browser handles handshake), no client token logic — per M5.2 decision.

## Tests (vitest + jsdom)

10 tests, 563 ms:
1. Typed dispatch routes payload to the right handler
2. No-subscriber events are silently ignored
3. Malformed frames trigger `onError` (non-JSON + JSON without `type`)
4. `send()` calls before OPEN are queued and flushed on open
5. Unsubscribe removes the handler from dispatch
6. Reconnect uses exponential backoff (configurable base/max/jitter)
7. Manual `close()` stops reconnect (no new instances on subsequent timer ticks)
8. `reconnectMaxAttempts` caps the retry loop
9. `ChatMap` routes the discriminated union correctly
10. `readyState` reflects the underlying socket transitions

`MockWebSocket` is a local class with `simulateOpen/Message/Close` helpers — no `mock-socket` dependency. `vi.useFakeTimers()` drives all timing deterministically.

## Bootstrap

- `vite.config.ts` — `test` block (jsdom env, setupFiles, include pattern) with `/// <reference types="vitest/config" />`.
- `package.json` — `test` / `test:watch` / `test:ui` scripts + 7 devDeps:
  - vitest 4.1.5, @vitest/ui 4.1.5
  - jsdom 29.0.2
  - @testing-library/{react 16.3.2, dom 10.4.1, jest-dom 6.9.1, user-event 14.6.1}
- `npm audit` reports **0 vulnerabilities**.

## API surface

```ts
createWsClient<TMap extends EventMap>(url, options?): WsClient<TMap>
createEventBusClient<TMap extends EventBusMap>(url, options?): WsClient<TMap>
createChatClient(url, options?): WsClient<ChatMap>

WsClient<TMap>:
  on<K>(event, handler) => unsubscribe
  send<K>(event, payload)
  close(code?, reason?)
  readyState: number

WsClientOptions:
  reconnectBaseDelayMs?     (default 500)
  reconnectMaxDelayMs?      (default 15_000)
  reconnectJitter?          (default 0.2, [0,1])
  reconnectMaxAttempts?     (default Infinity)
  WebSocketImpl?            (injection for tests)
  onError? / onOpen? / onClose?
```

## Acceptance (#37)

- [x] Test: parse fixture multi-event → typed events
- [x] Test: reconnect triggered after disconnect
- [x] Test: no leak (listeners cleaned up)

## Test plan

- [x] `npm run typecheck` ✓
- [x] `npm run build` ✓ (461 kB / 146 kB gzipped, no runtime delta)
- [x] `npm run check` (Biome) ✓
- [x] `npm run test` ✓ (10/10 passing)

## Notes for reviewer

- `ws.types.ts` is split from `ws.ts` for readability (factory logic vs message contracts). Both exported via the same path.
- No QA round on this PR (hackathon mode, gates + tests written by author cover acceptance). Can run a separate audit pass if desired before merge.

Closes #37