### PR TITLE
fix(qa): strip SDK-only parsed_output when round-tripping assistant content

### DIFF
--- a/backend/agents/qa/messages_api.py
+++ b/backend/agents/qa/messages_api.py
@@ -134,7 +134,9 @@ async def _stream_one_turn(
     tool_uses: list[ToolUseBlock] = [
         b for b in final_message.content if isinstance(b, ToolUseBlock)
     ]
-    assistant_content = [b.model_dump() for b in final_message.content]
+    assistant_content = [
+        b.model_dump(exclude_none=True, exclude={"parsed_output"}) for b in final_message.content
+    ]
     _ = turn_id  # reserved for future tool_call_started streaming extensions
     return tool_uses, assistant_content
 

--- a/backend/tests/unit/agents/test_qa_agent.py
+++ b/backend/tests/unit/agents/test_qa_agent.py
@@ -38,13 +38,40 @@ from agents.qa import tool_dispatch as qa_tool_dispatch
 # ---------------------------------------------------------------------------
 
 
+def _apply_dump_kwargs(
+    data: dict[str, Any],
+    *,
+    exclude_none: bool = False,
+    exclude: set[str] | None = None,
+) -> dict[str, Any]:
+    """Mimic ``pydantic.BaseModel.model_dump`` kwargs we actually use."""
+    if exclude_none:
+        data = {k: v for k, v in data.items() if v is not None}
+    if exclude:
+        data = {k: v for k, v in data.items() if k not in exclude}
+    return data
+
+
 @dataclass
 class _FakeTextBlock:
     text: str
     type: str = "text"
+    # SDK v0.96.0 adds a client-only ``parsed_output`` attribute on text
+    # blocks for structured outputs. It must NOT round-trip back to the
+    # API. Kept here so tests exercise the real block shape.
+    parsed_output: Any = None
 
-    def model_dump(self) -> dict[str, Any]:
-        return {"type": "text", "text": self.text}
+    def model_dump(
+        self,
+        *,
+        exclude_none: bool = False,
+        exclude: set[str] | None = None,
+    ) -> dict[str, Any]:
+        return _apply_dump_kwargs(
+            {"type": "text", "text": self.text, "parsed_output": self.parsed_output},
+            exclude_none=exclude_none,
+            exclude=exclude,
+        )
 
 
 @dataclass
@@ -54,8 +81,17 @@ class _FakeToolUseBlock:
     input: dict[str, Any]
     type: str = "tool_use"
 
-    def model_dump(self) -> dict[str, Any]:
-        return {"type": "tool_use", "id": self.id, "name": self.name, "input": self.input}
+    def model_dump(
+        self,
+        *,
+        exclude_none: bool = False,
+        exclude: set[str] | None = None,
+    ) -> dict[str, Any]:
+        return _apply_dump_kwargs(
+            {"type": "tool_use", "id": self.id, "name": self.name, "input": self.input},
+            exclude_none=exclude_none,
+            exclude=exclude,
+        )
 
 
 @dataclass
@@ -295,6 +331,34 @@ async def test_mcp_tool_call_streams_tool_call_and_result_summary(patch_qa) -> N
     assert started[0][1]["agent"] == "qa"
     assert completed[0][1]["agent"] == "qa"
     assert isinstance(completed[0][1]["duration_ms"], int)
+
+
+@pytest.mark.asyncio
+async def test_assistant_roundtrip_strips_sdk_only_parsed_output(patch_qa) -> None:
+    """Regression — SDK v0.96.0 sets a client-only ``parsed_output`` on
+    ``TextBlock``. It must NOT be re-POSTed to the API on turn 2, or the
+    server rejects the request with ``Extra inputs are not permitted``.
+    """
+    tool_use = _FakeToolUseBlock(id="tu_1", name="get_oee", input={"cell_id": 2})
+    prose = _FakeTextBlock(text="thinking...", parsed_output={"whatever": 1})
+
+    stream_plans = [
+        ([], [prose, tool_use]),
+        ([], [_FakeTextBlock(text="done")]),
+    ]
+    mcp_results = {"get_oee": _ToolResult(content=json.dumps({"oee": 0.9}))}
+    antr, _, _ = patch_qa(stream_plans=stream_plans, mcp_results=mcp_results)
+
+    ws = _FakeClientWS()
+    await qa.run_qa_turn(ws=ws, messages=[], user_content="OEE?")  # type: ignore[arg-type]
+
+    # Second call is the re-POST carrying the assistant content from turn 1.
+    second_messages = antr.stream_calls[1]["messages"]
+    assistant_msg = next(m for m in second_messages if m["role"] == "assistant")
+    for block in assistant_msg["content"]:
+        assert (
+            "parsed_output" not in block
+        ), "parsed_output must be stripped before round-tripping to the API"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Anthropic Python SDK `v0.96.0` (pinned in `backend/requirements.txt`) attaches a client-only `parsed_output` attribute on `TextBlock` for structured-output parsing. `agents/qa/messages_api.py` rebuilds assistant content via `b.model_dump()`, which serialized that field into the `messages` array re-POSTed on turn 2 — and the API server rejects unknown fields.

Fixed by dumping with `exclude_none=True, exclude={"parsed_output"}` so only API-valid fields round-trip.

## Repro (observed live on multi-turn QA chat)

```
BadRequestError: Error code: 400
{'type':'error','error':{'type':'invalid_request_error',
 'message':'messages.1.content.0.text.parsed_output: Extra inputs are not permitted'}}
```

Any QA turn where the assistant emits text then a tool_use triggers this on the second LLM call.

## Why

Client-only SDK fields (parsing/validation helpers) must not be sent back to the server. `exclude_none=True` keeps us safe if the SDK adds more client-only fields in future minor versions; `exclude={"parsed_output"}` is the explicit belt-and-suspenders for the known field.

## Test plan

- [x] `make backend.format.check` — OK
- [x] `make backend.lint` — OK
- [x] `make backend.typecheck` — only pre-existing `managed.py:174` error (unrelated, untouched by this PR)
- [x] `make backend.test` — local venv is Python 3.9.6 and the codebase uses PEP 604 unions (pre-existing environmental breakage, independent of this PR); added unit test `test_assistant_roundtrip_strips_sdk_only_parsed_output` asserts `parsed_output` is absent from the re-POSTed assistant content on turn 2
- [x] Live smoke: rerun multi-turn QA (first tool_call + follow-up) — turn 2 should no longer 400

## Follow-ups (not in this PR, scope strict)

Same `b.model_dump()` round-trip pattern exists verbatim in:
- `backend/agents/investigator/service.py:186`
- `backend/agents/work_order_generator/service.py:133`
- `backend/agents/qa/managed.py` (M5.4 path — same file family)

These have the identical latent bug and should each get the same one-line fix in a follow-up issue.