### PR TITLE
refactor(frontend): align LoginPage and DataPage on DA v2 (#72 #73 #74)

### DIFF
--- a/frontend/src/pages/DataPage.tsx
+++ b/frontend/src/pages/DataPage.tsx
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
+import { AriaMark, Badge, Card, Icons, SectionHeader, ThemeToggle } from "../design-system";
 import { apiFetch } from "../lib/api";
 import { getUser, logout } from "../lib/auth";
 
@@ -65,35 +66,28 @@ interface TreeNode {
 const NOW = () => new Date().toISOString();
 const MINUTES_AGO = (m: number) => new Date(Date.now() - m * 60_000).toISOString();
 
-function Section({ title, children }: { title: string; children: React.ReactNode }) {
-    return (
-        <section className="bg-white rounded-lg shadow p-4 space-y-3">
-            <h2 className="text-sm font-semibold text-slate-700 uppercase tracking-wide">
-                {title}
-            </h2>
-            {children}
-        </section>
-    );
-}
-
 function Pre({ value }: { value: unknown }) {
     return (
-        <pre className="text-xs bg-slate-50 border border-slate-200 rounded p-2 overflow-auto max-h-64">
+        <pre className="max-h-64 overflow-auto rounded-[var(--ds-radius-sm)] border border-[var(--ds-border)] bg-[var(--ds-bg-elevated)] p-2 font-mono text-[var(--ds-text-xs)] text-[var(--ds-fg-primary)]">
             {JSON.stringify(value, null, 2)}
         </pre>
     );
 }
 
-function StatusBadge({ ok, label }: { ok: boolean; label: string }) {
+function Loading() {
+    return <p className="text-[var(--ds-text-sm)] text-[var(--ds-fg-muted)]">Loading…</p>;
+}
+
+function ErrorLine({ error }: { error: unknown }) {
     return (
-        <span
-            className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${
-                ok ? "bg-green-100 text-green-800" : "bg-slate-200 text-slate-700"
-            }`}
-        >
-            {label}
-        </span>
+        <p className="text-[var(--ds-text-sm)] text-[var(--ds-status-critical)]">
+            {error instanceof Error ? error.message : "Request failed."}
+        </p>
     );
+}
+
+function Empty({ label }: { label: string }) {
+    return <p className="text-[var(--ds-text-sm)] text-[var(--ds-fg-muted)]">{label}</p>;
 }
 
 export default function DataPage() {
@@ -159,184 +153,263 @@ export default function DataPage() {
     }
 
     return (
-        <div className="min-h-full bg-slate-100">
-            <header className="bg-slate-900 text-white px-6 py-3 flex items-center justify-between">
-                <div>
-                    <h1 className="text-lg font-bold">ARIA — Data Explorer</h1>
-                    <p className="text-xs text-slate-400">Last 60 min window · auto-refresh 5s</p>
-                </div>
-                <div className="flex items-center gap-3 text-sm">
-                    <span className="text-slate-300">
-                        {user?.username} <span className="text-slate-500">({user?.role})</span>
+        <div className="min-h-full bg-[var(--ds-bg-base)]">
+            <header className="sticky top-0 z-20 flex h-14 items-center gap-4 border-b border-[var(--ds-border)] bg-[var(--ds-bg-base)] px-6">
+                <div className="flex items-center gap-2.5">
+                    <AriaMark size={20} />
+                    <span className="text-[var(--ds-text-md)] font-semibold tracking-[-0.01em] text-[var(--ds-fg-primary)]">
+                        ARIA
                     </span>
+                </div>
+                <span className="h-5 w-px flex-none bg-[var(--ds-border)]" aria-hidden />
+                <span className="text-[var(--ds-text-sm)] text-[var(--ds-fg-muted)]">
+                    Data explorer
+                </span>
+
+                <div className="ml-auto flex items-center gap-3 text-[var(--ds-text-sm)]">
+                    {user && (
+                        <span className="hidden items-baseline gap-1.5 sm:inline-flex">
+                            <span className="font-medium text-[var(--ds-fg-primary)]">
+                                {user.username}
+                            </span>
+                            <span className="text-[var(--ds-fg-subtle)]">·</span>
+                            <span className="text-[var(--ds-fg-muted)]">{user.role}</span>
+                        </span>
+                    )}
+                    <ThemeToggle />
                     <button
                         type="button"
                         onClick={handleLogout}
-                        className="rounded bg-slate-700 hover:bg-slate-600 px-3 py-1 text-xs"
+                        className="inline-flex h-8 items-center gap-1.5 rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-surface)] px-2.5 text-[var(--ds-text-sm)] font-medium text-[var(--ds-fg-muted)] transition-colors duration-[var(--ds-motion-fast)] hover:border-[var(--ds-border-strong)] hover:bg-[var(--ds-bg-hover)] hover:text-[var(--ds-fg-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)]"
                     >
+                        <Icons.LogOut className="size-3.5" />
                         Logout
                     </button>
                 </div>
             </header>
 
-            <main className="p-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
-                <Section title="Current cell status">
-                    {status.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
-                    {status.error && (
-                        <p className="text-sm text-red-600">{(status.error as Error).message}</p>
-                    )}
-                    {status.data && (
-                        <table className="w-full text-sm">
-                            <thead className="text-left text-xs text-slate-500 uppercase">
-                                <tr>
-                                    <th className="py-1 pr-2">Cell</th>
-                                    <th className="py-1 pr-2">Line</th>
-                                    <th className="py-1 pr-2">Status</th>
-                                    <th className="py-1">Since</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {status.data.map((c) => (
-                                    <tr key={c.cell_id} className="border-t border-slate-100">
-                                        <td className="py-1.5 pr-2 font-medium">{c.cell_name}</td>
-                                        <td className="py-1.5 pr-2 text-slate-500">
-                                            {c.line_name ?? "—"}
-                                        </td>
-                                        <td className="py-1.5 pr-2">
-                                            <StatusBadge
-                                                ok={!!c.is_productive}
-                                                label={c.status_name ?? "?"}
-                                            />
-                                        </td>
-                                        <td className="py-1.5 text-xs text-slate-500">
-                                            {c.last_status_change
-                                                ? new Date(
-                                                      c.last_status_change,
-                                                  ).toLocaleTimeString()
-                                                : "—"}
-                                        </td>
-                                    </tr>
-                                ))}
-                            </tbody>
-                        </table>
-                    )}
-                </Section>
+            <main className="px-6 pt-8 pb-10">
+                <SectionHeader
+                    label="Data explorer"
+                    size="lg"
+                    meta={<span>Last 60 min · auto-refresh 5s</span>}
+                />
 
-                <Section title="Current process signals">
-                    {signals.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
-                    {signals.data && (
-                        <table className="w-full text-sm">
-                            <thead className="text-left text-xs text-slate-500 uppercase">
-                                <tr>
-                                    <th className="py-1 pr-2">Signal</th>
-                                    <th className="py-1 pr-2 text-right">Value</th>
-                                    <th className="py-1 pr-2">Unit</th>
-                                    <th className="py-1">At</th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                {signals.data.map((s) => (
-                                    <tr key={s.signal_def_id} className="border-t border-slate-100">
-                                        <td className="py-1.5 pr-2">
-                                            {s.display_name ?? s.signal_name}
-                                        </td>
-                                        <td className="py-1.5 pr-2 text-right font-mono">
-                                            {s.raw_value.toFixed(2)}
-                                        </td>
-                                        <td className="py-1.5 pr-2 text-slate-500">
-                                            {s.unit_name ?? "—"}
-                                        </td>
-                                        <td className="py-1.5 text-xs text-slate-500">
-                                            {new Date(s.time).toLocaleTimeString()}
-                                        </td>
+                <div className="mt-6 grid grid-cols-1 gap-5 lg:grid-cols-2">
+                    <Card>
+                        <SectionHeader label="Current cell status" size="sm" className="mb-3" />
+                        {status.isLoading && <Loading />}
+                        {status.error && <ErrorLine error={status.error} />}
+                        {status.data && (
+                            <table className="w-full text-[var(--ds-text-sm)]">
+                                <thead>
+                                    <tr className="text-left text-[var(--ds-text-xs)] font-medium text-[var(--ds-fg-muted)]">
+                                        <th className="py-1 pr-2">Cell</th>
+                                        <th className="py-1 pr-2">Line</th>
+                                        <th className="py-1 pr-2">Status</th>
+                                        <th className="py-1">Since</th>
                                     </tr>
-                                ))}
-                            </tbody>
-                        </table>
-                    )}
-                </Section>
+                                </thead>
+                                <tbody>
+                                    {status.data.map((c) => (
+                                        <tr
+                                            key={c.cell_id}
+                                            className="border-t border-[var(--ds-border)]"
+                                        >
+                                            <td className="py-1.5 pr-2 font-medium text-[var(--ds-fg-primary)]">
+                                                {c.cell_name}
+                                            </td>
+                                            <td className="py-1.5 pr-2 text-[var(--ds-fg-muted)]">
+                                                {c.line_name ?? "—"}
+                                            </td>
+                                            <td className="py-1.5 pr-2">
+                                                <Badge
+                                                    variant={
+                                                        c.is_productive ? "nominal" : "default"
+                                                    }
+                                                >
+                                                    {c.status_name ?? "?"}
+                                                </Badge>
+                                            </td>
+                                            <td className="py-1.5 text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+                                                {c.last_status_change
+                                                    ? new Date(
+                                                          c.last_status_change,
+                                                      ).toLocaleTimeString()
+                                                    : "—"}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        )}
+                    </Card>
 
-                <Section title="OEE (last 60 min)">
-                    {oee.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
-                    {oee.data && oee.data.length === 0 && (
-                        <p className="text-sm text-slate-500">No data.</p>
-                    )}
-                    {oee.data && oee.data.length > 0 && (
-                        <div className="grid grid-cols-4 gap-3 text-center">
-                            {(["oee", "availability", "performance", "quality"] as const).map(
-                                (k) => (
-                                    <div key={k} className="bg-slate-50 rounded p-3">
-                                        <div className="text-xs text-slate-500 uppercase">{k}</div>
-                                        <div className="text-2xl font-bold text-slate-900">
-                                            {(Number(oee.data[0][k] ?? 0) * 100).toFixed(1)}%
+                    <Card>
+                        <SectionHeader label="Current process signals" size="sm" className="mb-3" />
+                        {signals.isLoading && <Loading />}
+                        {signals.error && <ErrorLine error={signals.error} />}
+                        {signals.data && (
+                            <table className="w-full text-[var(--ds-text-sm)]">
+                                <thead>
+                                    <tr className="text-left text-[var(--ds-text-xs)] font-medium text-[var(--ds-fg-muted)]">
+                                        <th className="py-1 pr-2">Signal</th>
+                                        <th className="py-1 pr-2 text-right">Value</th>
+                                        <th className="py-1 pr-2">Unit</th>
+                                        <th className="py-1">At</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    {signals.data.map((s) => (
+                                        <tr
+                                            key={s.signal_def_id}
+                                            className="border-t border-[var(--ds-border)]"
+                                        >
+                                            <td className="py-1.5 pr-2 text-[var(--ds-fg-primary)]">
+                                                {s.display_name ?? s.signal_name}
+                                            </td>
+                                            <td className="py-1.5 pr-2 text-right font-mono tabular-nums text-[var(--ds-fg-primary)]">
+                                                {s.raw_value.toFixed(2)}
+                                            </td>
+                                            <td className="py-1.5 pr-2 text-[var(--ds-fg-muted)]">
+                                                {s.unit_name ?? "—"}
+                                            </td>
+                                            <td className="py-1.5 text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+                                                {new Date(s.time).toLocaleTimeString()}
+                                            </td>
+                                        </tr>
+                                    ))}
+                                </tbody>
+                            </table>
+                        )}
+                    </Card>
+
+                    <Card>
+                        <SectionHeader
+                            label="OEE"
+                            size="sm"
+                            meta={<span>Last 60 min</span>}
+                            className="mb-3"
+                        />
+                        {oee.isLoading && <Loading />}
+                        {oee.error && <ErrorLine error={oee.error} />}
+                        {oee.data && oee.data.length === 0 && <Empty label="No data." />}
+                        {oee.data && oee.data.length > 0 && (
+                            <div className="grid grid-cols-4 gap-3">
+                                {(["oee", "availability", "performance", "quality"] as const).map(
+                                    (k) => (
+                                        <div
+                                            key={k}
+                                            className="rounded-[var(--ds-radius-sm)] border border-[var(--ds-border)] bg-[var(--ds-bg-elevated)] p-3 text-center"
+                                        >
+                                            <div className="text-[var(--ds-text-xs)] font-medium text-[var(--ds-fg-muted)]">
+                                                {labelFor(k)}
+                                            </div>
+                                            <div className="mt-1 font-mono text-[var(--ds-text-2xl)] font-semibold tabular-nums text-[var(--ds-fg-primary)]">
+                                                {(Number(oee.data[0][k] ?? 0) * 100).toFixed(1)}%
+                                            </div>
                                         </div>
-                                    </div>
-                                ),
-                            )}
-                        </div>
-                    )}
-                </Section>
+                                    ),
+                                )}
+                            </div>
+                        )}
+                    </Card>
 
-                <Section title="Current shift">
-                    {currentShift.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
-                    {currentShift.data ? <Pre value={currentShift.data} /> : null}
-                </Section>
+                    <Card>
+                        <SectionHeader label="Current shift" size="sm" className="mb-3" />
+                        {currentShift.isLoading && <Loading />}
+                        {currentShift.error && <ErrorLine error={currentShift.error} />}
+                        {currentShift.data ? <Pre value={currentShift.data} /> : null}
+                    </Card>
 
-                <Section title="Hierarchy tree">
-                    {tree.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
-                    {tree.data && <Pre value={tree.data} />}
-                </Section>
+                    <Card>
+                        <SectionHeader label="Hierarchy tree" size="sm" className="mb-3" />
+                        {tree.isLoading && <Loading />}
+                        {tree.error && <ErrorLine error={tree.error} />}
+                        {tree.data && <Pre value={tree.data} />}
+                    </Card>
 
-                <Section title="Work orders">
-                    {workOrders.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
-                    {workOrders.data && workOrders.data.length === 0 && (
-                        <p className="text-sm text-slate-500">No work orders yet.</p>
-                    )}
-                    {workOrders.data && workOrders.data.length > 0 && (
-                        <ul className="space-y-2 text-sm">
-                            {workOrders.data.map((w) => (
-                                <li key={w.id} className="border border-slate-200 rounded p-2">
-                                    <div className="flex items-center justify-between">
-                                        <span className="font-medium">{w.title}</span>
-                                        <span className="text-xs text-slate-500">
+                    <Card>
+                        <SectionHeader label="Work orders" size="sm" className="mb-3" />
+                        {workOrders.isLoading && <Loading />}
+                        {workOrders.error && <ErrorLine error={workOrders.error} />}
+                        {workOrders.data && workOrders.data.length === 0 && (
+                            <Empty label="No work orders yet." />
+                        )}
+                        {workOrders.data && workOrders.data.length > 0 && (
+                            <ul className="space-y-2 text-[var(--ds-text-sm)]">
+                                {workOrders.data.map((w) => (
+                                    <li
+                                        key={w.id}
+                                        className="flex items-center justify-between gap-3 rounded-[var(--ds-radius-sm)] border border-[var(--ds-border)] bg-[var(--ds-bg-elevated)] p-2.5"
+                                    >
+                                        <span className="font-medium text-[var(--ds-fg-primary)]">
+                                            {w.title}
+                                        </span>
+                                        <span className="text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
                                             {w.priority} · {w.status}
                                         </span>
-                                    </div>
-                                </li>
-                            ))}
-                        </ul>
-                    )}
-                </Section>
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </Card>
 
-                <Section title="Logbook (last 60 min)">
-                    {logbook.isLoading && <p className="text-sm text-slate-500">Loading…</p>}
-                    {logbook.data && logbook.data.length === 0 && (
-                        <p className="text-sm text-slate-500">No entries.</p>
-                    )}
-                    {logbook.data && logbook.data.length > 0 && (
-                        <ul className="space-y-2 text-sm">
-                            {logbook.data.map((l) => (
-                                <li key={l.id} className="border-l-2 border-slate-300 pl-3">
-                                    <div className="flex justify-between">
-                                        <span className="font-medium">{l.title}</span>
-                                        <span className="text-xs text-slate-500">
-                                            {l.category} · {l.severity}
-                                        </span>
-                                    </div>
-                                    <p className="text-xs text-slate-500">
-                                        {l.cell_name ?? `cell #${l.cell_id}`} ·{" "}
-                                        {new Date(l.created_at).toLocaleString()} ·{" "}
-                                        {l.author_username ?? "—"}
-                                    </p>
-                                    {l.body && (
-                                        <p className="text-xs mt-1 text-slate-700">{l.body}</p>
-                                    )}
-                                </li>
-                            ))}
-                        </ul>
-                    )}
-                </Section>
+                    <Card className="lg:col-span-2">
+                        <SectionHeader
+                            label="Logbook"
+                            size="sm"
+                            meta={<span>Last 60 min</span>}
+                            className="mb-3"
+                        />
+                        {logbook.isLoading && <Loading />}
+                        {logbook.error && <ErrorLine error={logbook.error} />}
+                        {logbook.data && logbook.data.length === 0 && <Empty label="No entries." />}
+                        {logbook.data && logbook.data.length > 0 && (
+                            <ul className="space-y-3 text-[var(--ds-text-sm)]">
+                                {logbook.data.map((l) => (
+                                    <li
+                                        key={l.id}
+                                        className="border-l-2 border-[var(--ds-border-strong)] pl-3"
+                                    >
+                                        <div className="flex items-baseline justify-between gap-3">
+                                            <span className="font-medium text-[var(--ds-fg-primary)]">
+                                                {l.title}
+                                            </span>
+                                            <span className="text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+                                                {l.category} · {l.severity}
+                                            </span>
+                                        </div>
+                                        <p className="text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+                                            {l.cell_name ?? `cell #${l.cell_id}`} ·{" "}
+                                            {new Date(l.created_at).toLocaleString()} ·{" "}
+                                            {l.author_username ?? "—"}
+                                        </p>
+                                        {l.body && (
+                                            <p className="mt-1 text-[var(--ds-text-xs)] text-[var(--ds-fg-primary)]">
+                                                {l.body}
+                                            </p>
+                                        )}
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                    </Card>
+                </div>
             </main>
         </div>
     );
+}
+
+function labelFor(key: "oee" | "availability" | "performance" | "quality"): string {
+    switch (key) {
+        case "oee":
+            return "OEE";
+        case "availability":
+            return "Availability";
+        case "performance":
+            return "Performance";
+        case "quality":
+            return "Quality";
+    }
 }

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,11 +1,23 @@
-import { type FormEvent, useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { type FormEvent, useId, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { AriaMark, ThemeToggle } from "../design-system";
 import { login } from "../lib/auth";
+
+const DEV = import.meta.env.DEV;
+
+interface LocationState {
+    from?: { pathname?: string };
+}
 
 export default function LoginPage() {
     const navigate = useNavigate();
-    const [username, setUsername] = useState("admin");
-    const [password, setPassword] = useState("admin123");
+    const location = useLocation();
+    const usernameId = useId();
+    const passwordId = useId();
+    const errorId = useId();
+
+    const [username, setUsername] = useState(DEV ? "admin" : "");
+    const [password, setPassword] = useState(DEV ? "admin123" : "");
     const [loading, setLoading] = useState(false);
     const [error, setError] = useState<string | null>(null);
 
@@ -15,7 +27,9 @@ export default function LoginPage() {
         setError(null);
         try {
             await login(username, password);
-            navigate("/data", { replace: true });
+            const from = (location.state as LocationState | null)?.from?.pathname;
+            const target = from && from !== "/login" ? from : "/control-room";
+            navigate(target, { replace: true });
         } catch (err) {
             setError(err instanceof Error ? err.message : "Login failed");
         } finally {
@@ -24,60 +38,106 @@ export default function LoginPage() {
     }
 
     return (
-        <div className="min-h-full flex items-center justify-center bg-slate-50 p-4">
-            <form
-                onSubmit={onSubmit}
-                className="w-full max-w-sm bg-white rounded-lg shadow p-6 space-y-4"
-            >
-                <div>
-                    <h1 className="text-2xl font-bold text-slate-900">ARIA</h1>
-                    <p className="text-sm text-slate-500">Sign in to continue</p>
+        <div className="min-h-full flex flex-col bg-[var(--ds-bg-base)]">
+            <header className="flex items-center justify-between px-6 py-4">
+                <div className="flex items-center gap-2.5">
+                    <AriaMark size={20} />
+                    <span className="text-[var(--ds-text-md)] font-semibold tracking-[-0.01em] text-[var(--ds-fg-primary)]">
+                        ARIA
+                    </span>
                 </div>
+                <ThemeToggle />
+            </header>
 
-                <div className="space-y-1">
-                    <label className="block text-sm font-medium text-slate-700">
-                        Username
+            <main className="flex flex-1 items-center justify-center px-4 py-8">
+                <form
+                    onSubmit={onSubmit}
+                    aria-busy={loading}
+                    noValidate
+                    className="w-full max-w-sm rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-surface)] p-6 space-y-5"
+                >
+                    <div className="space-y-1">
+                        <h1 className="text-[var(--ds-text-2xl)] font-semibold leading-tight tracking-[-0.01em] text-[var(--ds-fg-primary)]">
+                            Sign in
+                        </h1>
+                        <p className="text-[var(--ds-text-sm)] text-[var(--ds-fg-muted)]">
+                            Operator console for water-treatment telemetry.
+                        </p>
+                    </div>
+
+                    <div className="space-y-1.5">
+                        <label
+                            htmlFor={usernameId}
+                            className="block text-[var(--ds-text-sm)] font-medium text-[var(--ds-fg-muted)]"
+                        >
+                            Username
+                        </label>
                         <input
+                            id={usernameId}
+                            name="username"
                             type="text"
+                            autoComplete="username"
                             value={username}
                             onChange={(e) => setUsername(e.target.value)}
                             required
-                            className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm focus:border-slate-900 focus:outline-none"
+                            disabled={loading}
+                            className="h-9 w-full rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-elevated)] px-3 text-[var(--ds-text-sm)] text-[var(--ds-fg-primary)] placeholder:text-[var(--ds-fg-subtle)] transition-colors duration-[var(--ds-motion-fast)] hover:border-[var(--ds-border-strong)] focus:border-[var(--ds-accent)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)] disabled:opacity-50"
                         />
-                    </label>
-                </div>
+                    </div>
 
-                <div className="space-y-1">
-                    <label className="block text-sm font-medium text-slate-700">
-                        Password
+                    <div className="space-y-1.5">
+                        <label
+                            htmlFor={passwordId}
+                            className="block text-[var(--ds-text-sm)] font-medium text-[var(--ds-fg-muted)]"
+                        >
+                            Password
+                        </label>
                         <input
+                            id={passwordId}
+                            name="password"
                             type="password"
+                            autoComplete="current-password"
                             value={password}
                             onChange={(e) => setPassword(e.target.value)}
                             required
-                            className="mt-1 w-full rounded border border-slate-300 px-3 py-2 text-sm focus:border-slate-900 focus:outline-none"
+                            disabled={loading}
+                            aria-describedby={error ? errorId : undefined}
+                            className="h-9 w-full rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-elevated)] px-3 text-[var(--ds-text-sm)] text-[var(--ds-fg-primary)] placeholder:text-[var(--ds-fg-subtle)] transition-colors duration-[var(--ds-motion-fast)] hover:border-[var(--ds-border-strong)] focus:border-[var(--ds-accent)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)] disabled:opacity-50"
                         />
-                    </label>
-                </div>
-
-                {error && (
-                    <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded px-3 py-2">
-                        {error}
                     </div>
-                )}
 
-                <button
-                    type="submit"
-                    disabled={loading}
-                    className="w-full rounded bg-slate-900 text-white text-sm font-medium py-2 hover:bg-slate-800 disabled:opacity-50"
-                >
-                    {loading ? "Signing in..." : "Sign in"}
-                </button>
+                    {error && (
+                        <div
+                            id={errorId}
+                            role="alert"
+                            className="rounded-[var(--ds-radius-md)] border px-3 py-2 text-[var(--ds-text-sm)]"
+                            style={{
+                                backgroundColor:
+                                    "color-mix(in oklab, var(--ds-status-critical), transparent 88%)",
+                                borderColor:
+                                    "color-mix(in oklab, var(--ds-status-critical), transparent 70%)",
+                                color: "var(--ds-status-critical)",
+                            }}
+                        >
+                            {error}
+                        </div>
+                    )}
 
-                <p className="text-xs text-slate-400 text-center">
-                    Default seed users: admin/admin123, operator/operator123, viewer/viewer123
-                </p>
-            </form>
+                    <button
+                        type="submit"
+                        disabled={loading}
+                        className="inline-flex h-9 w-full items-center justify-center gap-2 rounded-[var(--ds-radius-md)] bg-[var(--ds-accent)] px-3.5 text-[var(--ds-text-sm)] font-medium text-[var(--ds-accent-fg)] transition-colors duration-[var(--ds-motion-fast)] hover:bg-[var(--ds-accent-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)] disabled:cursor-not-allowed disabled:opacity-40"
+                    >
+                        {loading ? "Signing in…" : "Sign in"}
+                    </button>
+
+                    {DEV && (
+                        <p className="text-center text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
+                            Dev seed: admin / admin123 · operator / operator123 · viewer / viewer123
+                        </p>
+                    )}
+                </form>
+            </main>
         </div>
     );
 }


### PR DESCRIPTION
## Summary

Pivots the two remaining legacy pages (`LoginPage` + `DataPage`) onto the operator-calm v2 design system and resolves three M6.3 follow-ups in one pass.

## Changes

### LoginPage — full v2 rebuild
- Tokens-only (Inter sentence-case, `--ds-radius-md` 10px, `--ds-accent` + `--ds-accent-ring` focus ring, `--ds-bg-{base,surface,elevated}` hierarchy). No decorative shadow.
- AriaMark + wordmark + `ThemeToggle` in the top bar — theme-switching available **before** auth (no first-surface flash).
- Inputs: h-9, bg elevated, border → focus → 2px accent ring. `autocomplete` set (`username` / `current-password`), `useId` pairs `htmlFor`, `aria-describedby`, `aria-busy`, `role="alert"` on error.
- **Redirect fixed (#72)** — reads `location.state.from.pathname` first (respects RequireAuth memory), falls back to `/control-room`. No more hardcoded `/data`.
- **Credentials demo guarded (#74)** — `import.meta.env.DEV` gates both the prefill (`useState("")` in prod) and the seed hint footer. Vite strips the literals in prod bundle (`grep 'admin123' dist/assets/index-*.js` → empty).

### DataPage — debug viewer, v2 skin
- All queries, sections, and logic **preserved** — purely visual swap.
- Legacy classes replaced:
  - `bg-slate-*` / `bg-white` → `var(--ds-bg-*)`
  - `text-slate-*` → `var(--ds-fg-*)`
  - `text-red-*` / `bg-red-*` → `--ds-status-critical` (with `color-mix` tints)
  - `border-slate-*` → `--ds-border`
  - `rounded-lg` → `--ds-radius-md`
  - decorative `shadow` → removed
- Legacy `<Section>` / `<StatusBadge>` → DS primitives (`Card` + `SectionHeader` + `Badge`).
- Sentence-case everywhere. Mono reserved to numerics (tabular-nums) per §3.3.
- Header aligned with `TopBar` (h-14, same tokens) — AriaMark + wordmark + ThemeToggle + user info + logout.
- **Off-DS sweep clean (#73)** — `grep -nE "(bg-slate|text-slate|bg-white|bg-red|text-red|#[0-9a-fA-F]{3,6})" src/pages/{LoginPage,DataPage}.tsx` returns 0 occurrences.

### Architecture
- No changes to `RequireAuth.tsx` — it already passes `state={{ from: location }}`; LoginPage now reads it.
- Zero new deps.

## Acceptance

- [x] `/login` uses DS v2 tokens (no raw slate classes)
- [x] `/data` uses DS v2 tokens (no raw slate classes)
- [x] Post-login redirects to `/control-room` (or the `from` state if present)
- [x] Prod build strips demo credentials and seed hint
- [x] Dark mode + light mode both render correctly on both pages
- [x] `ThemeToggle` accessible before auth

## Test plan

```bash
# Sync and run the app in Docker (only path where login proxy works)
git fetch
git checkout refactor/login-data-v2-cleanup
git pull
make up  # or: docker compose up -d

# Test in browser at http://localhost:5173
```

**Visual checks** (both dark and light via `ThemeToggle` on /login):

1. **`/login`** — card centered, tokens v2 (no white card on light bg), AriaMark + wordmark at top, ThemeToggle top-right, inputs with focus ring on tab, no visible shadow, seed-hint footer visible (DEV mode only).
2. **Login success** → lands on `/control-room` (not `/data`).
3. **Direct nav to `/data` while logged out** → bounces to `/login`, then post-auth → lands back on `/data` (respects `from` state).
4. **`/data`** — sentence-case, cards with hairlines, sentence-case OEE chips, logbook with `--ds-border-strong` rail, no raw slate anywhere.

**Prod bundle check** (optional):
```bash
cd frontend && npm run build
grep -oE "admin123|Dev seed|operator123|viewer123" dist/assets/index-*.js
# → expected: empty (credentials elided by Vite DCE)
```

**Gates** (all green):
- [x] `npm run typecheck`
- [x] `npm run build` (465 kB / 146 kB gz)
- [x] `npm run check` (Biome, 35 files, 0 errors)

## Follow-ups opened on this PR

None — this PR resolves all 3 outstanding M6.3 follow-ups.

Closes #72
Closes #73
Closes #74