### PR TITLE
fix(frontend): route 5 Lucide icons through design-system wrapper

### DIFF
--- a/frontend/src/app/EquipmentPicker.tsx
+++ b/frontend/src/app/EquipmentPicker.tsx
@@ -1,12 +1,5 @@
 import { AnimatePresence, motion } from "framer-motion";
 import {
-    Building2 as RawBuilding2,
-    Cpu as RawCpu,
-    GitBranch as RawGitBranch,
-    Layers as RawLayers,
-    MapPin as RawMapPin,
-} from "lucide-react";
-import {
     type KeyboardEvent as ReactKeyboardEvent,
     useCallback,
     useEffect,
@@ -812,11 +805,11 @@ const LEVEL_ICON: Record<
     TreeLevel,
     React.ComponentType<{ className?: string; strokeWidth?: number }>
 > = {
-    enterprise: RawBuilding2,
-    site: RawMapPin,
-    area: RawLayers,
-    line: RawGitBranch,
-    cell: RawCpu,
+    enterprise: Icons.Building2,
+    site: Icons.MapPin,
+    area: Icons.Layers,
+    line: Icons.GitBranch,
+    cell: Icons.Cpu,
 };
 
 function LevelIcon({ level, className }: { level: TreeLevel; className?: string }) {

--- a/frontend/src/design-system/icons.tsx
+++ b/frontend/src/design-system/icons.tsx
@@ -5,6 +5,7 @@ import {
     AlertTriangle as RawAlertTriangle,
     ArrowRight as RawArrowRight,
     Bot as RawBot,
+    Building2 as RawBuilding2,
     Check as RawCheck,
     ChevronDown as RawChevronDown,
     ChevronLeft as RawChevronLeft,
@@ -14,12 +15,16 @@ import {
     Clock as RawClock,
     Command as RawCommand,
     Copy as RawCopy,
+    Cpu as RawCpu,
     Database as RawDatabase,
     Eye as RawEye,
     FileText as RawFileText,
     Filter as RawFilter,
     Gauge as RawGauge,
+    GitBranch as RawGitBranch,
+    Layers as RawLayers,
     LogOut as RawLogOut,
+    MapPin as RawMapPin,
     MessageSquare as RawMessageSquare,
     Monitor as RawMonitor,
     MoreHorizontal as RawMoreHorizontal,
@@ -61,6 +66,7 @@ export const AlertCircle = styled(RawAlertCircle, "AlertCircle");
 export const AlertTriangle = styled(RawAlertTriangle, "AlertTriangle");
 export const ArrowRight = styled(RawArrowRight, "ArrowRight");
 export const Bot = styled(RawBot, "Bot");
+export const Building2 = styled(RawBuilding2, "Building2");
 export const Check = styled(RawCheck, "Check");
 export const ChevronDown = styled(RawChevronDown, "ChevronDown");
 export const ChevronLeft = styled(RawChevronLeft, "ChevronLeft");
@@ -70,12 +76,16 @@ export const CircleDot = styled(RawCircleDot, "CircleDot");
 export const Clock = styled(RawClock, "Clock");
 export const Command = styled(RawCommand, "Command");
 export const Copy = styled(RawCopy, "Copy");
+export const Cpu = styled(RawCpu, "Cpu");
 export const Database = styled(RawDatabase, "Database");
 export const Eye = styled(RawEye, "Eye");
 export const FileText = styled(RawFileText, "FileText");
 export const Filter = styled(RawFilter, "Filter");
 export const Gauge = styled(RawGauge, "Gauge");
+export const GitBranch = styled(RawGitBranch, "GitBranch");
+export const Layers = styled(RawLayers, "Layers");
 export const LogOut = styled(RawLogOut, "LogOut");
+export const MapPin = styled(RawMapPin, "MapPin");
 export const MessageSquare = styled(RawMessageSquare, "MessageSquare");
 export const Monitor = styled(RawMonitor, "Monitor");
 export const MoreHorizontal = styled(RawMoreHorizontal, "MoreHorizontal");


### PR DESCRIPTION
## Summary

M6.3 follow-up flagged by `dev-frontend-tree` during the ISA-95 tree view refactor (PR #71, commit aa67504): `EquipmentPicker.tsx` was importing 5 icons directly from `lucide-react`, bypassing the centralized `design-system/icons.tsx` wrapper and breaking DESIGN_PLAN §7.

This PR re-exports `Building2`, `MapPin`, `Layers`, `GitBranch`, `Cpu` through the wrapper (same pattern as `ChevronDown`, `Search`, `X`, `Check`, `RefreshCw`), then switches `EquipmentPicker.tsx` to `Icons.*`.

## Changes

- `frontend/src/design-system/icons.tsx` — +10 lines: 5 `Raw*` imports + 5 styled exports, alphabetical.
- `frontend/src/app/EquipmentPicker.tsx` — removes the `lucide-react` direct import block, routes `LEVEL_ICON` map through `Icons.*`.

## Visual impact

Strictly pixel-identical. `LevelIcon` still passes `strokeWidth={1.75}` explicitly, which overrides the wrapper default via `{...props}` spread — final rendered strokeWidth unchanged.

Heads-up for later: the wrapper default is `1.75`, the DESIGN_PLAN §7 says `1.5`. Discrepancy to reconcile once this is merged (either update the doc to match code, or rebase the wrapper to `1.5` — but that changes every icon's look project-wide, out of scope here).

## Test plan

- [x] `npm run typecheck` — green
- [x] `npm run check` — green (biome, 53 files)
- [x] `npm run build` — green (vite 7.3.2, 2495 modules, 1.66s)
- [x] `grep -n 'from "lucide-react"' frontend/src/app/EquipmentPicker.tsx` — empty
- [ ] Tree view visual QA on running app

Closes #81