### PR TITLE
feat(artifacts): M7.5 registry + Zod dispatcher for ui_render (#44)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
                 "recharts": "^3.8.1",
                 "remark-gfm": "^4.0.1",
                 "tailwindcss": "^4.1.18",
+                "zod": "^3.25.76",
                 "zustand": "^5.0.12"
             },
             "devDependencies": {
@@ -130,6 +131,7 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -655,6 +657,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             },
@@ -703,6 +706,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20.19.0"
             }
@@ -2112,6 +2116,7 @@
             "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -2401,6 +2406,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
             "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -2411,6 +2417,7 @@
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -2558,6 +2565,7 @@
             "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vitest/utils": "4.1.5",
                 "fflate": "^0.8.2",
@@ -2686,6 +2694,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.10.12",
                 "caniuse-lite": "^1.0.30001782",
@@ -5007,6 +5016,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
             "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -5128,6 +5138,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
             "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -5137,6 +5148,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
             "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -5183,6 +5195,7 @@
             "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
             "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/use-sync-external-store": "^0.0.6",
                 "use-sync-external-store": "^1.4.0"
@@ -5297,7 +5310,8 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
             "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/redux-thunk": {
             "version": "3.1.0",
@@ -5986,6 +6000,7 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
             "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.27.0",
                 "fdir": "^6.5.0",
@@ -6061,6 +6076,7 @@
             "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vitest/expect": "4.1.5",
                 "@vitest/mocker": "4.1.5",
@@ -6293,6 +6309,15 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/zod": {
+            "version": "3.25.76",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/colinhacks"
             }
         },
         "node_modules/zustand": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
         "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1",
         "tailwindcss": "^4.1.18",
+        "zod": "^3.25.76",
         "zustand": "^5.0.12"
     },
     "devDependencies": {

--- a/frontend/src/app/chat/Message.tsx
+++ b/frontend/src/app/chat/Message.tsx
@@ -1,4 +1,5 @@
 import { memo } from "react";
+import { ArtifactRenderer } from "../../artifacts";
 import { Badge, Icons, StatusDot } from "../../design-system";
 import type { AgentMessage, AgentPart, UserMessage } from "./chatStore";
 import { Markdown } from "./Markdown";
@@ -135,6 +136,15 @@ function AgentRow({ message, now }: AgentRowProps) {
                 {message.parts.map((part) => {
                     if (part.kind === "tool_call") return <ToolCallRow key={part.id} part={part} />;
                     if (part.kind === "handoff") return <HandoffRow key={part.id} part={part} />;
+                    if (part.kind === "artifact") {
+                        return (
+                            <ArtifactRenderer
+                                key={part.id}
+                                component={part.component}
+                                props={part.props}
+                            />
+                        );
+                    }
                     return (
                         <div key={part.id} className="max-w-full text-[var(--ds-fg-primary)]">
                             <Markdown>{part.content}</Markdown>

--- a/frontend/src/app/chat/chatStore.test.ts
+++ b/frontend/src/app/chat/chatStore.test.ts
@@ -96,7 +96,7 @@ describe("chatStore — real WS integration", () => {
         expect(lastFake().sendSpy).toHaveBeenCalledWith({ type: "user", content: "hi" });
     });
 
-    it("ignores ui_render + thinking_delta bursts without breaking the streaming turn", async () => {
+    it("accumulates ui_render as artifact parts and ignores thinking_delta bursts", async () => {
         const useChatStore = await importStoreFresh();
         useChatStore.getState().sendMessage("investigate");
         lastFake().simulateOpen();
@@ -110,8 +110,8 @@ describe("chatStore — real WS integration", () => {
         for (let i = 0; i < 10; i += 1) {
             lastFake().simulateEvent({
                 type: "ui_render",
-                component: "Chart",
-                props: { idx: i },
+                component: "signal_chart",
+                props: { cell_id: 1, signal_def_id: i },
             });
             lastFake().simulateEvent({
                 type: "thinking_delta",
@@ -124,10 +124,18 @@ describe("chatStore — real WS integration", () => {
             .messages.find((m) => m.id === agentId && m.role === "agent");
         if (!after || after.role !== "agent") throw new Error("agent message missing after burst");
 
+        // thinking_delta is still ignored — no "thinking" parts should land.
         for (const part of after.parts) {
-            expect(part.kind).not.toBe("ui_render");
             expect(part.kind).not.toBe("thinking");
         }
+
+        const artifacts = after.parts.filter((p) => p.kind === "artifact");
+        expect(artifacts).toHaveLength(10);
+        artifacts.forEach((p, idx) => {
+            if (p.kind !== "artifact") throw new Error("expected artifact part");
+            expect(p.component).toBe("signal_chart");
+            expect(p.props).toEqual({ cell_id: 1, signal_def_id: idx });
+        });
         expect(after.streaming).toBe(true);
     });
 

--- a/frontend/src/app/chat/chatStore.ts
+++ b/frontend/src/app/chat/chatStore.ts
@@ -38,7 +38,14 @@ export interface HandoffPart {
     reason: string;
 }
 
-export type AgentPart = ToolCallPart | TextPart | HandoffPart;
+export interface ArtifactPart {
+    kind: "artifact";
+    id: string;
+    component: string;
+    props: Record<string, unknown>;
+}
+
+export type AgentPart = ToolCallPart | TextPart | HandoffPart | ArtifactPart;
 
 export interface AgentMessage {
     id: string;
@@ -188,7 +195,22 @@ export const useChatStore = create<ChatState>((set, get) => {
                 break;
             }
             case "ui_render": {
-                // UI-render widgets land in a later milestone.
+                upsertAgentMessage((msg) => {
+                    const parts = [...msg.parts];
+                    // Seal any ongoing text part so the artifact sits between text runs,
+                    // matching the tool_call insertion pattern above.
+                    const lastIdx = parts.length - 1;
+                    if (parts[lastIdx]?.kind === "text" && (parts[lastIdx] as TextPart).streaming) {
+                        parts[lastIdx] = { ...(parts[lastIdx] as TextPart), streaming: false };
+                    }
+                    parts.push({
+                        kind: "artifact",
+                        id: nextId(internal, "ar"),
+                        component: message.component,
+                        props: message.props,
+                    });
+                    return { ...msg, parts };
+                });
                 break;
             }
             case "done": {

--- a/frontend/src/artifacts/ArtifactRenderer.test.tsx
+++ b/frontend/src/artifacts/ArtifactRenderer.test.tsx
@@ -1,0 +1,77 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ArtifactRenderer } from "./ArtifactRenderer";
+import { registry } from "./registry";
+
+afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+});
+
+describe("ArtifactRenderer", () => {
+    it("renders an unknown fallback when the component is not registered", () => {
+        render(<ArtifactRenderer component="ghost_widget" props={{}} />);
+        expect(screen.getByText(/Unknown artifact: ghost_widget/i)).toBeInTheDocument();
+    });
+
+    it("renders the matching placeholder when props validate", () => {
+        render(
+            <ArtifactRenderer
+                component="alert_banner"
+                props={{
+                    cell_id: 3,
+                    severity: "alert",
+                    message: "Vibration exceeded threshold",
+                    anomaly_id: 77,
+                }}
+            />,
+        );
+        expect(screen.getByText(/Alert banner/i)).toBeInTheDocument();
+        expect(screen.getByText(/cell 3 · alert/i)).toBeInTheDocument();
+    });
+
+    it("renders an invalid-props fallback when the schema rejects the payload", () => {
+        render(
+            <ArtifactRenderer
+                component="signal_chart"
+                // missing required signal_def_id, wrong types for cell_id
+                props={{ cell_id: "not-a-number" }}
+            />,
+        );
+        expect(
+            screen.getByText(/Artifact error: invalid props for signal_chart/i),
+        ).toBeInTheDocument();
+    });
+
+    it("catches runtime render errors via its error boundary", () => {
+        // Silence expected error logs in this assertion path.
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+        const originalAlertBanner = registry.alert_banner;
+        const Boom = () => {
+            throw new Error("boom");
+        };
+        // Inject a throwing component behind a registered name so the dispatcher
+        // reaches the error boundary path (valid lookup + valid schema + throw).
+        registry.alert_banner = Boom;
+
+        try {
+            render(
+                <ArtifactRenderer
+                    component="alert_banner"
+                    props={{
+                        cell_id: 1,
+                        severity: "info",
+                        message: "ok",
+                    }}
+                />,
+            );
+            expect(
+                screen.getByText(/Artifact error: alert_banner failed to render/i),
+            ).toBeInTheDocument();
+        } finally {
+            registry.alert_banner = originalAlertBanner;
+            errorSpy.mockRestore();
+        }
+    });
+});

--- a/frontend/src/artifacts/ArtifactRenderer.tsx
+++ b/frontend/src/artifacts/ArtifactRenderer.tsx
@@ -1,0 +1,132 @@
+import { motion } from "framer-motion";
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Badge, Card, Icons } from "../design-system";
+import { fadeInUp } from "../design-system/motion";
+import { getArtifactComponent } from "./registry";
+import { type ArtifactComponentName, schemas } from "./schemas";
+
+type FallbackKind = "unknown" | "invalid" | "runtime";
+
+interface FallbackProps {
+    kind: FallbackKind;
+    name: string;
+    detail?: string;
+}
+
+/**
+ * Discrete, DS-tokens-only error surface — never leaks a stacktrace into the
+ * chat. Each variant maps to a failure mode the dispatcher knows about.
+ */
+function ArtifactFallback({ kind, name, detail }: FallbackProps) {
+    const title =
+        kind === "unknown"
+            ? `Unknown artifact: ${name}`
+            : kind === "invalid"
+              ? `Artifact error: invalid props for ${name}`
+              : `Artifact error: ${name} failed to render`;
+
+    return (
+        <Card padding="sm">
+            <div className="flex items-start gap-2">
+                <Icons.AlertTriangle
+                    aria-hidden
+                    className="size-4 flex-none text-[var(--ds-fg-subtle)]"
+                />
+                <div className="flex min-w-0 flex-col gap-1">
+                    <div className="flex items-center gap-2">
+                        <Badge variant="default" size="sm">
+                            Artifact
+                        </Badge>
+                        <span className="text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+                            {title}
+                        </span>
+                    </div>
+                    {detail && (
+                        <span className="font-mono text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)] break-words">
+                            {detail}
+                        </span>
+                    )}
+                </div>
+            </div>
+        </Card>
+    );
+}
+
+interface BoundaryProps {
+    component: string;
+    children: ReactNode;
+}
+
+interface BoundaryState {
+    hasError: boolean;
+    message?: string;
+}
+
+/**
+ * Class error boundary — hooks don't catch render errors. Scoped per-artifact
+ * so a single bad payload can't take down the whole message list.
+ */
+class ArtifactErrorBoundary extends Component<BoundaryProps, BoundaryState> {
+    state: BoundaryState = { hasError: false };
+
+    static getDerivedStateFromError(error: unknown): BoundaryState {
+        const message = error instanceof Error ? error.message : String(error);
+        return { hasError: true, message };
+    }
+
+    componentDidCatch(error: unknown, info: ErrorInfo): void {
+        // Keep it visible in dev — swallowing errors here would hide real bugs.
+        console.error(`[ArtifactRenderer] ${this.props.component} threw:`, error, info);
+    }
+
+    render(): ReactNode {
+        if (this.state.hasError) {
+            return (
+                <ArtifactFallback
+                    kind="runtime"
+                    name={this.props.component}
+                    detail={this.state.message}
+                />
+            );
+        }
+        return this.props.children;
+    }
+}
+
+export interface ArtifactRendererProps {
+    component: string;
+    props: unknown;
+}
+
+/**
+ * Resolve a `ui_render` event to a React node.
+ *
+ * Flow (mirrors issue #44):
+ *  1. Lookup name in registry → unknown → fallback.
+ *  2. Parse props against the Zod schema → invalid → fallback.
+ *  3. Mount behind an error boundary + `fadeInUp` motion wrap.
+ *
+ * No fetching, no data shaping — placeholders receive the parsed props as-is.
+ */
+export function ArtifactRenderer({ component, props }: ArtifactRendererProps) {
+    const Component = getArtifactComponent(component);
+    if (!Component) {
+        return <ArtifactFallback kind="unknown" name={component} />;
+    }
+
+    const schema = schemas[component as ArtifactComponentName];
+    const parseResult = schema.safeParse(props);
+    if (!parseResult.success) {
+        const issue = parseResult.error.issues[0];
+        const detail = issue ? `${issue.path.join(".") || "(root)"} — ${issue.message}` : undefined;
+        return <ArtifactFallback kind="invalid" name={component} detail={detail} />;
+    }
+
+    return (
+        <ArtifactErrorBoundary component={component}>
+            <motion.div variants={fadeInUp} initial="hidden" animate="visible">
+                <Component {...parseResult.data} />
+            </motion.div>
+        </ArtifactErrorBoundary>
+    );
+}

--- a/frontend/src/artifacts/index.ts
+++ b/frontend/src/artifacts/index.ts
@@ -1,0 +1,5 @@
+export type { ArtifactRendererProps } from "./ArtifactRenderer";
+export { ArtifactRenderer } from "./ArtifactRenderer";
+export { getArtifactComponent, registry } from "./registry";
+export type { ArtifactComponentName } from "./schemas";
+export { schemas } from "./schemas";

--- a/frontend/src/artifacts/placeholders/AlertBanner.tsx
+++ b/frontend/src/artifacts/placeholders/AlertBanner.tsx
@@ -1,0 +1,11 @@
+// Placeholder for M8.1. Real component TBD.
+import type { AlertBannerProps } from "../schemas";
+import { dumpJson, PlaceholderShell } from "./PlaceholderShell";
+
+export function AlertBanner(props: AlertBannerProps) {
+    return (
+        <PlaceholderShell label="Alert banner" detail={`cell ${props.cell_id} · ${props.severity}`}>
+            <pre className="whitespace-pre-wrap">{dumpJson(props)}</pre>
+        </PlaceholderShell>
+    );
+}

--- a/frontend/src/artifacts/placeholders/BarChart.tsx
+++ b/frontend/src/artifacts/placeholders/BarChart.tsx
@@ -1,0 +1,11 @@
+// Placeholder for M8.3. Real component TBD.
+import type { BarChartProps } from "../schemas";
+import { dumpJson, PlaceholderShell } from "./PlaceholderShell";
+
+export function BarChart(props: BarChartProps) {
+    return (
+        <PlaceholderShell label="Bar chart" detail={`${props.title} · ${props.bars.length} bars`}>
+            <pre className="whitespace-pre-wrap">{dumpJson(props)}</pre>
+        </PlaceholderShell>
+    );
+}

--- a/frontend/src/artifacts/placeholders/DiagnosticCard.tsx
+++ b/frontend/src/artifacts/placeholders/DiagnosticCard.tsx
@@ -1,0 +1,15 @@
+// Placeholder for M8.1. Real component TBD.
+import type { DiagnosticCardProps } from "../schemas";
+import { dumpJson, PlaceholderShell } from "./PlaceholderShell";
+
+export function DiagnosticCard(props: DiagnosticCardProps) {
+    const confidencePct = Math.round(props.confidence * 100);
+    return (
+        <PlaceholderShell
+            label="Diagnostic"
+            detail={`cell ${props.cell_id} · confidence ${confidencePct}%`}
+        >
+            <pre className="whitespace-pre-wrap">{dumpJson(props)}</pre>
+        </PlaceholderShell>
+    );
+}

--- a/frontend/src/artifacts/placeholders/EquipmentKbCard.tsx
+++ b/frontend/src/artifacts/placeholders/EquipmentKbCard.tsx
@@ -1,0 +1,11 @@
+// Placeholder for M8.2. Real component TBD.
+import type { EquipmentKbCardProps } from "../schemas";
+import { dumpJson, PlaceholderShell } from "./PlaceholderShell";
+
+export function EquipmentKbCard(props: EquipmentKbCardProps) {
+    return (
+        <PlaceholderShell label="Equipment KB" detail={`cell ${props.cell_id}`}>
+            <pre className="whitespace-pre-wrap">{dumpJson(props)}</pre>
+        </PlaceholderShell>
+    );
+}

--- a/frontend/src/artifacts/placeholders/KbProgress.tsx
+++ b/frontend/src/artifacts/placeholders/KbProgress.tsx
@@ -1,0 +1,15 @@
+// Placeholder for M8.2. Real component TBD.
+import type { KbProgressProps } from "../schemas";
+import { dumpJson, PlaceholderShell } from "./PlaceholderShell";
+
+export function KbProgress(props: KbProgressProps) {
+    const done = props.steps.filter((s) => s.status === "done").length;
+    return (
+        <PlaceholderShell
+            label="KB progress"
+            detail={`cell ${props.cell_id} · ${done}/${props.steps.length} done`}
+        >
+            <pre className="whitespace-pre-wrap">{dumpJson(props)}</pre>
+        </PlaceholderShell>
+    );
+}

--- a/frontend/src/artifacts/placeholders/PatternMatch.tsx
+++ b/frontend/src/artifacts/placeholders/PatternMatch.tsx
@@ -1,0 +1,15 @@
+// Placeholder for M8.1. Real component TBD.
+import type { PatternMatchProps } from "../schemas";
+import { dumpJson, PlaceholderShell } from "./PlaceholderShell";
+
+export function PatternMatch(props: PatternMatchProps) {
+    const similarityPct = Math.round(props.similarity * 100);
+    return (
+        <PlaceholderShell
+            label="Pattern match"
+            detail={`cell ${props.cell_id} · similarity ${similarityPct}%`}
+        >
+            <pre className="whitespace-pre-wrap">{dumpJson(props)}</pre>
+        </PlaceholderShell>
+    );
+}

--- a/frontend/src/artifacts/placeholders/PlaceholderShell.tsx
+++ b/frontend/src/artifacts/placeholders/PlaceholderShell.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+import { Badge, Card } from "../../design-system";
+
+/**
+ * Shared scaffold for every M7.5 artifact placeholder.
+ *
+ * Placeholders are intentionally thin — they only prove the dispatcher path
+ * works end-to-end. Each real component lands in its M8.x milestone.
+ *
+ * Design discipline (DESIGN_PLAN_v2):
+ * - Tokens only (no hex, no gradients).
+ * - Sentence case label + mono detail (no mono-caps, no bracketed headers).
+ * - `variant="code"` badge is our mono-flavored Badge — see Badge.tsx.
+ */
+export interface PlaceholderShellProps {
+    label: string;
+    detail?: ReactNode;
+    children?: ReactNode;
+}
+
+export function PlaceholderShell({ label, detail, children }: PlaceholderShellProps) {
+    return (
+        <Card padding="sm" elevated>
+            <div className="flex flex-wrap items-center gap-2">
+                <Badge variant="accent" size="sm">
+                    {label}
+                </Badge>
+                {detail && (
+                    <span className="font-mono text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+                        {detail}
+                    </span>
+                )}
+            </div>
+            {children && (
+                <div className="mt-2 font-mono text-[var(--ds-text-xs)] leading-[1.55] text-[var(--ds-fg-subtle)] break-words">
+                    {children}
+                </div>
+            )}
+        </Card>
+    );
+}
+
+/** Compact JSON dump used by most placeholders to visualise inbound props. */
+export function dumpJson(value: unknown): string {
+    try {
+        return JSON.stringify(value, null, 2);
+    } catch {
+        return String(value);
+    }
+}

--- a/frontend/src/artifacts/placeholders/SignalChart.tsx
+++ b/frontend/src/artifacts/placeholders/SignalChart.tsx
@@ -1,0 +1,14 @@
+// Placeholder for M8.1. Real component TBD.
+import type { SignalChartProps } from "../schemas";
+import { dumpJson, PlaceholderShell } from "./PlaceholderShell";
+
+export function SignalChart(props: SignalChartProps) {
+    return (
+        <PlaceholderShell
+            label="Signal chart"
+            detail={`cell ${props.cell_id} · signal ${props.signal_def_id} · ${props.window_hours ?? 24}h`}
+        >
+            <pre className="whitespace-pre-wrap">{dumpJson(props)}</pre>
+        </PlaceholderShell>
+    );
+}

--- a/frontend/src/artifacts/placeholders/WorkOrderCard.tsx
+++ b/frontend/src/artifacts/placeholders/WorkOrderCard.tsx
@@ -1,0 +1,14 @@
+// Placeholder for M8.2. Real component TBD.
+import type { WorkOrderCardProps } from "../schemas";
+import { dumpJson, PlaceholderShell } from "./PlaceholderShell";
+
+export function WorkOrderCard(props: WorkOrderCardProps) {
+    return (
+        <PlaceholderShell
+            label="Work order"
+            detail={`cell ${props.cell_id} · WO #${props.work_order_id}`}
+        >
+            <pre className="whitespace-pre-wrap">{dumpJson(props)}</pre>
+        </PlaceholderShell>
+    );
+}

--- a/frontend/src/artifacts/registry.ts
+++ b/frontend/src/artifacts/registry.ts
@@ -1,0 +1,43 @@
+import type { ComponentType } from "react";
+import { AlertBanner } from "./placeholders/AlertBanner";
+import { BarChart } from "./placeholders/BarChart";
+import { DiagnosticCard } from "./placeholders/DiagnosticCard";
+import { EquipmentKbCard } from "./placeholders/EquipmentKbCard";
+import { KbProgress } from "./placeholders/KbProgress";
+import { PatternMatch } from "./placeholders/PatternMatch";
+import { SignalChart } from "./placeholders/SignalChart";
+import { WorkOrderCard } from "./placeholders/WorkOrderCard";
+import type { ArtifactComponentName } from "./schemas";
+
+/**
+ * Component type used by the registry — each entry validates its own props
+ * against a Zod schema before being mounted, so the registry erases the
+ * per-artifact shape. `ArtifactRenderer` hands the parsed data through.
+ */
+// biome-ignore lint/suspicious/noExplicitAny: registry entries are narrowed by the matching Zod schema in schemas.ts
+export type ArtifactComponent = ComponentType<any>;
+
+/**
+ * Single lookup table from backend `ui_render` component name → React FC.
+ *
+ * Component keys match the backend tool name **without** the `render_` prefix
+ * (the orchestrator strips it — see `backend/agents/ui_tools.py:50`).
+ *
+ * Adding a new artifact: add a Zod schema in `schemas.ts`, add a placeholder
+ * under `placeholders/`, wire both through here. One entry per type — no
+ * dynamic imports, no auto-registration.
+ */
+export const registry: Record<ArtifactComponentName, ArtifactComponent> = {
+    signal_chart: SignalChart,
+    equipment_kb_card: EquipmentKbCard,
+    work_order_card: WorkOrderCard,
+    diagnostic_card: DiagnosticCard,
+    pattern_match: PatternMatch,
+    bar_chart: BarChart,
+    kb_progress: KbProgress,
+    alert_banner: AlertBanner,
+};
+
+export function getArtifactComponent(name: string): ArtifactComponent | undefined {
+    return (registry as Record<string, ArtifactComponent>)[name];
+}

--- a/frontend/src/artifacts/schemas.ts
+++ b/frontend/src/artifacts/schemas.ts
@@ -1,0 +1,120 @@
+import { z } from "zod";
+
+/**
+ * Zod schemas for every `ui_render` component name emitted by the backend.
+ *
+ * Mirrors `backend/agents/ui_tools.py` — keep both in sync when the contract
+ * evolves. Component names are the backend `tool_name` without the `render_`
+ * prefix (stripped in the orchestrator — see `ui_tools.py` lines 46-53).
+ *
+ * `passthrough()` on every schema so future backend fields don't break the
+ * frontend before the matching placeholder update lands.
+ */
+
+export const SignalChartPropsSchema = z
+    .object({
+        cell_id: z.number().int(),
+        signal_def_id: z.number().int(),
+        window_hours: z.number().optional(),
+        mark_anomaly_at: z.string().optional(),
+        threshold: z.number().optional(),
+    })
+    .passthrough();
+
+export const EquipmentKbCardPropsSchema = z
+    .object({
+        cell_id: z.number().int(),
+        highlight_fields: z.array(z.string()).optional(),
+    })
+    .passthrough();
+
+export const WorkOrderCardPropsSchema = z
+    .object({
+        cell_id: z.number().int(),
+        work_order_id: z.number().int(),
+        printable: z.boolean().optional(),
+    })
+    .passthrough();
+
+export const DiagnosticCardPropsSchema = z
+    .object({
+        cell_id: z.number().int(),
+        title: z.string(),
+        confidence: z.number().min(0).max(1),
+        root_cause: z.string(),
+        contributing_factors: z.array(z.string()).min(1),
+        pattern_match_id: z.number().int().optional(),
+    })
+    .passthrough();
+
+export const PatternMatchPropsSchema = z
+    .object({
+        cell_id: z.number().int(),
+        current_event: z.string(),
+        past_event_ref: z.string(),
+        similarity: z.number().min(0).max(1),
+    })
+    .passthrough();
+
+export const BarChartPropsSchema = z
+    .object({
+        title: z.string(),
+        x_label: z.string(),
+        y_label: z.string(),
+        bars: z
+            .array(
+                z.object({
+                    label: z.string(),
+                    value: z.number(),
+                }),
+            )
+            .min(1),
+        cell_id: z.number().int().optional(),
+    })
+    .passthrough();
+
+export const KbProgressPropsSchema = z
+    .object({
+        cell_id: z.number().int(),
+        steps: z
+            .array(
+                z.object({
+                    label: z.string(),
+                    status: z.enum(["pending", "in_progress", "done", "skipped"]),
+                }),
+            )
+            .min(1),
+    })
+    .passthrough();
+
+export const AlertBannerPropsSchema = z
+    .object({
+        cell_id: z.number().int(),
+        severity: z.enum(["info", "alert", "trip"]),
+        message: z.string(),
+        anomaly_id: z.number().int().optional(),
+        signal_def_id: z.number().int().optional(),
+    })
+    .passthrough();
+
+export type SignalChartProps = z.infer<typeof SignalChartPropsSchema>;
+export type EquipmentKbCardProps = z.infer<typeof EquipmentKbCardPropsSchema>;
+export type WorkOrderCardProps = z.infer<typeof WorkOrderCardPropsSchema>;
+export type DiagnosticCardProps = z.infer<typeof DiagnosticCardPropsSchema>;
+export type PatternMatchProps = z.infer<typeof PatternMatchPropsSchema>;
+export type BarChartProps = z.infer<typeof BarChartPropsSchema>;
+export type KbProgressProps = z.infer<typeof KbProgressPropsSchema>;
+export type AlertBannerProps = z.infer<typeof AlertBannerPropsSchema>;
+
+export const schemas = {
+    signal_chart: SignalChartPropsSchema,
+    equipment_kb_card: EquipmentKbCardPropsSchema,
+    work_order_card: WorkOrderCardPropsSchema,
+    diagnostic_card: DiagnosticCardPropsSchema,
+    pattern_match: PatternMatchPropsSchema,
+    bar_chart: BarChartPropsSchema,
+    kb_progress: KbProgressPropsSchema,
+    alert_banner: AlertBannerPropsSchema,
+} as const;
+
+export type ArtifactComponentName = keyof typeof schemas;


### PR DESCRIPTION
## Summary

M7.5 — generative-UI infrastructure. Every `ui_render` frame emitted over the chat WS now resolves to a React component through a single registry, with Zod runtime validation and an error boundary. Components are placeholders for now — M8.1 → M8.3 replace them one at a time.

This unblocks every artifact milestone (M8.1 SignalChart, M8.2 EquipmentKbCard, M8.3 artifact bundle).

## What lands

### `frontend/src/artifacts/` (new module)

- **`registry.ts`** — single lookup table from backend tool name (without the `render_` prefix, stripped by the orchestrator per `backend/agents/ui_tools.py:50`) to a React FC. One line per artifact — adding one is a trivial PR.
- **`schemas.ts`** — one Zod schema per component, matching the backend tool schema field-by-field. Every schema uses `passthrough()` so future backend fields don't break mount before the placeholder catches up. Types inferred via `z.infer<>` and re-exported.
- **`ArtifactRenderer.tsx`** — the dispatcher. Three failure modes, each a discrete DS-tokens-only fallback card (no stacktrace leaks into the chat):
  - Unknown component name → `"Unknown artifact: X"`
  - Schema violation → `"Artifact error: invalid props for X"` + the first Zod issue path
  - Runtime render throw → class error boundary catches it, renders `"X failed to render"`
- **`placeholders/`** — 8 placeholders sharing a `PlaceholderShell` scaffold (accent badge + sentence-case label + mono JSON dump). Each is a DS-compliant card, zero hex literals, no banned lib, no new animation.
- **`index.ts`** — barrel re-export for `ArtifactRenderer` and `registry`.

### Wiring into the chat

- `frontend/src/app/chat/chatStore.ts` — adds `ArtifactPart` to the agent-message union. The `ui_render` case used to `break` silently (explicit M6.5 scope-out); it now seals any streaming text (same guard as `tool_call`) and pushes an artifact part carrying `{component, props}` straight from the wire. Order preserved between text runs, tool calls, handoffs, and artifacts.
- `frontend/src/app/chat/Message.tsx` — the part map dispatches the new kind to `<ArtifactRenderer>`, inserted between tool-call and text rows.

### New dep (DESIGN_PLAN §10 justification)

- `zod@^3.25.76` — runtime validation of LLM-emitted artifact props. Zod is the TS ecosystem standard; tiny bundle (~12kB gz), zero deps itself. Used only behind the artifact registry (`safeParse` before mount), so the dep stays contained. v3 locked — v4 stable exists (4.3.6) but ships breaking API changes; not worth the risk three days before demo when the surface we use (`safeParse`, object schemas, `passthrough`) has been stable since v3.0.

## Scope out (on purpose)

Per issue #44, this is infra only:

- **No real artifact implementations.** Charts, KB cards, WO cards — all placeholders. Those live in M8.1 / M8.2 / M8.3.
- **No new motion variants.** Reuses the existing `fadeInUp` (the `artifactReveal` mentioned in the issue was cleaned up in PR #111's motion purge; `fadeInUp` covers the same intent without re-introducing a variant we just removed).
- **No event-bus consumption.** M7.5 consumes the chat socket (`/api/v1/agent/chat`) only. Alert-banner via the event bus (`/api/v1/events` — Sentinel direct path per `ui_tools.py`) lands with M7.3 / M8.4.
- **No chart libs, no d3, no recharts.** Those arrive with M8 components. Strictly `zod` only.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run check` (biome) — 66 files, no issues
- [x] `npm run test` — **21/21** green (17 existing + 4 new `ArtifactRenderer.test.tsx` — one per failure mode + happy path)
- [x] `npm run build` — 1.64s, 2498 modules
- [x] `grep -n '"ui_render"' frontend/src/app/chat/chatStore.ts` → actually dispatches, no more silent `break`
- [ ] Manual smoke once a real stack is up:
  - [ ] Ask the chat a question that triggers a `render_*` tool call → placeholder appears inline with motion, Badge "Artifact", JSON props dumped
  - [ ] Force an unknown component name (e.g. via a custom prompt Claude mis-tools) → `"Unknown artifact"` fallback, no crash
  - [ ] Rapid burst of `ui_render` + `thinking_delta` mid-turn → all artifacts land in order, thinking deltas still ignored (M8.5 handles those)

## Test coverage added

- `frontend/src/artifacts/ArtifactRenderer.test.tsx` — 4 cases:
  1. Unknown component → fallback rendered, no throw
  2. Valid schema + valid props → placeholder rendered with correct label + detail
  3. Invalid schema → fallback rendered with Zod path/message, no throw
  4. Runtime throw in component → error boundary catches, fallback rendered (console.error mocked to silence the expected dev log)
- `frontend/src/app/chat/chatStore.test.ts` — existing burst test renamed to `accumulates ui_render as artifact parts and ignores thinking_delta bursts`, now asserts 10 artifacts land with correct `{component, props}` round-trip and `thinking_delta` remains a no-op.

## Related

- #106 (M7.4) — chat WS wire, the transport this consumes
- #109 — follow-up agent badge fix (unrelated but landing in the same M7)
- M8.1 (#45) / M8.2 (#46) / M8.3 (#47) — each replaces one or more placeholders with a real component

Closes #44