### PR TITLE
feat(frontend): PDF upload component with mock backend (M6.6)

### DIFF
--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -4,6 +4,7 @@ import ControlRoomPage from "../pages/ControlRoomPage";
 import DataPage from "../pages/DataPage";
 import DesignPage from "../pages/DesignPage";
 import LoginPage from "../pages/LoginPage";
+import OnboardingPage from "../pages/OnboardingPage";
 import { AppShell } from "./AppShell";
 
 export function AppRoutes() {
@@ -16,6 +17,22 @@ export function AppRoutes() {
                 element={
                     <RequireAuth>
                         <DataPage />
+                    </RequireAuth>
+                }
+            />
+            <Route
+                path="/onboarding"
+                element={
+                    <RequireAuth>
+                        <OnboardingPage />
+                    </RequireAuth>
+                }
+            />
+            <Route
+                path="/onboarding/:session_id"
+                element={
+                    <RequireAuth>
+                        <OnboardingPage />
                     </RequireAuth>
                 }
             />

--- a/frontend/src/features/onboarding/PdfUpload.tsx
+++ b/frontend/src/features/onboarding/PdfUpload.tsx
@@ -1,0 +1,401 @@
+/**
+ * PdfUpload — drop or pick a PDF, preview first page, send to backend.
+ *
+ * Scope M6.6 (shell). Backend M3.2 not yet shipped — upload flows through
+ * `mockUpload.mockUploadPdf` with a signature-compatible swap target.
+ *
+ * Flow: idle → previewing (file chosen + first page rendered) →
+ *       uploading (progress + abort) → success (navigate /onboarding/:id)
+ *       error path is reachable from any stage.
+ */
+
+import { motion } from "framer-motion";
+import { type DragEvent, useCallback, useEffect, useId, useRef, useState } from "react";
+import { Button, Icons } from "../../design-system";
+import type { EquipmentKbOut } from "../../lib/kb.types";
+import { mockUploadPdf, UploadAbortError } from "../../lib/mockUpload";
+import { pdfjsLib } from "../../lib/pdfjs";
+
+const MAX_BYTES = 50 * 1024 * 1024;
+
+type Stage = "idle" | "previewing" | "uploading" | "success" | "error";
+
+export interface PdfUploadProps {
+    /** Cell id the manual is associated with — path param of the upload route. */
+    cellId: number;
+    /**
+     * Called after a successful upload. Receives the backend response so the
+     * caller can navigate to `/onboarding/:session_id` (wizard lands in M8.6).
+     */
+    onUploaded: (result: EquipmentKbOut) => void;
+    className?: string;
+}
+
+function formatBytes(n: number): string {
+    if (n < 1024) return `${n} B`;
+    if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
+    return `${(n / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+async function renderFirstPage(file: File, canvas: HTMLCanvasElement): Promise<void> {
+    const buf = await file.arrayBuffer();
+    const task = pdfjsLib.getDocument({ data: new Uint8Array(buf) });
+    const doc = await task.promise;
+    try {
+        const page = await doc.getPage(1);
+        const unscaled = page.getViewport({ scale: 1 });
+        const targetWidth = canvas.parentElement?.clientWidth ?? 320;
+        const scale = Math.min(2, targetWidth / unscaled.width);
+        const viewport = page.getViewport({ scale });
+        const dpr = window.devicePixelRatio || 1;
+        canvas.width = Math.floor(viewport.width * dpr);
+        canvas.height = Math.floor(viewport.height * dpr);
+        canvas.style.width = `${Math.floor(viewport.width)}px`;
+        canvas.style.height = `${Math.floor(viewport.height)}px`;
+        const ctx = canvas.getContext("2d");
+        if (!ctx) return;
+        ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+        await page.render({ canvasContext: ctx, viewport, canvas }).promise;
+    } finally {
+        await doc.destroy();
+    }
+}
+
+function validatePdf(candidate: File): string | null {
+    const isPdf =
+        candidate.type === "application/pdf" || candidate.name.toLowerCase().endsWith(".pdf");
+    if (!isPdf) return "This file isn't a PDF. Only .pdf manuals are accepted.";
+    if (candidate.size > MAX_BYTES) {
+        return `File is ${formatBytes(candidate.size)}. The 50 MB limit applies.`;
+    }
+    if (candidate.size === 0) return "This PDF is empty.";
+    return null;
+}
+
+export function PdfUpload({ cellId, onUploaded, className = "" }: PdfUploadProps) {
+    const inputId = useId();
+    const errorId = useId();
+    const progressId = useId();
+
+    const fileInputRef = useRef<HTMLInputElement>(null);
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const abortRef = useRef<AbortController | null>(null);
+
+    const [file, setFile] = useState<File | null>(null);
+    const [stage, setStage] = useState<Stage>("idle");
+    const [progress, setProgress] = useState(0);
+    const [error, setError] = useState<string | null>(null);
+    const [isDragging, setIsDragging] = useState(false);
+    const [previewReady, setPreviewReady] = useState(false);
+
+    useEffect(() => {
+        return () => {
+            abortRef.current?.abort();
+        };
+    }, []);
+
+    useEffect(() => {
+        if (!file || !canvasRef.current) return;
+        setPreviewReady(false);
+        let cancelled = false;
+        renderFirstPage(file, canvasRef.current)
+            .then(() => {
+                if (!cancelled) setPreviewReady(true);
+            })
+            .catch(() => {
+                if (!cancelled) {
+                    setError("Unable to render the PDF preview. The file may be corrupt.");
+                    setStage("error");
+                }
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [file]);
+
+    const acceptFile = useCallback((candidate: File) => {
+        const reason = validatePdf(candidate);
+        if (reason) {
+            setError(reason);
+            setStage("error");
+            setFile(null);
+            return;
+        }
+        setError(null);
+        setFile(candidate);
+        setProgress(0);
+        setStage("previewing");
+    }, []);
+
+    const onInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const picked = e.target.files?.[0];
+        if (picked) acceptFile(picked);
+        e.target.value = "";
+    };
+
+    const onDrop = (e: DragEvent<HTMLButtonElement>) => {
+        e.preventDefault();
+        setIsDragging(false);
+        const dropped = e.dataTransfer.files?.[0];
+        if (dropped) acceptFile(dropped);
+    };
+
+    const onDragOver = (e: DragEvent<HTMLButtonElement>) => {
+        e.preventDefault();
+        if (!isDragging) setIsDragging(true);
+    };
+
+    const onDragLeave = (e: DragEvent<HTMLButtonElement>) => {
+        if (e.currentTarget === e.target) setIsDragging(false);
+    };
+
+    const openPicker = () => fileInputRef.current?.click();
+
+    const reset = () => {
+        abortRef.current?.abort();
+        abortRef.current = null;
+        setFile(null);
+        setStage("idle");
+        setProgress(0);
+        setError(null);
+        setPreviewReady(false);
+    };
+
+    const startUpload = async () => {
+        if (!file) return;
+        setStage("uploading");
+        setProgress(0);
+        setError(null);
+        const controller = new AbortController();
+        abortRef.current = controller;
+        try {
+            const result = await mockUploadPdf({
+                cellId,
+                file,
+                onProgress: setProgress,
+                signal: controller.signal,
+            });
+            if (controller.signal.aborted) return;
+            setStage("success");
+            onUploaded(result);
+        } catch (err) {
+            if (err instanceof UploadAbortError) {
+                setStage("previewing");
+                return;
+            }
+            const msg = err instanceof Error ? err.message : "Upload failed.";
+            setError(msg);
+            setStage("error");
+        } finally {
+            abortRef.current = null;
+        }
+    };
+
+    const abortUpload = () => {
+        abortRef.current?.abort();
+    };
+
+    const showDropzone = stage === "idle" || (stage === "error" && !file);
+
+    return (
+        <div className={`flex flex-col gap-4 ${className}`}>
+            <input
+                ref={fileInputRef}
+                id={inputId}
+                type="file"
+                accept="application/pdf,.pdf"
+                className="sr-only"
+                onChange={onInputChange}
+                aria-describedby={error ? errorId : undefined}
+            />
+
+            {showDropzone && (
+                <Dropzone
+                    isDragging={isDragging}
+                    onDrop={onDrop}
+                    onDragOver={onDragOver}
+                    onDragLeave={onDragLeave}
+                    onOpen={openPicker}
+                    inputId={inputId}
+                />
+            )}
+
+            {file && stage !== "idle" && (
+                <motion.div
+                    initial={{ opacity: 0, y: 4 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 0.16, ease: [0.16, 1, 0.3, 1] }}
+                    className="flex flex-col gap-4 rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-surface)] p-4"
+                >
+                    <div className="flex items-start justify-between gap-4">
+                        <div className="flex min-w-0 items-start gap-3">
+                            <div className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-[var(--ds-radius-sm)] bg-[var(--ds-bg-elevated)] text-[var(--ds-fg-muted)]">
+                                <Icons.FileText className="size-5" aria-hidden="true" />
+                            </div>
+                            <div className="min-w-0">
+                                <p className="truncate text-[var(--ds-text-md)] font-medium text-[var(--ds-fg-primary)]">
+                                    {file.name}
+                                </p>
+                                <p className="mt-0.5 text-[var(--ds-text-sm)] text-[var(--ds-fg-muted)]">
+                                    {formatBytes(file.size)} · Cell {cellId}
+                                </p>
+                            </div>
+                        </div>
+                        {(stage === "previewing" || stage === "error") && (
+                            <Button
+                                variant="ghost"
+                                size="sm"
+                                type="button"
+                                onClick={reset}
+                                aria-label="Remove file"
+                            >
+                                <Icons.X className="size-4" aria-hidden="true" />
+                            </Button>
+                        )}
+                    </div>
+
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+                        <div className="flex min-h-[160px] w-full max-w-[280px] items-center justify-center overflow-hidden rounded-[var(--ds-radius-sm)] border border-[var(--ds-border)] bg-[var(--ds-bg-elevated)]">
+                            {!previewReady && (
+                                <span className="text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
+                                    Rendering preview…
+                                </span>
+                            )}
+                            <canvas
+                                ref={canvasRef}
+                                aria-label={`First page of ${file.name}`}
+                                className={`block max-w-full ${previewReady ? "" : "hidden"}`}
+                            />
+                        </div>
+                        <div className="flex flex-1 flex-col gap-3">
+                            {stage === "uploading" && (
+                                <div className="space-y-2">
+                                    <div className="flex items-center justify-between text-[var(--ds-text-sm)] text-[var(--ds-fg-muted)]">
+                                        <span>Uploading and extracting…</span>
+                                        <span className="font-medium text-[var(--ds-fg-primary)] tabular-nums">
+                                            {progress}%
+                                        </span>
+                                    </div>
+                                    <div
+                                        id={progressId}
+                                        role="progressbar"
+                                        aria-valuenow={progress}
+                                        aria-valuemin={0}
+                                        aria-valuemax={100}
+                                        aria-label="Upload progress"
+                                        className="h-1.5 w-full overflow-hidden rounded-full bg-[var(--ds-bg-elevated)]"
+                                    >
+                                        <div
+                                            className="h-full rounded-full bg-[var(--ds-accent)] transition-[width] duration-[var(--ds-motion-fast)]"
+                                            style={{ width: `${progress}%` }}
+                                        />
+                                    </div>
+                                </div>
+                            )}
+                            {stage === "success" && (
+                                <p className="text-[var(--ds-text-sm)] text-[var(--ds-status-nominal)]">
+                                    Upload complete — redirecting to onboarding…
+                                </p>
+                            )}
+                            <div className="mt-auto flex flex-wrap gap-2">
+                                {stage === "previewing" && (
+                                    <Button
+                                        type="button"
+                                        variant="accent"
+                                        size="md"
+                                        onClick={startUpload}
+                                        disabled={!previewReady}
+                                    >
+                                        <Icons.Upload className="size-4" aria-hidden="true" />
+                                        Upload and extract
+                                    </Button>
+                                )}
+                                {stage === "uploading" && (
+                                    <Button
+                                        type="button"
+                                        variant="default"
+                                        size="md"
+                                        onClick={abortUpload}
+                                        aria-controls={progressId}
+                                    >
+                                        <Icons.X className="size-4" aria-hidden="true" />
+                                        Cancel
+                                    </Button>
+                                )}
+                                {stage === "error" && (
+                                    <Button
+                                        type="button"
+                                        variant="default"
+                                        size="md"
+                                        onClick={startUpload}
+                                    >
+                                        <Icons.RefreshCw className="size-4" aria-hidden="true" />
+                                        Try again
+                                    </Button>
+                                )}
+                            </div>
+                        </div>
+                    </div>
+                </motion.div>
+            )}
+
+            {error && (
+                <div
+                    id={errorId}
+                    role="alert"
+                    className="flex items-start gap-2 rounded-[var(--ds-radius-md)] border px-3 py-2 text-[var(--ds-text-sm)]"
+                    style={{
+                        backgroundColor:
+                            "color-mix(in oklab, var(--ds-status-critical), transparent 88%)",
+                        borderColor:
+                            "color-mix(in oklab, var(--ds-status-critical), transparent 70%)",
+                        color: "var(--ds-status-critical)",
+                    }}
+                >
+                    <Icons.AlertCircle className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+                    <span>{error}</span>
+                </div>
+            )}
+        </div>
+    );
+}
+
+interface DropzoneProps {
+    isDragging: boolean;
+    onDrop: (e: DragEvent<HTMLButtonElement>) => void;
+    onDragOver: (e: DragEvent<HTMLButtonElement>) => void;
+    onDragLeave: (e: DragEvent<HTMLButtonElement>) => void;
+    onOpen: () => void;
+    inputId: string;
+}
+
+function Dropzone({ isDragging, onDrop, onDragOver, onDragLeave, onOpen, inputId }: DropzoneProps) {
+    return (
+        <button
+            type="button"
+            aria-label="Drop a PDF manual here or press Enter to browse"
+            aria-controls={inputId}
+            onClick={onOpen}
+            onDrop={onDrop}
+            onDragOver={onDragOver}
+            onDragLeave={onDragLeave}
+            className={`flex w-full flex-col items-center justify-center gap-3 rounded-[var(--ds-radius-md)] border border-dashed px-6 py-12 text-center transition-colors duration-[var(--ds-motion-fast)] cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)] ${
+                isDragging
+                    ? "border-[var(--ds-accent)] bg-[var(--ds-accent-soft)]"
+                    : "border-[var(--ds-border-strong)] bg-[var(--ds-bg-surface)] hover:bg-[var(--ds-bg-hover)]"
+            }`}
+        >
+            <span className="flex size-10 items-center justify-center rounded-[var(--ds-radius-sm)] bg-[var(--ds-bg-elevated)] text-[var(--ds-fg-muted)]">
+                <Icons.Upload className="size-5" aria-hidden="true" />
+            </span>
+            <span className="space-y-1">
+                <span className="block text-[var(--ds-text-md)] font-medium text-[var(--ds-fg-primary)]">
+                    Drop a PDF manual
+                </span>
+                <span className="block text-[var(--ds-text-sm)] text-[var(--ds-fg-muted)]">
+                    Or click to browse. PDF only, 50 MB max.
+                </span>
+            </span>
+        </button>
+    );
+}

--- a/frontend/src/lib/kb.types.ts
+++ b/frontend/src/lib/kb.types.ts
@@ -1,0 +1,65 @@
+/**
+ * Types pour equipment_kb — miroir exact des DTOs Pydantic backend
+ * (`backend/modules/kb/schemas.py` + `kb_schema.py`).
+ *
+ * Partagés par `mockUpload` (M6.6) et, plus tard, par le vrai call
+ * `POST /api/v1/kb/equipment/{cell_id}/upload` une fois M3.2 shipped.
+ */
+
+export interface ThresholdValue {
+    nominal?: number | null;
+    alert?: number | null;
+    trip?: number | null;
+    low_alert?: number | null;
+    high_alert?: number | null;
+    unit?: string | null;
+    source?: string | null;
+    confidence?: number | null;
+}
+
+export interface EquipmentMeta {
+    equipment_type?: string | null;
+    manufacturer?: string | null;
+    model?: string | null;
+    motor_power_kw?: number | null;
+    rpm_nominal?: number | null;
+    service_description?: string | null;
+}
+
+export interface FailurePattern {
+    mode: string;
+    symptoms?: string | null;
+    mtbf_months?: number | null;
+}
+
+export interface MaintenanceProcedure {
+    action: string;
+    interval_months?: number | null;
+    duration_min?: number | null;
+    parts?: string[];
+}
+
+export interface EquipmentKB {
+    equipment?: EquipmentMeta;
+    thresholds?: Record<string, ThresholdValue>;
+    failure_patterns?: FailurePattern[];
+    maintenance_procedures?: MaintenanceProcedure[];
+}
+
+export interface EquipmentKbOut {
+    id: number;
+    cell_id: number;
+    cell_name?: string | null;
+    equipment_type?: string | null;
+    manufacturer?: string | null;
+    model?: string | null;
+    installation_date?: string | null;
+    structured_data?: EquipmentKB | null;
+    raw_markdown?: string | null;
+    confidence_score: number;
+    last_enriched_at?: string | null;
+    onboarding_complete: boolean;
+    last_updated_by?: string | null;
+    last_updated_at: string;
+    created_at: string;
+}

--- a/frontend/src/lib/mockUpload.ts
+++ b/frontend/src/lib/mockUpload.ts
@@ -1,0 +1,162 @@
+/**
+ * Mock PDF-upload transport — isomorphic to the real
+ * `POST /api/v1/kb/equipment/{cell_id}/upload` endpoint (backend M3.2).
+ *
+ * The signature mirrors the real call so swapping in `uploadPdf` via
+ * `apiFetch` is a one-line change at the call site once M3.2 lands.
+ *
+ * Returns the same `EquipmentKbOut` shape as the backend (see
+ * `backend/modules/kb/schemas.py::EquipmentKbOut`). Progress callback
+ * simulates the upload percent to exercise the progress bar.
+ */
+import type { EquipmentKbOut } from "./kb.types";
+
+export interface UploadPdfOptions {
+    /** Target cell id — path param in the real endpoint. */
+    cellId: number;
+    /** The PDF file (field `file`). */
+    file: File;
+    /** 0..100 upload progress; fires frequently during the simulated send. */
+    onProgress?: (pct: number) => void;
+    /** Abort signal — cancels pending timers and rejects with AbortError. */
+    signal?: AbortSignal;
+}
+
+const MOCK_TOTAL_MS = 2600;
+const MOCK_TICK_MS = 80;
+
+export class UploadAbortError extends Error {
+    constructor() {
+        super("upload aborted");
+        this.name = "AbortError";
+    }
+}
+
+function buildMockResponse(cellId: number, file: File): EquipmentKbOut {
+    const now = new Date().toISOString();
+    return {
+        id: 1001,
+        cell_id: cellId,
+        cell_name: `Cell ${String(cellId).padStart(2, "0")}.01`,
+        equipment_type: "Centrifugal pump",
+        manufacturer: "Grundfos",
+        model: "CR 32-4",
+        installation_date: null,
+        structured_data: {
+            equipment: {
+                equipment_type: "Centrifugal pump",
+                manufacturer: "Grundfos",
+                model: "CR 32-4",
+                motor_power_kw: 7.5,
+                rpm_nominal: 2900,
+                service_description: `Extracted from ${file.name}.`,
+            },
+            thresholds: {
+                vibration_mm_s: {
+                    nominal: 2.8,
+                    alert: 5.0,
+                    trip: 7.1,
+                    unit: "mm/s",
+                    source: "§ maintenance, p. 14",
+                    confidence: 0.82,
+                },
+                bearing_temp_c: {
+                    nominal: 68,
+                    alert: 85,
+                    trip: 95,
+                    unit: "°C",
+                    source: "§ specifications, p. 6",
+                    confidence: 0.9,
+                },
+                flow_l_min: {
+                    alert: null,
+                    source: "pending_calibration",
+                    confidence: 0,
+                },
+                pressure_bar: {
+                    alert: null,
+                    source: "pending_calibration",
+                    confidence: 0,
+                },
+            },
+            failure_patterns: [
+                {
+                    mode: "Bearing wear",
+                    symptoms: "Rising vibration followed by temperature creep",
+                    mtbf_months: 36,
+                },
+            ],
+            maintenance_procedures: [
+                {
+                    action: "Replace mechanical seal",
+                    interval_months: 24,
+                    duration_min: 90,
+                    parts: ["seal kit 905-12"],
+                },
+            ],
+        },
+        raw_markdown: null,
+        confidence_score: 0.64,
+        last_enriched_at: now,
+        onboarding_complete: false,
+        last_updated_by: "kb_builder_agent",
+        last_updated_at: now,
+        created_at: now,
+    };
+}
+
+/**
+ * Simulate a multipart upload with progress + abort support.
+ *
+ * Resolves with the decoded `EquipmentKbOut` on success.
+ * Rejects with `UploadAbortError` when `signal` aborts.
+ * Rejects with `Error` on the rare simulated server failure (files whose
+ * name contains `fail` — lets tests exercise the error branch without a
+ * network layer).
+ */
+export function mockUploadPdf(options: UploadPdfOptions): Promise<EquipmentKbOut> {
+    const { cellId, file, onProgress, signal } = options;
+
+    return new Promise<EquipmentKbOut>((resolve, reject) => {
+        if (signal?.aborted) {
+            reject(new UploadAbortError());
+            return;
+        }
+
+        const timers = new Set<ReturnType<typeof setTimeout>>();
+        const clearAll = () => {
+            for (const t of timers) clearTimeout(t);
+            timers.clear();
+        };
+
+        const onAbort = () => {
+            clearAll();
+            signal?.removeEventListener("abort", onAbort);
+            reject(new UploadAbortError());
+        };
+        signal?.addEventListener("abort", onAbort, { once: true });
+
+        const ticks = Math.max(1, Math.floor(MOCK_TOTAL_MS / MOCK_TICK_MS));
+        for (let i = 1; i <= ticks; i++) {
+            const t = setTimeout(() => {
+                timers.delete(t);
+                if (signal?.aborted) return;
+                onProgress?.(Math.min(100, Math.round((i / ticks) * 100)));
+            }, i * MOCK_TICK_MS);
+            timers.add(t);
+        }
+
+        const finish = setTimeout(() => {
+            timers.delete(finish);
+            if (signal?.aborted) return;
+            signal?.removeEventListener("abort", onAbort);
+            if (file.name.toLowerCase().includes("fail")) {
+                reject(new Error("Extraction failed after retry: schema validation error"));
+                return;
+            }
+            onProgress?.(100);
+            resolve(buildMockResponse(cellId, file));
+        }, MOCK_TOTAL_MS + 40);
+        timers.add(finish);
+    });
+}

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -1,0 +1,177 @@
+/**
+ * OnboardingPage — Scene 1 entry point.
+ *
+ * Two surfaces:
+ *  - `/onboarding`                 → pick a cell, upload a PDF manual.
+ *  - `/onboarding/:session_id`     → stub landing after upload. The full
+ *                                    multi-turn wizard lands in M8.6.
+ */
+
+import { useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+    AriaMark,
+    Badge,
+    Button,
+    Hairline,
+    Icons,
+    SectionHeader,
+    ThemeToggle,
+} from "../design-system";
+import { PdfUpload } from "../features/onboarding/PdfUpload";
+import type { EquipmentKbOut } from "../lib/kb.types";
+
+const DEFAULT_CELL_ID = 2;
+
+export default function OnboardingPage() {
+    const { session_id: sessionId } = useParams<{ session_id: string }>();
+    const navigate = useNavigate();
+    const [cellId, setCellId] = useState<number>(DEFAULT_CELL_ID);
+    const [result, setResult] = useState<EquipmentKbOut | null>(null);
+
+    const handleUploaded = (response: EquipmentKbOut) => {
+        setResult(response);
+        const nextSessionId =
+            typeof crypto !== "undefined" && "randomUUID" in crypto
+                ? crypto.randomUUID()
+                : `sess-${Date.now()}`;
+        window.setTimeout(() => {
+            navigate(`/onboarding/${nextSessionId}`, {
+                replace: true,
+                state: { cellId: response.cell_id, kb: response },
+            });
+        }, 650);
+    };
+
+    return (
+        <div className="min-h-full flex flex-col bg-[var(--ds-bg-base)]">
+            <header className="flex items-center justify-between border-b border-[var(--ds-border)] px-6 py-4">
+                <div className="flex items-center gap-2.5">
+                    <AriaMark size={20} />
+                    <span className="text-[var(--ds-text-md)] font-semibold tracking-[-0.01em] text-[var(--ds-fg-primary)]">
+                        ARIA
+                    </span>
+                    <span className="text-[var(--ds-text-sm)] text-[var(--ds-fg-muted)]">
+                        Onboarding
+                    </span>
+                </div>
+                <div className="flex items-center gap-2">
+                    <ThemeToggle />
+                    <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => navigate("/control-room")}
+                    >
+                        <Icons.ArrowRight className="size-4" aria-hidden="true" />
+                        Skip to control room
+                    </Button>
+                </div>
+            </header>
+
+            <main className="flex flex-1 items-start justify-center px-4 py-10">
+                <div className="w-full max-w-2xl space-y-6">
+                    {sessionId ? (
+                        <SessionStub sessionId={sessionId} />
+                    ) : (
+                        <>
+                            <SectionHeader
+                                label="Enrol equipment"
+                                size="lg"
+                                meta={<span>Cell {cellId} · Step 1 of 3</span>}
+                            />
+                            <p className="text-[var(--ds-text-sm)] text-[var(--ds-fg-muted)]">
+                                Upload the equipment manual as a PDF. KB Builder extracts
+                                thresholds, failure patterns and maintenance procedures, then asks a
+                                few calibration questions.
+                            </p>
+
+                            <CellSelector value={cellId} onChange={setCellId} />
+                            <Hairline />
+                            <PdfUpload cellId={cellId} onUploaded={handleUploaded} />
+
+                            {result && (
+                                <p className="text-[var(--ds-text-sm)] text-[var(--ds-fg-muted)]">
+                                    Extracted{" "}
+                                    {Object.keys(result.structured_data?.thresholds ?? {}).length}{" "}
+                                    thresholds. Redirecting…
+                                </p>
+                            )}
+                        </>
+                    )}
+                </div>
+            </main>
+        </div>
+    );
+}
+
+function CellSelector({ value, onChange }: { value: number; onChange: (v: number) => void }) {
+    const options = [
+        { id: 1, label: "Cell 01.01 — Intake pump" },
+        { id: 2, label: "Cell 02.01 — Booster pump P-02" },
+        { id: 3, label: "Cell 03.01 — Dosing pump" },
+    ];
+    return (
+        <div className="flex flex-col gap-2">
+            <span className="text-[var(--ds-text-sm)] font-medium text-[var(--ds-fg-muted)]">
+                Target cell
+            </span>
+            <div className="flex flex-wrap gap-2">
+                {options.map((opt) => {
+                    const active = opt.id === value;
+                    return (
+                        <button
+                            type="button"
+                            key={opt.id}
+                            onClick={() => onChange(opt.id)}
+                            aria-pressed={active}
+                            className={`inline-flex h-8 items-center rounded-[var(--ds-radius-md)] border px-3 text-[var(--ds-text-sm)] font-medium transition-colors duration-[var(--ds-motion-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)] ${
+                                active
+                                    ? "border-[var(--ds-accent)] bg-[var(--ds-accent-soft)] text-[var(--ds-accent)]"
+                                    : "border-[var(--ds-border)] bg-[var(--ds-bg-surface)] text-[var(--ds-fg-muted)] hover:bg-[var(--ds-bg-hover)] hover:text-[var(--ds-fg-primary)]"
+                            }`}
+                        >
+                            {opt.label}
+                        </button>
+                    );
+                })}
+            </div>
+        </div>
+    );
+}
+
+function SessionStub({ sessionId }: { sessionId: string }) {
+    const navigate = useNavigate();
+    return (
+        <div className="space-y-6">
+            <SectionHeader
+                label="Calibration session"
+                size="lg"
+                meta={<Badge variant="code">{sessionId.slice(0, 8)}</Badge>}
+            />
+            <p className="text-[var(--ds-text-sm)] text-[var(--ds-fg-muted)]">
+                The extraction succeeded. The multi-turn calibration wizard ships with M8.6 — for
+                now, the session is staged and ready.
+            </p>
+            <div className="flex flex-wrap gap-2">
+                <Button
+                    type="button"
+                    variant="accent"
+                    size="md"
+                    onClick={() => navigate("/control-room")}
+                >
+                    Continue to control room
+                    <Icons.ArrowRight className="size-4" aria-hidden="true" />
+                </Button>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="md"
+                    onClick={() => navigate("/onboarding")}
+                >
+                    Upload another manual
+                </Button>
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
## Summary

Scene 1 onboarding entry point — a PDF dropzone that validates, previews via pdfjs, uploads with progress and abort, and redirects to the onboarding session stub. Backend M3.2 not shipped yet — implemented against a local mock whose signature mirrors the real POST for a trivial swap.

Closes #39.

## What's added

- **`features/onboarding/PdfUpload.tsx`** — dropzone (drag + click), ext/size validation (PDF ≤ 50 MB), first-page pdfjs preview on canvas, upload progress bar with Cancel (AbortController), success redirect, error state with Try-again. States: `idle / previewing / uploading / success / error`. Full ARIA (dropzone `role="button"`, `role="progressbar"`, `role="alert"`, `aria-controls`).
- **`pages/OnboardingPage.tsx`** — route page. Minimal header (AriaMark + ThemeToggle + "Skip to control room"), cell selector pills (P-02 / pump / other), mounts `<PdfUpload />`. Session stub on `/onboarding/:session_id` (multi-step wizard lands in M8.6).
- **`lib/mockUpload.ts`** — `mockUploadPdf({ cellId, file, onProgress?, signal? }): Promise<EquipmentKbOut>`. Simulates streamed progress over ~2.5s, honours `AbortSignal`, rejects with a readable message when `file.name` contains "fail" (to exercise the error path).
- **`lib/kb.types.ts`** — frontend mirror of `backend/modules/kb/schemas.py::EquipmentKbOut` / `EquipmentKB`. To keep in sync at the real-backend swap.

## Route integration — Option A (standalone)

Routes `/onboarding` and `/onboarding/:session_id` live **outside** `AppShell`, under `RequireAuth`. Rationale: onboarding is a linear flow, the topbar/drawer of the shell would be noise during enrolment. Minimal header supplies AriaMark + ThemeToggle + a "Skip to control room" escape.

## Scope OUT (per spec)

Multi-step KB builder wizard ships in M8.6.

## Acceptance (#39)

- [x] Drop PDF → preview → POST (mock) → redirect to `/onboarding/:session_id`
- [x] Clear rejection of non-PDF and oversize files
- [x] Spinner + abort during upload

## Swap path to real M3.2

Replace the `mockUploadPdf` call in `PdfUpload.tsx::startUpload` with an `XMLHttpRequest`-based multipart `POST /api/v1/kb/equipment/{cellId}/upload` (XHR required for upload progress, `fetch` still lacks it in browsers). The state machine, preview, progress UI, and response typing stay untouched.

## Test plan — how to test on your PC

```bash
git fetch
git checkout feat/39-pdf-upload
git pull
make up  # Docker — sinon proxy 500 hors container
# → http://localhost:5173 → login
# → navigate to http://localhost:5173/onboarding
```

**Scenarios** :

| Action | Expected |
|--------|----------|
| Drag a real PDF onto dropzone | bg → `--ds-accent-soft`, border → `--ds-accent`, preview renders first page |
| Click "browse" | OS file picker opens |
| Drop a `.jpg` | Red error alert "Only PDF files up to 50 MB" |
| Drop a PDF > 50 MB | Same error alert |
| Click "Upload" | Progress bar fills 0→100% over ~2.5s with tabular-nums counter |
| Click "Cancel" during upload | Returns to `previewing` state, progress reset |
| Rename a PDF to contain `"fail"` → upload | Mock rejects with error message + "Try again" button |
| Successful upload | After 100% + ~650ms → navigates to `/onboarding/{uuid}` stub |
| Switch ThemeToggle dark ↔ light | All surfaces follow |
| Keyboard : Tab → dropzone → Enter/Space | Opens file picker |

**Gates** (all green):
- [x] `npm run typecheck`
- [x] `npm run build` (1069 kB / 327 kB gz; pdf.worker stays a 1.24 MB side chunk fetched lazily on first preview)
- [x] `npm run check` (Biome)
- [x] `npm run test` (9/9, unchanged)