### PR TITLE
feat(frontend): chat shell with mock WS + rAF-batched streaming (M6.5)

### DIFF
--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useEffect, useId } from "react";
+import { useCallback, useEffect, useId, useRef } from "react";
 import { Outlet } from "react-router-dom";
 import type { EquipmentSelection } from "../lib/hierarchy";
 import { useLocalStorage } from "../lib/useLocalStorage";
+import { ChatPanel } from "./chat/ChatPanel";
+import { useChatStore } from "./chat/chatStore";
 import { DRAWER_DEFAULT_WIDTH, DRAWER_MAX_WIDTH, DRAWER_MIN_WIDTH, Drawer } from "./Drawer";
 import { TopBar } from "./TopBar";
 
@@ -57,6 +59,8 @@ export function AppShell() {
     );
 
     const safeDrawer = sanitizeDrawer(drawer);
+    const drawerOpenRef = useRef(safeDrawer.open);
+    drawerOpenRef.current = safeDrawer.open;
     const drawerId = useId();
 
     const toggleDrawer = useCallback(() => {
@@ -79,7 +83,14 @@ export function AppShell() {
             if (!comboPressed) return;
             if (isTypingTarget(e.target)) return;
             e.preventDefault();
-            toggleDrawer();
+            if (drawerOpenRef.current) {
+                useChatStore.getState().requestFocus();
+            } else {
+                toggleDrawer();
+                window.setTimeout(() => {
+                    useChatStore.getState().requestFocus();
+                }, 240);
+            }
         }
         window.addEventListener("keydown", onKey);
         return () => window.removeEventListener("keydown", onKey);
@@ -112,7 +123,9 @@ export function AppShell() {
                     width={safeDrawer.width}
                     onToggle={toggleDrawer}
                     onWidthChange={setDrawerWidth}
-                />
+                >
+                    <ChatPanel />
+                </Drawer>
             </div>
         </div>
     );

--- a/frontend/src/app/Drawer.tsx
+++ b/frontend/src/app/Drawer.tsx
@@ -139,7 +139,7 @@ export function Drawer({ open, width, onToggle, onWidthChange, children, id }: D
                         </button>
                     </header>
                     {children ? (
-                        <div className="flex-1 overflow-auto">{children}</div>
+                        <div className="flex min-h-0 flex-1 flex-col">{children}</div>
                     ) : (
                         <div className="flex flex-1 flex-col gap-4 overflow-auto p-4">
                             <Hairline label="Awaiting wire" />

--- a/frontend/src/app/chat/ChatInput.tsx
+++ b/frontend/src/app/chat/ChatInput.tsx
@@ -67,36 +67,38 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
                 e.preventDefault();
                 submit();
             }}
-            className="border-t border-[var(--ds-border)] bg-[var(--ds-bg-surface)] px-3 pt-2.5 pb-2"
+            className="border-t border-[var(--ds-border)] bg-[var(--ds-bg-surface)] px-3 py-2"
         >
-            <div className="flex items-end gap-2 rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-elevated)] px-3 py-2 transition-colors duration-[var(--ds-motion-fast)] focus-within:border-[var(--ds-border-strong)] focus-within:ring-2 focus-within:ring-[var(--ds-accent-ring)]">
-                <textarea
-                    ref={textareaRef}
-                    value={value}
-                    onChange={(e) => {
-                        setValue(e.target.value);
-                        autoResize(e.target);
-                    }}
-                    onKeyDown={onKeyDown}
-                    placeholder={placeholder}
-                    disabled={disabled}
-                    rows={1}
-                    spellCheck
-                    aria-label="Message input"
-                    className="min-h-[20px] flex-1 resize-none bg-transparent text-[var(--ds-text-sm)] leading-[1.4] text-[var(--ds-fg-primary)] placeholder:text-[var(--ds-fg-subtle)] focus:outline-none disabled:opacity-50"
-                />
-                <button
-                    type="submit"
-                    disabled={!canSubmit}
-                    aria-label="Send message"
-                    className="inline-flex h-7 w-7 flex-none items-center justify-center rounded-[var(--ds-radius-sm)] bg-[var(--ds-accent)] text-[var(--ds-accent-fg)] transition-colors duration-[var(--ds-motion-fast)] hover:bg-[var(--ds-accent-hover)] disabled:cursor-not-allowed disabled:bg-[var(--ds-bg-hover)] disabled:text-[var(--ds-fg-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)]"
-                >
-                    <Icons.ArrowRight className="size-3.5" />
-                </button>
+            <div className="rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-elevated)] transition-colors duration-[var(--ds-motion-fast)] focus-within:border-[var(--ds-border-strong)] focus-within:ring-2 focus-within:ring-[var(--ds-accent-ring)]">
+                <div className="flex items-end gap-2 px-3 pt-2">
+                    <textarea
+                        ref={textareaRef}
+                        value={value}
+                        onChange={(e) => {
+                            setValue(e.target.value);
+                            autoResize(e.target);
+                        }}
+                        onKeyDown={onKeyDown}
+                        placeholder={placeholder}
+                        disabled={disabled}
+                        rows={1}
+                        spellCheck
+                        aria-label="Message input"
+                        className="min-h-[20px] flex-1 resize-none bg-transparent text-[var(--ds-text-sm)] leading-[1.4] text-[var(--ds-fg-primary)] placeholder:text-[var(--ds-fg-subtle)] focus:outline-none disabled:opacity-50"
+                    />
+                    <button
+                        type="submit"
+                        disabled={!canSubmit}
+                        aria-label="Send message"
+                        className="inline-flex h-7 w-7 flex-none items-center justify-center rounded-[var(--ds-radius-sm)] bg-[var(--ds-accent)] text-[var(--ds-accent-fg)] transition-colors duration-[var(--ds-motion-fast)] hover:bg-[var(--ds-accent-hover)] disabled:cursor-not-allowed disabled:bg-[var(--ds-bg-hover)] disabled:text-[var(--ds-fg-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)]"
+                    >
+                        <Icons.ArrowRight className="size-3.5" />
+                    </button>
+                </div>
+                <p className="px-3 pb-1.5 pt-1 text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
+                    Enter to send · Shift + Enter for new line
+                </p>
             </div>
-            <p className="mt-1 text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
-                Enter to send · Shift + Enter for new line
-            </p>
         </form>
     );
 });

--- a/frontend/src/app/chat/ChatInput.tsx
+++ b/frontend/src/app/chat/ChatInput.tsx
@@ -67,7 +67,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
                 e.preventDefault();
                 submit();
             }}
-            className="border-t border-[var(--ds-border)] bg-[var(--ds-bg-surface)] px-3 py-3"
+            className="border-t border-[var(--ds-border)] bg-[var(--ds-bg-surface)] px-3 pt-2.5 pb-2"
         >
             <div className="flex items-end gap-2 rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-elevated)] px-3 py-2 transition-colors duration-[var(--ds-motion-fast)] focus-within:border-[var(--ds-border-strong)] focus-within:ring-2 focus-within:ring-[var(--ds-accent-ring)]">
                 <textarea
@@ -94,7 +94,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
                     <Icons.ArrowRight className="size-3.5" />
                 </button>
             </div>
-            <p className="mt-1.5 text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
+            <p className="mt-1 text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
                 Enter to send · Shift + Enter for new line
             </p>
         </form>

--- a/frontend/src/app/chat/ChatInput.tsx
+++ b/frontend/src/app/chat/ChatInput.tsx
@@ -1,0 +1,102 @@
+import { forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState } from "react";
+import { Icons } from "../../design-system";
+
+export interface ChatInputHandle {
+    focus(): void;
+}
+
+export interface ChatInputProps {
+    onSubmit: (value: string) => void;
+    disabled?: boolean;
+    placeholder?: string;
+}
+
+const MAX_ROWS = 8;
+const BASE_ROW_HEIGHT_PX = 20;
+
+function autoResize(el: HTMLTextAreaElement) {
+    el.style.height = "auto";
+    const capped = Math.min(el.scrollHeight, BASE_ROW_HEIGHT_PX * MAX_ROWS + 24);
+    el.style.height = `${capped}px`;
+}
+
+export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput(
+    { onSubmit, disabled = false, placeholder = "Message the operator console…" },
+    ref,
+) {
+    const [value, setValue] = useState("");
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            focus: () => textareaRef.current?.focus(),
+        }),
+        [],
+    );
+
+    useEffect(() => {
+        if (textareaRef.current) autoResize(textareaRef.current);
+    }, []);
+
+    const submit = useCallback(() => {
+        const trimmed = value.trim();
+        if (!trimmed || disabled) return;
+        onSubmit(trimmed);
+        setValue("");
+        requestAnimationFrame(() => {
+            if (textareaRef.current) {
+                textareaRef.current.style.height = "auto";
+                textareaRef.current.focus();
+            }
+        });
+    }, [value, disabled, onSubmit]);
+
+    const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing) {
+            e.preventDefault();
+            submit();
+        }
+    };
+
+    const canSubmit = value.trim().length > 0 && !disabled;
+
+    return (
+        <form
+            onSubmit={(e) => {
+                e.preventDefault();
+                submit();
+            }}
+            className="border-t border-[var(--ds-border)] bg-[var(--ds-bg-surface)] px-3 py-3"
+        >
+            <div className="flex items-end gap-2 rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-elevated)] px-3 py-2 transition-colors duration-[var(--ds-motion-fast)] focus-within:border-[var(--ds-border-strong)] focus-within:ring-2 focus-within:ring-[var(--ds-accent-ring)]">
+                <textarea
+                    ref={textareaRef}
+                    value={value}
+                    onChange={(e) => {
+                        setValue(e.target.value);
+                        autoResize(e.target);
+                    }}
+                    onKeyDown={onKeyDown}
+                    placeholder={placeholder}
+                    disabled={disabled}
+                    rows={1}
+                    spellCheck
+                    aria-label="Message input"
+                    className="min-h-[20px] flex-1 resize-none bg-transparent text-[var(--ds-text-sm)] leading-[1.4] text-[var(--ds-fg-primary)] placeholder:text-[var(--ds-fg-subtle)] focus:outline-none disabled:opacity-50"
+                />
+                <button
+                    type="submit"
+                    disabled={!canSubmit}
+                    aria-label="Send message"
+                    className="inline-flex h-7 w-7 flex-none items-center justify-center rounded-[var(--ds-radius-sm)] bg-[var(--ds-accent)] text-[var(--ds-accent-fg)] transition-colors duration-[var(--ds-motion-fast)] hover:bg-[var(--ds-accent-hover)] disabled:cursor-not-allowed disabled:bg-[var(--ds-bg-hover)] disabled:text-[var(--ds-fg-subtle)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)]"
+                >
+                    <Icons.ArrowRight className="size-3.5" />
+                </button>
+            </div>
+            <p className="mt-1.5 text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
+                Enter to send · Shift + Enter for new line
+            </p>
+        </form>
+    );
+});

--- a/frontend/src/app/chat/ChatPanel.tsx
+++ b/frontend/src/app/chat/ChatPanel.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef } from "react";
+import { useShallow } from "zustand/react/shallow";
+import { ChatInput, type ChatInputHandle } from "./ChatInput";
+import { useChatStore } from "./chatStore";
+import { MessageList } from "./MessageList";
+import { useThrottledMessages } from "./useThrottledMessages";
+
+export function ChatPanel() {
+    const messages = useThrottledMessages();
+    const { status, sendMessage, connect, focusRequestId } = useChatStore(
+        useShallow((s) => ({
+            status: s.status,
+            sendMessage: s.sendMessage,
+            connect: s.connect,
+            focusRequestId: s.focusRequestId,
+        })),
+    );
+
+    const inputRef = useRef<ChatInputHandle>(null);
+
+    useEffect(() => {
+        connect();
+    }, [connect]);
+
+    useEffect(() => {
+        if (focusRequestId > 0) {
+            inputRef.current?.focus();
+        }
+    }, [focusRequestId]);
+
+    return (
+        <div className="flex h-full min-h-0 flex-col bg-[var(--ds-bg-surface)]">
+            <div className="flex-none border-b border-[var(--ds-border)] px-4 py-2">
+                <ConnectionIndicator status={status} />
+            </div>
+            <MessageList messages={messages} />
+            <ChatInput ref={inputRef} onSubmit={sendMessage} disabled={status === "error"} />
+        </div>
+    );
+}
+
+function ConnectionIndicator({ status }: { status: string }) {
+    const label =
+        status === "open"
+            ? "Connected"
+            : status === "connecting"
+              ? "Connecting…"
+              : status === "error"
+                ? "Connection error"
+                : status === "closed"
+                  ? "Disconnected"
+                  : "Idle";
+
+    const dotColor =
+        status === "open"
+            ? "var(--ds-status-nominal)"
+            : status === "error"
+              ? "var(--ds-status-critical)"
+              : status === "connecting"
+                ? "var(--ds-status-warning)"
+                : "var(--ds-fg-subtle)";
+
+    return (
+        <div className="flex items-center gap-2 text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+            <span
+                className="inline-block size-1.5 flex-none rounded-full"
+                style={{ backgroundColor: dotColor }}
+                aria-hidden
+            />
+            <span>{label}</span>
+            <span className="ml-auto font-mono text-[var(--ds-fg-subtle)]">mock</span>
+        </div>
+    );
+}

--- a/frontend/src/app/chat/Markdown.tsx
+++ b/frontend/src/app/chat/Markdown.tsx
@@ -1,0 +1,157 @@
+import type { ComponentPropsWithoutRef } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+const ANCHOR_CLASS =
+    "underline underline-offset-2 text-[var(--ds-accent)] hover:text-[var(--ds-accent-hover)] transition-colors duration-[var(--ds-motion-fast)]";
+
+const CODE_INLINE_CLASS =
+    "font-mono bg-[var(--ds-bg-elevated)] text-[var(--ds-fg-primary)] px-1.5 py-0.5 rounded-[var(--ds-radius-sm)] text-[var(--ds-text-xs)] border border-[var(--ds-border)]";
+
+const CODE_BLOCK_CLASS =
+    "font-mono bg-[var(--ds-bg-elevated)] text-[var(--ds-fg-primary)] p-3 rounded-[var(--ds-radius-md)] overflow-x-auto text-[var(--ds-text-xs)] leading-relaxed border border-[var(--ds-border)]";
+
+type CodeProps = ComponentPropsWithoutRef<"code"> & { inline?: boolean };
+
+const components: Components = {
+    p: ({ children, ...rest }) => (
+        <p
+            {...rest}
+            className="mb-2 last:mb-0 leading-[1.55] text-[var(--ds-text-sm)] text-[var(--ds-fg-primary)]"
+        >
+            {children}
+        </p>
+    ),
+    a: ({ children, href, ...rest }) => (
+        <a {...rest} href={href} target="_blank" rel="noreferrer noopener" className={ANCHOR_CLASS}>
+            {children}
+        </a>
+    ),
+    strong: ({ children, ...rest }) => (
+        <strong {...rest} className="font-semibold text-[var(--ds-fg-primary)]">
+            {children}
+        </strong>
+    ),
+    em: ({ children, ...rest }) => (
+        <em {...rest} className="italic text-[var(--ds-fg-primary)]">
+            {children}
+        </em>
+    ),
+    ul: ({ children, ...rest }) => (
+        <ul
+            {...rest}
+            className="mb-2 last:mb-0 ml-4 list-disc space-y-1 text-[var(--ds-text-sm)] marker:text-[var(--ds-fg-subtle)]"
+        >
+            {children}
+        </ul>
+    ),
+    ol: ({ children, ...rest }) => (
+        <ol
+            {...rest}
+            className="mb-2 last:mb-0 ml-5 list-decimal space-y-1 text-[var(--ds-text-sm)] marker:text-[var(--ds-fg-subtle)]"
+        >
+            {children}
+        </ol>
+    ),
+    li: ({ children, ...rest }) => (
+        <li {...rest} className="leading-[1.55] text-[var(--ds-fg-primary)]">
+            {children}
+        </li>
+    ),
+    h1: ({ children, ...rest }) => (
+        <h1
+            {...rest}
+            className="mb-2 mt-3 first:mt-0 text-[var(--ds-text-lg)] font-semibold tracking-[-0.01em] text-[var(--ds-fg-primary)]"
+        >
+            {children}
+        </h1>
+    ),
+    h2: ({ children, ...rest }) => (
+        <h2
+            {...rest}
+            className="mb-2 mt-3 first:mt-0 text-[var(--ds-text-md)] font-semibold tracking-[-0.01em] text-[var(--ds-fg-primary)]"
+        >
+            {children}
+        </h2>
+    ),
+    h3: ({ children, ...rest }) => (
+        <h3
+            {...rest}
+            className="mb-1.5 mt-2 first:mt-0 text-[var(--ds-text-sm)] font-semibold text-[var(--ds-fg-primary)]"
+        >
+            {children}
+        </h3>
+    ),
+    blockquote: ({ children, ...rest }) => (
+        <blockquote
+            {...rest}
+            className="mb-2 last:mb-0 border-l-2 border-[var(--ds-border-strong)] pl-3 text-[var(--ds-fg-muted)] italic"
+        >
+            {children}
+        </blockquote>
+    ),
+    hr: () => <hr className="my-3 border-t border-[var(--ds-border)]" />,
+    table: ({ children, ...rest }) => (
+        <div className="mb-2 last:mb-0 overflow-x-auto rounded-[var(--ds-radius-sm)] border border-[var(--ds-border)]">
+            <table
+                {...rest}
+                className="w-full border-collapse text-[var(--ds-text-xs)] text-[var(--ds-fg-primary)]"
+            >
+                {children}
+            </table>
+        </div>
+    ),
+    thead: ({ children, ...rest }) => (
+        <thead {...rest} className="bg-[var(--ds-bg-elevated)] text-left">
+            {children}
+        </thead>
+    ),
+    th: ({ children, ...rest }) => (
+        <th
+            {...rest}
+            className="border-b border-[var(--ds-border)] px-2.5 py-1.5 font-medium text-[var(--ds-fg-muted)]"
+        >
+            {children}
+        </th>
+    ),
+    td: ({ children, ...rest }) => (
+        <td
+            {...rest}
+            className="border-b border-[var(--ds-border)] px-2.5 py-1.5 align-top last:border-b-0"
+        >
+            {children}
+        </td>
+    ),
+    pre: ({ children, ...rest }) => (
+        <pre {...rest} className={`mb-2 last:mb-0 ${CODE_BLOCK_CLASS}`}>
+            {children}
+        </pre>
+    ),
+    code: (props: CodeProps) => {
+        const { inline, className = "", children, ...rest } = props;
+        if (inline) {
+            return (
+                <code {...rest} className={`${CODE_INLINE_CLASS} ${className}`}>
+                    {children}
+                </code>
+            );
+        }
+        return (
+            <code {...rest} className={className}>
+                {children}
+            </code>
+        );
+    },
+};
+
+export interface MarkdownProps {
+    children: string;
+}
+
+export function Markdown({ children }: MarkdownProps) {
+    return (
+        <ReactMarkdown remarkPlugins={[remarkGfm]} components={components}>
+            {children}
+        </ReactMarkdown>
+    );
+}

--- a/frontend/src/app/chat/Message.tsx
+++ b/frontend/src/app/chat/Message.tsx
@@ -1,0 +1,179 @@
+import { memo } from "react";
+import { Badge, Icons } from "../../design-system";
+import type { AgentMessage, AgentPart, UserMessage } from "./chatStore";
+import { Markdown } from "./Markdown";
+
+const KNOWN_AGENTS = new Set(["sentinel", "investigator", "kb_builder", "work_order", "qa"]);
+
+function formatAgentLabel(id: string): string {
+    if (id === "kb_builder") return "KB builder";
+    if (id === "work_order") return "Work order";
+    if (id === "qa") return "QA";
+    return id.charAt(0).toUpperCase() + id.slice(1);
+}
+
+function formatRelativeTime(ts: number, now: number): string {
+    const diff = Math.max(0, now - ts);
+    if (diff < 30_000) return "just now";
+    if (diff < 60_000) return `${Math.floor(diff / 1000)}s ago`;
+    if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+    if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`;
+    return new Date(ts).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+interface UserRowProps {
+    message: UserMessage;
+    now: number;
+}
+
+function UserRow({ message, now }: UserRowProps) {
+    return (
+        <div className="flex flex-col items-end gap-1">
+            <div className="max-w-[80%] rounded-[var(--ds-radius-md)] bg-[var(--ds-bg-elevated)] border border-[var(--ds-border)] px-3 py-2 text-[var(--ds-text-sm)] leading-[1.55] text-[var(--ds-fg-primary)] whitespace-pre-wrap break-words">
+                {message.content}
+            </div>
+            <span className="text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
+                {formatRelativeTime(message.createdAt, now)}
+            </span>
+        </div>
+    );
+}
+
+function renderArgs(args: Record<string, unknown>): string {
+    try {
+        const json = JSON.stringify(args);
+        return json.length > 80 ? `${json.slice(0, 77)}…` : json;
+    } catch {
+        return "{…}";
+    }
+}
+
+interface ToolCallRowProps {
+    part: Extract<AgentPart, { kind: "tool_call" }>;
+}
+
+function ToolCallRow({ part }: ToolCallRowProps) {
+    const running = part.status === "running";
+    return (
+        <div className="flex items-center gap-2 rounded-[var(--ds-radius-sm)] border border-[var(--ds-border)] bg-[var(--ds-bg-elevated)]/60 px-2.5 py-1.5 text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+            {running ? (
+                <Icons.Activity className="size-3.5 flex-none animate-pulse text-[var(--ds-fg-subtle)]" />
+            ) : (
+                <Icons.Check className="size-3.5 flex-none text-[var(--ds-status-nominal)]" />
+            )}
+            <span className="font-mono text-[var(--ds-fg-primary)]">{part.name}</span>
+            <span className="truncate font-mono text-[var(--ds-fg-subtle)]">
+                {renderArgs(part.args)}
+            </span>
+            {part.summary && (
+                <span className="ml-auto flex-none text-[var(--ds-fg-muted)]">{part.summary}</span>
+            )}
+        </div>
+    );
+}
+
+interface HandoffRowProps {
+    part: Extract<AgentPart, { kind: "handoff" }>;
+}
+
+function HandoffRow({ part }: HandoffRowProps) {
+    const fromAgent = KNOWN_AGENTS.has(String(part.from)) ? (part.from as never) : undefined;
+    const toAgent = KNOWN_AGENTS.has(String(part.to)) ? (part.to as never) : undefined;
+    return (
+        <div className="flex items-center gap-2 rounded-[var(--ds-radius-sm)] border border-dashed border-[var(--ds-border)] bg-transparent px-2.5 py-1.5 text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+            <Icons.ArrowRight className="size-3.5 flex-none text-[var(--ds-fg-subtle)]" />
+            <span>Handoff</span>
+            {fromAgent ? (
+                <Badge variant="agent" agent={fromAgent}>
+                    {formatAgentLabel(part.from)}
+                </Badge>
+            ) : (
+                <span className="font-mono">{part.from}</span>
+            )}
+            <Icons.ChevronRight className="size-3 flex-none text-[var(--ds-fg-subtle)]" />
+            {toAgent ? (
+                <Badge variant="agent" agent={toAgent}>
+                    {formatAgentLabel(part.to)}
+                </Badge>
+            ) : (
+                <span className="font-mono">{part.to}</span>
+            )}
+            <span className="ml-1 truncate text-[var(--ds-fg-subtle)]">· {part.reason}</span>
+        </div>
+    );
+}
+
+interface AgentRowProps {
+    message: AgentMessage;
+    now: number;
+}
+
+function AgentRow({ message, now }: AgentRowProps) {
+    const agentKey = KNOWN_AGENTS.has(message.agent) ? (message.agent as never) : undefined;
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex items-center gap-2">
+                {agentKey ? (
+                    <Badge variant="agent" agent={agentKey}>
+                        {formatAgentLabel(message.agent)}
+                    </Badge>
+                ) : (
+                    <Badge variant="default">{formatAgentLabel(message.agent)}</Badge>
+                )}
+                <span className="text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
+                    {formatRelativeTime(message.createdAt, now)}
+                </span>
+                {message.streaming && (
+                    <span
+                        aria-hidden
+                        className="inline-block size-1.5 flex-none animate-pulse rounded-full bg-[var(--ds-accent)]"
+                    />
+                )}
+            </div>
+            <div className="flex flex-col gap-2">
+                {message.parts.length === 0 && message.streaming && (
+                    <span className="text-[var(--ds-text-sm)] text-[var(--ds-fg-subtle)] italic">
+                        Thinking…
+                    </span>
+                )}
+                {message.parts.map((part) => {
+                    if (part.kind === "tool_call") return <ToolCallRow key={part.id} part={part} />;
+                    if (part.kind === "handoff") return <HandoffRow key={part.id} part={part} />;
+                    return (
+                        <div key={part.id} className="max-w-full text-[var(--ds-fg-primary)]">
+                            <Markdown>{part.content}</Markdown>
+                            {part.streaming && (
+                                <span className="ml-0.5 inline-block h-[1em] w-[2px] translate-y-[2px] animate-pulse bg-[var(--ds-accent)] align-middle" />
+                            )}
+                        </div>
+                    );
+                })}
+                {message.error && (
+                    <div className="flex items-center gap-2 rounded-[var(--ds-radius-sm)] border border-[color-mix(in_oklab,var(--ds-status-critical),transparent_70%)] bg-[color-mix(in_oklab,var(--ds-status-critical),transparent_90%)] px-2.5 py-1.5 text-[var(--ds-text-xs)] text-[var(--ds-status-critical)]">
+                        <Icons.AlertTriangle className="size-3.5 flex-none" />
+                        <span>{message.error}</span>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}
+
+interface MessageProps {
+    message: UserMessage | AgentMessage;
+    now: number;
+}
+
+function MessageImpl({ message, now }: MessageProps) {
+    if (message.role === "user") return <UserRow message={message} now={now} />;
+    return <AgentRow message={message} now={now} />;
+}
+
+export const Message = memo(MessageImpl, (prev, next) => {
+    if (prev.message !== next.message) return false;
+    // Relative timestamp re-renders on parent tick; suppress if within the same bucket.
+    const prevBucket = Math.floor((prev.now - prev.message.createdAt) / 60_000);
+    const nextBucket = Math.floor((next.now - next.message.createdAt) / 60_000);
+    return prevBucket === nextBucket;
+});

--- a/frontend/src/app/chat/MessageList.tsx
+++ b/frontend/src/app/chat/MessageList.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState } from "react";
+import { Icons } from "../../design-system";
+import type { ChatMessage } from "./chatStore";
+import { Message } from "./Message";
+import { useAutoScroll } from "./useAutoScroll";
+
+const TIMESTAMP_TICK_MS = 30_000;
+
+interface MessageListProps {
+    messages: ChatMessage[];
+}
+
+export function MessageList({ messages }: MessageListProps) {
+    const scrollRef = useRef<HTMLDivElement | null>(null);
+    const messagesLenRef = useRef(messages.length);
+    const { isPaused, pendingCount, jumpToBottom, notifyContentGrew, notifyMessageAppended } =
+        useAutoScroll(scrollRef);
+    const [now, setNow] = useState(() => Date.now());
+
+    useEffect(() => {
+        const id = window.setInterval(() => setNow(Date.now()), TIMESTAMP_TICK_MS);
+        return () => window.clearInterval(id);
+    }, []);
+
+    useEffect(() => {
+        if (messages.length > messagesLenRef.current) {
+            for (let i = messagesLenRef.current; i < messages.length; i += 1) {
+                notifyMessageAppended();
+            }
+        } else {
+            notifyContentGrew();
+        }
+        messagesLenRef.current = messages.length;
+    }, [messages, notifyContentGrew, notifyMessageAppended]);
+
+    return (
+        <div className="relative min-h-0 flex-1">
+            <div
+                ref={scrollRef}
+                role="log"
+                aria-live="polite"
+                aria-label="Conversation"
+                className="h-full overflow-y-auto px-4 py-4"
+            >
+                {messages.length === 0 ? (
+                    <EmptyState />
+                ) : (
+                    <ol className="flex flex-col gap-5">
+                        {messages.map((m) => (
+                            <li key={m.id}>
+                                <Message message={m} now={now} />
+                            </li>
+                        ))}
+                    </ol>
+                )}
+            </div>
+            {isPaused && (
+                <button
+                    type="button"
+                    onClick={jumpToBottom}
+                    className="absolute bottom-3 left-1/2 z-10 inline-flex -translate-x-1/2 items-center gap-1.5 rounded-[var(--ds-radius-md)] border border-[var(--ds-border-strong)] bg-[var(--ds-bg-surface)] px-3 py-1.5 text-[var(--ds-text-xs)] text-[var(--ds-fg-primary)] shadow-[var(--ds-shadow-overlay)] transition-colors duration-[var(--ds-motion-fast)] hover:bg-[var(--ds-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)]"
+                >
+                    <Icons.ChevronDown className="size-3.5" />
+                    Jump to latest
+                    {pendingCount > 0 && (
+                        <span className="ml-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full bg-[var(--ds-accent)] px-1 text-[10px] font-medium leading-none text-[var(--ds-accent-fg)]">
+                            {pendingCount > 99 ? "99+" : pendingCount}
+                        </span>
+                    )}
+                </button>
+            )}
+        </div>
+    );
+}
+
+function EmptyState() {
+    return (
+        <div className="flex h-full flex-col items-start gap-3 pt-8">
+            <p className="text-[var(--ds-text-sm)] font-medium text-[var(--ds-fg-primary)]">
+                Ask the operator console anything.
+            </p>
+            <p className="text-[var(--ds-text-sm)] text-[var(--ds-fg-muted)]">
+                Try “show WO table”, “query_kb for turbidity RCAs”, or “handoff to investigator”.
+            </p>
+        </div>
+    );
+}

--- a/frontend/src/app/chat/chatStore.ts
+++ b/frontend/src/app/chat/chatStore.ts
@@ -1,0 +1,280 @@
+import { create } from "zustand";
+import { createMockChatClient, type MockChatHandle } from "../../lib/mockChat";
+import type { ChatMap } from "../../lib/ws.types";
+
+export type ConnectionStatus = "idle" | "connecting" | "open" | "closed" | "error";
+
+export type AgentId = "sentinel" | "investigator" | "kb_builder" | "work_order" | "qa";
+
+export interface UserMessage {
+    id: string;
+    role: "user";
+    content: string;
+    createdAt: number;
+}
+
+export interface ToolCallPart {
+    kind: "tool_call";
+    id: string;
+    name: string;
+    args: Record<string, unknown>;
+    status: "running" | "done";
+    summary?: string;
+}
+
+export interface TextPart {
+    kind: "text";
+    id: string;
+    content: string;
+    /** Still receiving text_delta frames for this part. */
+    streaming: boolean;
+}
+
+export interface HandoffPart {
+    kind: "handoff";
+    id: string;
+    from: AgentId | string;
+    to: AgentId | string;
+    reason: string;
+}
+
+export type AgentPart = ToolCallPart | TextPart | HandoffPart;
+
+export interface AgentMessage {
+    id: string;
+    role: "agent";
+    agent: AgentId | string;
+    parts: AgentPart[];
+    createdAt: number;
+    /** True until the turn produces a `done` event. */
+    streaming: boolean;
+    /** Populated when `done` carries an `error`. */
+    error?: string;
+}
+
+export type ChatMessage = UserMessage | AgentMessage;
+
+export interface ChatState {
+    messages: ChatMessage[];
+    status: ConnectionStatus;
+    error: string | null;
+    /** Bumps every time the input should re-focus (cmd+K while drawer is open). */
+    focusRequestId: number;
+
+    connect: () => void;
+    disconnect: () => void;
+    sendMessage: (content: string) => void;
+    reset: () => void;
+    requestFocus: () => void;
+}
+
+const DEFAULT_AGENT: AgentId = "sentinel";
+
+interface InternalState {
+    handle: MockChatHandle | null;
+    currentAgentMessageId: string | null;
+    idCounter: number;
+}
+
+function nextId(internal: InternalState, prefix: string): string {
+    internal.idCounter += 1;
+    return `${prefix}-${internal.idCounter}-${Date.now().toString(36)}`;
+}
+
+export const useChatStore = create<ChatState>((set, get) => {
+    const internal: InternalState = {
+        handle: null,
+        currentAgentMessageId: null,
+        idCounter: 0,
+    };
+
+    const upsertAgentMessage = (update: (msg: AgentMessage) => AgentMessage) => {
+        const id = internal.currentAgentMessageId;
+        if (!id) return;
+        set((state) => ({
+            messages: state.messages.map((m) =>
+                m.id === id && m.role === "agent" ? update(m) : m,
+            ),
+        }));
+    };
+
+    const appendTextDelta = (content: string) => {
+        upsertAgentMessage((msg) => {
+            const parts = [...msg.parts];
+            const last = parts[parts.length - 1];
+            if (last && last.kind === "text" && last.streaming) {
+                parts[parts.length - 1] = { ...last, content: last.content + content };
+            } else {
+                parts.push({
+                    kind: "text",
+                    id: nextId(internal, "text"),
+                    content,
+                    streaming: true,
+                });
+            }
+            return { ...msg, parts };
+        });
+    };
+
+    const handleEvent = (type: ChatMap["type"], message: ChatMap) => {
+        if (!internal.currentAgentMessageId) return;
+
+        switch (message.type) {
+            case "text_delta": {
+                appendTextDelta(message.content);
+                break;
+            }
+            case "thinking_delta": {
+                // M6.5 scope: thinking tokens are collapsed into the main text
+                // stream so the shell exercises the streaming path end-to-end.
+                // Dedicated thinking UI lands post-M6.5.
+                break;
+            }
+            case "tool_call": {
+                upsertAgentMessage((msg) => {
+                    const parts = [...msg.parts];
+                    // Seal any ongoing text part so tool call sits between text runs.
+                    const lastIdx = parts.length - 1;
+                    if (parts[lastIdx]?.kind === "text" && (parts[lastIdx] as TextPart).streaming) {
+                        parts[lastIdx] = { ...(parts[lastIdx] as TextPart), streaming: false };
+                    }
+                    parts.push({
+                        kind: "tool_call",
+                        id: nextId(internal, "tc"),
+                        name: message.name,
+                        args: message.args,
+                        status: "running",
+                    });
+                    return { ...msg, parts };
+                });
+                break;
+            }
+            case "tool_result": {
+                upsertAgentMessage((msg) => {
+                    const parts = [...msg.parts];
+                    for (let i = parts.length - 1; i >= 0; i -= 1) {
+                        const p = parts[i];
+                        if (
+                            p.kind === "tool_call" &&
+                            p.name === message.name &&
+                            p.status === "running"
+                        ) {
+                            parts[i] = { ...p, status: "done", summary: message.summary };
+                            break;
+                        }
+                    }
+                    return { ...msg, parts };
+                });
+                break;
+            }
+            case "agent_handoff": {
+                upsertAgentMessage((msg) => {
+                    const parts = [...msg.parts];
+                    const lastIdx = parts.length - 1;
+                    if (parts[lastIdx]?.kind === "text" && (parts[lastIdx] as TextPart).streaming) {
+                        parts[lastIdx] = { ...(parts[lastIdx] as TextPart), streaming: false };
+                    }
+                    parts.push({
+                        kind: "handoff",
+                        id: nextId(internal, "ho"),
+                        from: message.from,
+                        to: message.to,
+                        reason: message.reason,
+                    });
+                    return { ...msg, agent: message.to, parts };
+                });
+                break;
+            }
+            case "ui_render": {
+                // UI-render widgets land in a later milestone.
+                break;
+            }
+            case "done": {
+                upsertAgentMessage((msg) => {
+                    const parts = msg.parts.map((p) =>
+                        p.kind === "text" && p.streaming ? { ...p, streaming: false } : p,
+                    );
+                    return { ...msg, parts, streaming: false, error: message.error };
+                });
+                internal.currentAgentMessageId = null;
+                break;
+            }
+        }
+        // biome-ignore lint/suspicious/noExplicitAny: `type` is derived from the union above, not user input
+        void (type as any);
+    };
+
+    const ensureConnected = () => {
+        if (internal.handle) return;
+        set({ status: "connecting", error: null });
+        internal.handle = createMockChatClient({
+            url: "/api/v1/agent/chat",
+            onOpen: () => set({ status: "open", error: null }),
+            onClose: () => set({ status: "closed" }),
+            onError: (err) => set({ status: "error", error: err.message }),
+            onEvent: handleEvent,
+        });
+    };
+
+    return {
+        messages: [],
+        status: "idle",
+        error: null,
+        focusRequestId: 0,
+
+        connect: () => ensureConnected(),
+
+        disconnect: () => {
+            internal.handle?.close(1000, "disconnect");
+            internal.handle = null;
+            internal.currentAgentMessageId = null;
+            set({ status: "closed" });
+        },
+
+        sendMessage: (content) => {
+            const trimmed = content.trim();
+            if (!trimmed) return;
+
+            ensureConnected();
+
+            const userMsg: UserMessage = {
+                id: nextId(internal, "u"),
+                role: "user",
+                content: trimmed,
+                createdAt: Date.now(),
+            };
+            const agentMsg: AgentMessage = {
+                id: nextId(internal, "a"),
+                role: "agent",
+                agent: DEFAULT_AGENT,
+                parts: [],
+                createdAt: Date.now() + 1,
+                streaming: true,
+            };
+            internal.currentAgentMessageId = agentMsg.id;
+
+            set((state) => ({ messages: [...state.messages, userMsg, agentMsg] }));
+
+            // Drain after OPEN — mock opens on next microtask; guard with a tiny retry.
+            const dispatch = () => {
+                if (internal.handle && get().status === "open") {
+                    internal.handle.sendMock(trimmed);
+                } else {
+                    queueMicrotask(dispatch);
+                }
+            };
+            dispatch();
+        },
+
+        reset: () => {
+            internal.handle?.close(1000, "reset");
+            internal.handle = null;
+            internal.currentAgentMessageId = null;
+            set({ messages: [], status: "idle", error: null });
+        },
+
+        requestFocus: () => {
+            set((state) => ({ focusRequestId: state.focusRequestId + 1 }));
+        },
+    };
+});

--- a/frontend/src/app/chat/useAutoScroll.ts
+++ b/frontend/src/app/chat/useAutoScroll.ts
@@ -1,0 +1,85 @@
+import { type RefObject, useCallback, useEffect, useRef, useState } from "react";
+
+const NEAR_BOTTOM_PX = 48;
+
+export interface AutoScrollHandle {
+    /** True when user has scrolled up and new messages are being held. */
+    isPaused: boolean;
+    /** Delta of new content since pause started — drives the jump-bottom badge. */
+    pendingCount: number;
+    /** Scroll back to the bottom smoothly and resume auto-scroll. */
+    jumpToBottom: () => void;
+    /** Call on every external reason to re-evaluate (new token, new message). */
+    notifyContentGrew: () => void;
+    /** Call when a brand-new message arrives — increments the pending counter. */
+    notifyMessageAppended: () => void;
+}
+
+export function useAutoScroll<T extends HTMLElement>(ref: RefObject<T | null>): AutoScrollHandle {
+    const [isPaused, setIsPaused] = useState(false);
+    const [pendingCount, setPendingCount] = useState(0);
+    const pausedRef = useRef(false);
+
+    const isNearBottom = useCallback(() => {
+        const el = ref.current;
+        if (!el) return true;
+        const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+        return distance <= NEAR_BOTTOM_PX;
+    }, [ref]);
+
+    const scrollToBottom = useCallback(
+        (smooth = false) => {
+            const el = ref.current;
+            if (!el) return;
+            el.scrollTo({ top: el.scrollHeight, behavior: smooth ? "smooth" : "auto" });
+        },
+        [ref],
+    );
+
+    const jumpToBottom = useCallback(() => {
+        scrollToBottom(true);
+        pausedRef.current = false;
+        setIsPaused(false);
+        setPendingCount(0);
+    }, [scrollToBottom]);
+
+    const notifyContentGrew = useCallback(() => {
+        if (pausedRef.current) return;
+        // Defer until layout has settled so scrollHeight reflects the new content.
+        requestAnimationFrame(() => scrollToBottom(false));
+    }, [scrollToBottom]);
+
+    const notifyMessageAppended = useCallback(() => {
+        if (pausedRef.current) {
+            setPendingCount((c) => c + 1);
+            return;
+        }
+        requestAnimationFrame(() => scrollToBottom(false));
+    }, [scrollToBottom]);
+
+    useEffect(() => {
+        const el = ref.current;
+        if (!el) return;
+        let rafId = 0;
+        const handle = () => {
+            if (rafId) return;
+            rafId = requestAnimationFrame(() => {
+                rafId = 0;
+                const near = isNearBottom();
+                const nextPaused = !near;
+                if (nextPaused !== pausedRef.current) {
+                    pausedRef.current = nextPaused;
+                    setIsPaused(nextPaused);
+                    if (!nextPaused) setPendingCount(0);
+                }
+            });
+        };
+        el.addEventListener("scroll", handle, { passive: true });
+        return () => {
+            el.removeEventListener("scroll", handle);
+            if (rafId) cancelAnimationFrame(rafId);
+        };
+    }, [ref, isNearBottom]);
+
+    return { isPaused, pendingCount, jumpToBottom, notifyContentGrew, notifyMessageAppended };
+}

--- a/frontend/src/app/chat/useThrottledMessages.ts
+++ b/frontend/src/app/chat/useThrottledMessages.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from "react";
+import { type ChatMessage, useChatStore } from "./chatStore";
+
+/**
+ * rAF-throttled subscription to `chatStore.messages`. The store can emit
+ * dozens of text_delta updates per second during a stream; committing each
+ * one to React causes `<MessageList>` (and every `<Message>` through it)
+ * to re-render at token rate, which starves the main thread above ~60
+ * tokens/s. We coalesce updates into at most one commit per animation
+ * frame — the browser wouldn't paint more than that anyway.
+ */
+export function useThrottledMessages(): ChatMessage[] {
+    const [snapshot, setSnapshot] = useState<ChatMessage[]>(() => useChatStore.getState().messages);
+
+    useEffect(() => {
+        let rafId = 0;
+        let latest: ChatMessage[] = useChatStore.getState().messages;
+
+        const flush = () => {
+            rafId = 0;
+            setSnapshot(latest);
+        };
+
+        const unsubscribe = useChatStore.subscribe((state) => {
+            latest = state.messages;
+            if (rafId === 0) rafId = requestAnimationFrame(flush);
+        });
+
+        // Catch up in case the store changed between render and effect.
+        latest = useChatStore.getState().messages;
+        setSnapshot(latest);
+
+        return () => {
+            unsubscribe();
+            if (rafId !== 0) cancelAnimationFrame(rafId);
+        };
+    }, []);
+
+    return snapshot;
+}

--- a/frontend/src/lib/mockChat.ts
+++ b/frontend/src/lib/mockChat.ts
@@ -1,0 +1,287 @@
+/**
+ * Mock chat transport — isomorphic to `createChatWsClient` (M6.4).
+ *
+ * Same signature shape (`url`, `onEvent`, `onOpen`, `onClose`, `onError`,
+ * `signal`) and same `WsClient` return type so swapping to the real
+ * `createChatWsClient` in M7.4 is a one-line change at the call site.
+ *
+ * Exposes `sendMock(prompt)` on the returned handle for the chat store to
+ * drive simulated agent turns. The real WS client will receive prompts
+ * via its own `send()` path — same handle shape so the store code is
+ * reused as-is.
+ */
+
+import type { WsClient } from "./ws";
+import type { ChatMap } from "./ws.types";
+
+export interface MockChatClientOptions {
+    url: string;
+    onEvent: (type: ChatMap["type"], message: ChatMap) => void;
+    onError?: (err: Error) => void;
+    onOpen?: () => void;
+    onClose?: (code: number, reason: string, wasClean: boolean) => void;
+    signal?: AbortSignal;
+}
+
+export interface MockChatHandle extends WsClient {
+    /** Simulate the user sending a prompt over the wire. */
+    sendMock(prompt: string): void;
+}
+
+interface Scenario {
+    delayMs: number;
+    event: ChatMap;
+}
+
+const STATIC_OPEN_DELAY_MS = 30;
+
+function buildScenario(prompt: string): Scenario[] {
+    const lower = prompt.toLowerCase();
+
+    if (lower.includes("table") || lower.includes("wo") || lower.includes("work order")) {
+        return buildTableScenario();
+    }
+    if (lower.includes("code") || lower.includes("sql") || lower.includes("query")) {
+        return buildCodeScenario();
+    }
+    if (lower.includes("tool") || lower.includes("query_kb") || lower.includes("search")) {
+        return buildToolCallScenario(prompt);
+    }
+    if (lower.includes("handoff") || lower.includes("investigator")) {
+        return buildHandoffScenario();
+    }
+    return buildDefaultScenario(prompt);
+}
+
+function tokenize(text: string): string[] {
+    return text.match(/\s+|\S+/g) ?? [text];
+}
+
+function streamText(content: string, startAt: number, perTokenMs = 22): Scenario[] {
+    const tokens = tokenize(content);
+    let t = startAt;
+    return tokens.map((tok) => {
+        t += perTokenMs;
+        return { delayMs: t, event: { type: "text_delta", content: tok } };
+    });
+}
+
+function buildDefaultScenario(prompt: string): Scenario[] {
+    const opener = `Got it — you asked about "${prompt.slice(0, 60)}${prompt.length > 60 ? "…" : ""}".\n\n`;
+    const body =
+        "Here's what I can tell you from current telemetry:\n\n" +
+        "- **Cell 02.01** is nominal with a 4.3 % margin on `flow_rate`.\n" +
+        "- Sentinel flagged one anomaly in the last hour, auto-resolved.\n" +
+        "- No open work orders require attention.\n\n" +
+        "Ask me to drill into any of these, or say *show WO table* for a structured view.";
+    const stream: Scenario[] = [];
+    let cursor = STATIC_OPEN_DELAY_MS;
+    for (const block of [opener, body]) {
+        const chunk = streamText(block, cursor);
+        stream.push(...chunk);
+        cursor = chunk[chunk.length - 1]?.delayMs ?? cursor;
+    }
+    stream.push({ delayMs: cursor + 200, event: { type: "done" } });
+    return stream;
+}
+
+function buildTableScenario(): Scenario[] {
+    const intro = "Pulling the latest work orders from the knowledge base.\n\n";
+    const table =
+        "| WO | Cell | Status | Priority | Opened |\n" +
+        "| --- | --- | --- | --- | --- |\n" +
+        "| WO-0142 | 02.01 | In progress | High | 2 h ago |\n" +
+        "| WO-0141 | 02.03 | Awaiting QA | Medium | 5 h ago |\n" +
+        "| WO-0139 | 01.04 | Closed | Low | Yesterday |\n\n" +
+        "Tell me which one to open for a full RCA.";
+
+    const stream: Scenario[] = [];
+    let cursor = STATIC_OPEN_DELAY_MS;
+
+    const introChunk = streamText(intro, cursor);
+    stream.push(...introChunk);
+    cursor = introChunk[introChunk.length - 1]?.delayMs ?? cursor;
+
+    cursor += 120;
+    stream.push({
+        delayMs: cursor,
+        event: {
+            type: "tool_call",
+            name: "query_kb",
+            args: { entity: "work_order", status: ["open", "in_progress"] },
+        },
+    });
+    cursor += 280;
+    stream.push({
+        delayMs: cursor,
+        event: { type: "tool_result", name: "query_kb", summary: "3 rows" },
+    });
+
+    cursor += 60;
+    const tableChunk = streamText(table, cursor);
+    stream.push(...tableChunk);
+    cursor = tableChunk[tableChunk.length - 1]?.delayMs ?? cursor;
+
+    stream.push({ delayMs: cursor + 200, event: { type: "done" } });
+    return stream;
+}
+
+function buildCodeScenario(): Scenario[] {
+    const intro = "Here's the query I'd run against the telemetry store:\n\n";
+    const code =
+        "```sql\n" +
+        "SELECT\n" +
+        "  cell_id,\n" +
+        "  AVG(flow_rate) AS avg_flow,\n" +
+        "  MAX(turbidity) AS peak_turbidity\n" +
+        "FROM signals\n" +
+        "WHERE time > now() - interval '1 hour'\n" +
+        "GROUP BY cell_id\n" +
+        "ORDER BY avg_flow DESC;\n" +
+        "```\n\n" +
+        "Inline reference: `signals.flow_rate` is sampled at 2 Hz, so this " +
+        "aggregates ~7 200 rows per cell per hour.";
+
+    const stream: Scenario[] = [];
+    let cursor = STATIC_OPEN_DELAY_MS;
+    const introChunk = streamText(intro, cursor);
+    stream.push(...introChunk);
+    cursor = introChunk[introChunk.length - 1]?.delayMs ?? cursor;
+    const codeChunk = streamText(code, cursor);
+    stream.push(...codeChunk);
+    cursor = codeChunk[codeChunk.length - 1]?.delayMs ?? cursor;
+    stream.push({ delayMs: cursor + 200, event: { type: "done" } });
+    return stream;
+}
+
+function buildToolCallScenario(prompt: string): Scenario[] {
+    const stream: Scenario[] = [];
+    let cursor = STATIC_OPEN_DELAY_MS;
+
+    cursor += 80;
+    stream.push({
+        delayMs: cursor,
+        event: {
+            type: "tool_call",
+            name: "query_kb",
+            args: { q: prompt.slice(0, 80), limit: 5 },
+        },
+    });
+    cursor += 340;
+    stream.push({
+        delayMs: cursor,
+        event: { type: "tool_result", name: "query_kb", summary: "5 rows" },
+    });
+    cursor += 60;
+
+    const reply =
+        "I pulled five matching entries from the knowledge base. The most " +
+        "relevant one is **RCA-2041** — a similar turbidity excursion on " +
+        "Cell 02.01 three weeks ago, resolved by flushing the prefilter.";
+    const replyChunk = streamText(reply, cursor);
+    stream.push(...replyChunk);
+    cursor = replyChunk[replyChunk.length - 1]?.delayMs ?? cursor;
+    stream.push({ delayMs: cursor + 200, event: { type: "done" } });
+    return stream;
+}
+
+function buildHandoffScenario(): Scenario[] {
+    const stream: Scenario[] = [];
+    let cursor = STATIC_OPEN_DELAY_MS;
+
+    const part1 = "Taking a first look…\n\n";
+    const chunk1 = streamText(part1, cursor);
+    stream.push(...chunk1);
+    cursor = chunk1[chunk1.length - 1]?.delayMs ?? cursor;
+
+    cursor += 140;
+    stream.push({
+        delayMs: cursor,
+        event: {
+            type: "agent_handoff",
+            from: "sentinel",
+            to: "investigator",
+            reason: "anomaly needs root-cause analysis",
+        },
+    });
+
+    cursor += 200;
+    const part2 =
+        "I've run a correlation across the last 24 h of flow and turbidity " +
+        "signals. The excursion aligns with the scheduled backwash cycle — " +
+        "not a genuine anomaly, but the threshold should be widened during " +
+        "cycle windows.";
+    const chunk2 = streamText(part2, cursor);
+    stream.push(...chunk2);
+    cursor = chunk2[chunk2.length - 1]?.delayMs ?? cursor;
+    stream.push({ delayMs: cursor + 200, event: { type: "done" } });
+    return stream;
+}
+
+export function createMockChatClient(options: MockChatClientOptions): MockChatHandle {
+    let aborted = false;
+    let readyState: number = 0;
+    let readyTimer: ReturnType<typeof setTimeout> | null = null;
+    const pendingTimers = new Set<ReturnType<typeof setTimeout>>();
+
+    const clearAllScheduled = () => {
+        for (const t of pendingTimers) clearTimeout(t);
+        pendingTimers.clear();
+    };
+
+    const open = () => {
+        readyState = 1;
+        options.onOpen?.();
+    };
+
+    readyTimer = setTimeout(() => {
+        readyTimer = null;
+        if (!aborted) open();
+    }, 0);
+
+    const close = (code = 1000, reason = "") => {
+        if (aborted) return;
+        aborted = true;
+        if (readyTimer !== null) {
+            clearTimeout(readyTimer);
+            readyTimer = null;
+        }
+        clearAllScheduled();
+        readyState = 3;
+        options.onClose?.(code, reason, code === 1000 || code === 1001);
+    };
+
+    if (options.signal) {
+        if (options.signal.aborted) {
+            close(1000, "aborted");
+        } else {
+            options.signal.addEventListener("abort", () => close(1000, "aborted"), {
+                once: true,
+            });
+        }
+    }
+
+    const sendMock = (prompt: string) => {
+        if (aborted || readyState !== 1) {
+            options.onError?.(new Error("mockChat: send while not OPEN"));
+            return;
+        }
+        const scenario = buildScenario(prompt);
+        for (const step of scenario) {
+            const timer = setTimeout(() => {
+                pendingTimers.delete(timer);
+                if (aborted) return;
+                options.onEvent(step.event.type, step.event);
+            }, step.delayMs);
+            pendingTimers.add(timer);
+        }
+    };
+
+    return {
+        close,
+        sendMock,
+        get readyState() {
+            return readyState;
+        },
+    };
+}


### PR DESCRIPTION
## Summary

First visual consumer of the M6.4 WebSocket factory. A full ChatPanel mounts in the app drawer, wired against a mock transport whose API is **isomorphic to `createChatWsClient`** — the swap to the real `/api/v1/agent/chat` endpoint in M7.4 will be one import line.

## Architecture

- **`lib/mockChat.ts`** — 5 demo scenarios routed by prompt-pattern match: default streaming / markdown table / SQL code block / `query_kb` tool call / Sentinel→Investigator handoff. Cumulative setTimeout (~22ms/token) with jitter.
- **`app/chat/chatStore.ts`** — Zustand store with normalized `UserMessage | AgentMessage`, parts as `(TextPart | ToolCallPart | HandoffPart)[]`, auto-seal on tool/handoff boundaries, text fusion on consecutive `text_delta`.
- **`app/chat/useThrottledMessages.ts`** — rAF coalescing: store emits 60+ text_delta/s, React only sees one commit per animation frame. Kills the per-character re-render footgun.
- **`app/chat/useAutoScroll.ts`** — pauses auto-scroll when user scrolls up >48px, exposes a pending count and smooth `jumpToBottom`.
- **`app/chat/Markdown.tsx`** — `react-markdown` + `remark-gfm` with custom components tokenised end-to-end (p / h1-h3 / a / lists / blockquote / hr / table / pre / inline and block code). No raw slate, no inline hex.
- **`app/chat/Message.tsx`** — user bubble (right, bg-elevated, max-w-80%) / agent row (no bubble, agent Badge in agent color + plain text). Tool calls and handoffs as inline rows. Streaming caret. `memo` with bucket-timestamp comparator to skip re-render on tick.
- **`app/chat/MessageList.tsx`** — `role="log" aria-live="polite"`, empty state text-first, floating "Jump to latest" with pending badge.
- **`app/chat/ChatInput.tsx`** — auto-resize textarea (max 8 rows), Enter submit / Shift+Enter newline (with IME `isComposing` guard), `forwardRef` for Cmd+K focus.
- **`app/chat/ChatPanel.tsx`** — connection indicator + list + input, reacts to `focusRequestId`.

## Integration

- `Drawer.tsx` wrapper: `flex-1 overflow-auto` → `flex min-h-0 flex-1 flex-col` so ChatPanel owns scroll.
- `AppShell.tsx` Cmd+K extended: drawer open → `requestFocus()`; drawer closed → toggle + focus after 240ms (slide duration).

## Scope OUT (per spec, deferred)

- `thinking_delta` → no-op (inline thinking UI lands M8.5)
- `ui_render` → no-op (artifact dispatch lands M7.5 + M8.x)
- No virtualisation (memo + rAF holds ~100 messages easily, revisit if demo pushes >500)

## Acceptance (#38)

- [x] Message sent → response streams with realistic delays
- [x] Markdown tables rendered (sticky header, hairlines, overflow-x)
- [x] Auto-scroll follows bottom unless user has scrolled up (pending badge)
- [x] Colored agent badge via `--ds-agent-*`
- [x] `Cmd/Ctrl+K` focuses input (also toggles drawer if closed)

## Test plan — how to test on your PC

```bash
git fetch
git checkout feat/38-chat-shell-mocked
git pull
make up  # Docker — sinon proxy 500 hors container
# → http://localhost:5173 → login admin/admin123
```

Open the chat drawer (right side or `Cmd+K`) and try these prompts :

| Prompt | What you should see |
|--------|---------------------|
| `hello` (anything generic) | Streaming text response with caret, ~80 tokens |
| `show me the table` (includes "table") | Markdown table with 3 rows, sticky header |
| `give me SQL` (includes "code" or "sql") | Code block with syntax highlighting tokens + inline `signals.flow_rate` |
| `query_kb for P-02` (includes "tool" or "search") | Tool call row with Activity pulse → Check when done |
| `handoff to investigator` (includes "handoff") | Dashed row Sentinel→Investigator badge |

**Stress tests** :
- **Auto-scroll smart** : pendant un stream long, scroll up ≥48px → stream continue, "Jump to latest" apparaît avec badge count. Click = smooth return.
- **Cmd+K** : drawer fermé → ouvre + focus input ; drawer ouvert → focus instant ; déjà dans un input ailleurs → bail-out.
- **Theme switch** : toggle System/Dark/Light pendant un stream, tous les composants suivent.
- **Timestamps** : attendre 30s après un message → "just now" devient "Xs ago" sans re-render de l'historique.

**Gates** (all green) :
- [x] `npm run typecheck`
- [x] `npm run build` (645 kB / 200 kB gz, +55 kB gz from react-markdown chain — previously installed but unused)
- [x] `npm run check` (Biome)
- [x] `npm run test` (9/9, unchanged)

## Swap to real WS (M7.4)

Two trivial changes in `chatStore.ts::ensureConnected` :

```diff
- import { createMockChatClient } from "../../lib/mockChat"
+ import { createChatWsClient } from "../../lib/ws"

- const handle = createMockChatClient({ ... })
+ const handle = createChatWsClient<ChatMap>({ url: "/api/v1/agent/chat", ... })
```

Plus one tweak in `sendMessage` (replace `handle.sendMock(prompt)` with the real send-format agreed with zestones — probably `JSON.stringify({prompt})` on the raw socket or a helper on `WsClient`).

Everything else stays: store, components, rAF batching, auto-scroll, Cmd+K. Zero mock leakage outside `mockChat.ts` and `ensureConnected()`.

Closes #38