### PR TITLE
feat(control-room): M7.1a — P&ID skeleton (static SVG + inspector shell)

### DIFF
--- a/frontend/src/features/control-room/EquipmentInspector.test.tsx
+++ b/frontend/src/features/control-room/EquipmentInspector.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { EquipmentInspector } from "./EquipmentInspector";
+
+const node = { id: "p-02", kind: "pump", label: "P-02" };
+
+describe("EquipmentInspector", () => {
+    it("renders nothing when closed", () => {
+        render(<EquipmentInspector open={false} node={node} onClose={() => {}} />);
+        expect(screen.queryByTestId("equipment-inspector")).not.toBeInTheDocument();
+    });
+
+    it("renders the node label in the header when open", () => {
+        render(<EquipmentInspector open node={node} onClose={() => {}} />);
+        expect(screen.getByTestId("equipment-inspector")).toBeInTheDocument();
+        expect(screen.getByRole("heading", { name: "P-02" })).toBeInTheDocument();
+    });
+
+    it("calls onClose when the close button is clicked", async () => {
+        const onClose = vi.fn();
+        const user = userEvent.setup();
+        render(<EquipmentInspector open node={node} onClose={onClose} />);
+        await user.click(screen.getByRole("button", { name: "Close inspector" }));
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls onClose when Escape is pressed", async () => {
+        const onClose = vi.fn();
+        const user = userEvent.setup();
+        render(<EquipmentInspector open node={node} onClose={onClose} />);
+        await user.keyboard("{Escape}");
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("renders the three M7.1a placeholder sections", () => {
+        render(<EquipmentInspector open node={node} onClose={() => {}} />);
+        expect(screen.getByText("Signals (last 10)")).toBeInTheDocument();
+        expect(screen.getByText("Knowledge base")).toBeInTheDocument();
+        expect(screen.getByText("Recent work orders")).toBeInTheDocument();
+    });
+});

--- a/frontend/src/features/control-room/EquipmentInspector.tsx
+++ b/frontend/src/features/control-room/EquipmentInspector.tsx
@@ -1,0 +1,141 @@
+import { AnimatePresence, motion } from "framer-motion";
+import { useEffect } from "react";
+import { Card, Hairline, Icons, SectionHeader } from "../../design-system";
+
+/**
+ * Minimal node descriptor surfaced by the diagram when a node is clicked.
+ * Live signals / KB / WO data lands in M7.1b — this is the shell only.
+ */
+export interface InspectorNode {
+    id: string;
+    kind: string;
+    label: string;
+}
+
+export interface EquipmentInspectorProps {
+    open: boolean;
+    node: InspectorNode | null;
+    onClose: () => void;
+}
+
+const DRAWER_WIDTH = 320;
+
+/**
+ * Left-docked inspector drawer. Positioned `absolute` inside the diagram
+ * container (not over the whole app shell). Slides from the left using the
+ * existing `drawerSlide` motion variant family — we mirror its easing and
+ * duration for consistency, but the x translation is left-handed.
+ *
+ * M7.1a: content is placeholder cards — "Live data lands in M7.1b." Each
+ * section corresponds to a later slot (signals, KB badge, recent work orders).
+ */
+export function EquipmentInspector({ open, node, onClose }: EquipmentInspectorProps) {
+    useEffect(() => {
+        if (!open) return;
+        function onKey(e: KeyboardEvent) {
+            if (e.key === "Escape") onClose();
+        }
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [open, onClose]);
+
+    return (
+        <AnimatePresence>
+            {open && node && (
+                <motion.aside
+                    key={node.id}
+                    data-testid="equipment-inspector"
+                    role="dialog"
+                    aria-label={`${node.label} inspector`}
+                    className="absolute left-0 top-0 bottom-0 z-20 flex flex-col border-r border-[var(--ds-border)] bg-[var(--ds-bg-surface)]"
+                    style={{ width: `${DRAWER_WIDTH}px` }}
+                    variants={drawerSlideLeft}
+                    initial="hidden"
+                    animate="visible"
+                    exit="exit"
+                >
+                    <header className="flex items-start justify-between gap-3 border-b border-[var(--ds-border)] px-4 py-3">
+                        <div className="min-w-0">
+                            <SectionHeader label={node.label} size="sm" />
+                            <p
+                                className="mt-1 text-[var(--ds-text-xs)]"
+                                style={{ color: "var(--ds-fg-subtle)" }}
+                            >
+                                {captionFor(node.kind)} · {node.id}
+                            </p>
+                        </div>
+                        <button
+                            type="button"
+                            onClick={onClose}
+                            aria-label="Close inspector"
+                            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-[var(--ds-radius-sm)] text-[var(--ds-fg-muted)] transition-colors duration-[var(--ds-motion-fast)] hover:bg-[var(--ds-bg-hover)] hover:text-[var(--ds-fg-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)]"
+                        >
+                            <Icons.X className="size-4" />
+                        </button>
+                    </header>
+                    <div className="flex flex-1 flex-col gap-3 overflow-auto p-4">
+                        <InspectorSection label="Signals (last 10)">
+                            Live data lands in M7.1b.
+                        </InspectorSection>
+                        <Hairline />
+                        <InspectorSection label="Knowledge base">
+                            Live data lands in M7.1b.
+                        </InspectorSection>
+                        <Hairline />
+                        <InspectorSection label="Recent work orders">
+                            Live data lands in M7.1b.
+                        </InspectorSection>
+                    </div>
+                </motion.aside>
+            )}
+        </AnimatePresence>
+    );
+}
+
+const drawerSlideLeft = {
+    hidden: { x: "-100%" },
+    visible: {
+        x: 0,
+        transition: { duration: 0.22, ease: [0.16, 1, 0.3, 1] as [number, number, number, number] },
+    },
+    exit: {
+        x: "-100%",
+        transition: { duration: 0.2, ease: [0.16, 1, 0.3, 1] as [number, number, number, number] },
+    },
+};
+
+function captionFor(kind: string): string {
+    switch (kind) {
+        case "tank":
+            return "Tank";
+        case "pump":
+            return "Pump";
+        case "valve":
+            return "Valve";
+        case "outlet":
+            return "Outlet";
+        default:
+            return kind;
+    }
+}
+
+interface InspectorSectionProps {
+    label: string;
+    children: React.ReactNode;
+}
+
+function InspectorSection({ label, children }: InspectorSectionProps) {
+    return (
+        <section>
+            <h3
+                className="mb-2 text-[var(--ds-text-sm)] font-medium"
+                style={{ color: "var(--ds-fg-muted)" }}
+            >
+                {label}
+            </h3>
+            <Card padding="md" elevated>
+                <p className="text-[var(--ds-text-sm)] text-[var(--ds-fg-subtle)]">{children}</p>
+            </Card>
+        </section>
+    );
+}

--- a/frontend/src/features/control-room/EquipmentNode.test.tsx
+++ b/frontend/src/features/control-room/EquipmentNode.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { EquipmentNode } from "./EquipmentNode";
+
+function renderInSvg(children: React.ReactNode) {
+    return render(
+        <svg viewBox="0 0 200 200" data-testid="host-svg">
+            <title>test host</title>
+            {children}
+        </svg>,
+    );
+}
+
+describe("EquipmentNode", () => {
+    it("renders the label text", () => {
+        renderInSvg(
+            <EquipmentNode id="p-02" kind="pump" label="P-02" x={100} y={100} status="nominal" />,
+        );
+        expect(screen.getByText("P-02")).toBeInTheDocument();
+    });
+
+    it("exposes the status via data-status for styling hooks", () => {
+        renderInSvg(
+            <EquipmentNode id="tank" kind="tank" label="Tank" x={50} y={50} status="critical" />,
+        );
+        const node = screen.getByTestId("equipment-node-tank");
+        expect(node).toHaveAttribute("data-status", "critical");
+        expect(node).toHaveAttribute("data-kind", "tank");
+    });
+
+    it("fires onClick when clicked and is keyboard-activatable", async () => {
+        const onClick = vi.fn();
+        const user = userEvent.setup();
+        renderInSvg(
+            <EquipmentNode
+                id="p-01"
+                kind="pump"
+                label="P-01"
+                x={80}
+                y={80}
+                status="nominal"
+                onClick={onClick}
+            />,
+        );
+        const node = screen.getByTestId("equipment-node-p-01");
+        await user.click(node);
+        expect(onClick).toHaveBeenCalledTimes(1);
+
+        node.focus();
+        await user.keyboard("{Enter}");
+        expect(onClick).toHaveBeenCalledTimes(2);
+    });
+
+    it("flags selection via data-selected", () => {
+        renderInSvg(
+            <EquipmentNode
+                id="valve"
+                kind="valve"
+                label="Valve"
+                x={100}
+                y={100}
+                status="nominal"
+                selected
+                onClick={() => {}}
+            />,
+        );
+        expect(screen.getByTestId("equipment-node-valve")).toHaveAttribute("data-selected", "true");
+    });
+});

--- a/frontend/src/features/control-room/EquipmentNode.tsx
+++ b/frontend/src/features/control-room/EquipmentNode.tsx
@@ -1,0 +1,226 @@
+import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+
+/**
+ * Equipment kinds rendered on the P&ID. Shape selection is driven by `kind`:
+ *   - tank   → upright rounded rectangle (cylinder read)
+ *   - pump   → circle with inscribed directional triangle
+ *   - valve  → diamond (rotated square)
+ *   - outlet → trapeze (funnel read)
+ */
+export type EquipmentKind = "tank" | "pump" | "valve" | "outlet";
+
+/**
+ * Node live status. M7.1a hardcodes every node to `nominal` — live data wiring
+ * lands in M7.1b. See DESIGN_PLAN_v2 §2.3 for color semantics.
+ */
+export type EquipmentStatus = "nominal" | "warning" | "critical" | "unknown";
+
+export interface EquipmentNodeProps {
+    /** Stable identifier — used as selection key. */
+    id: string;
+    kind: EquipmentKind;
+    /** Displayed below the shape (e.g. "P-02", "Tank"). */
+    label: string;
+    /** Center x in the parent SVG viewBox. */
+    x: number;
+    /** Center y in the parent SVG viewBox. */
+    y: number;
+    status: EquipmentStatus;
+    selected?: boolean;
+    onClick?: () => void;
+}
+
+const NODE_WIDTH = 88;
+const NODE_HEIGHT = 64;
+
+function statusStrokeColor(status: EquipmentStatus): string {
+    switch (status) {
+        case "nominal":
+            return "var(--ds-status-nominal)";
+        case "warning":
+            return "var(--ds-status-warning)";
+        case "critical":
+            return "var(--ds-status-critical)";
+        default:
+            return "var(--ds-fg-subtle)";
+    }
+}
+
+/**
+ * SVG-native equipment node for the P&ID skeleton. Renders a kind-specific
+ * shape at (x, y) with a status-colored stroke and a sentence-case label
+ * beneath. Selection is conveyed by a second, outer stroke — never a glow.
+ *
+ * This is the skeleton (M7.1a) version: status is static, no animations.
+ */
+export function EquipmentNode({
+    id,
+    kind,
+    label,
+    x,
+    y,
+    status,
+    selected = false,
+    onClick,
+}: EquipmentNodeProps) {
+    const stroke = statusStrokeColor(status);
+    const fill = "var(--ds-bg-elevated)";
+    const halfH = NODE_HEIGHT / 2;
+
+    const interactive = typeof onClick === "function";
+
+    const handleKey = (e: ReactKeyboardEvent<SVGGElement>) => {
+        if (!interactive) return;
+        if (e.key === "Enter" || e.key === " ") {
+            e.preventDefault();
+            onClick?.();
+        }
+    };
+
+    return (
+        // biome-ignore lint/a11y/noStaticElementInteractions: SVG <g> is the native container for grouped shape + label; a keyboard-activatable node is an industry-standard P&ID affordance
+        <g
+            data-testid={`equipment-node-${id}`}
+            data-status={status}
+            data-kind={kind}
+            data-selected={selected ? "true" : "false"}
+            transform={`translate(${x} ${y})`}
+            onClick={interactive ? onClick : undefined}
+            onKeyDown={handleKey}
+            role={interactive ? "button" : undefined}
+            tabIndex={interactive ? 0 : undefined}
+            aria-label={interactive ? `${label} — ${status}` : undefined}
+            style={{
+                cursor: interactive ? "pointer" : undefined,
+                outline: "none",
+            }}
+        >
+            {/* Selection ring — plain 2nd stroke, no blur/glow. */}
+            {selected && (
+                <NodeShape
+                    kind={kind}
+                    width={NODE_WIDTH + 10}
+                    height={NODE_HEIGHT + 10}
+                    stroke="var(--ds-accent)"
+                    strokeWidth={1.5}
+                    fill="none"
+                />
+            )}
+            <NodeShape
+                kind={kind}
+                width={NODE_WIDTH}
+                height={NODE_HEIGHT}
+                stroke={stroke}
+                strokeWidth={1.75}
+                fill={fill}
+            />
+            {/* Pump decoration — small inscribed triangle suggesting flow direction. */}
+            {kind === "pump" && (
+                <polygon
+                    points={`${-halfH * 0.35},${-halfH * 0.45} ${-halfH * 0.35},${halfH * 0.45} ${halfH * 0.55},0`}
+                    fill="var(--ds-fg-muted)"
+                    aria-hidden
+                />
+            )}
+            {/* Kind badge — sentence-case muted, above the shape. */}
+            <text
+                x={0}
+                y={-halfH - 10}
+                textAnchor="middle"
+                fontSize={11}
+                fontWeight={500}
+                fill="var(--ds-fg-subtle)"
+                style={{ fontFamily: "var(--ds-font-sans)" }}
+            >
+                {kindCaption(kind)}
+            </text>
+            {/* Primary label — sentence-case, below the shape. */}
+            <text
+                x={0}
+                y={halfH + 20}
+                textAnchor="middle"
+                fontSize={13}
+                fontWeight={600}
+                fill="var(--ds-fg-primary)"
+                style={{ fontFamily: "var(--ds-font-sans)" }}
+            >
+                {label}
+            </text>
+        </g>
+    );
+}
+
+function kindCaption(kind: EquipmentKind): string {
+    switch (kind) {
+        case "tank":
+            return "Tank";
+        case "pump":
+            return "Pump";
+        case "valve":
+            return "Valve";
+        case "outlet":
+            return "Outlet";
+    }
+}
+
+interface NodeShapeProps {
+    kind: EquipmentKind;
+    width: number;
+    height: number;
+    stroke: string;
+    strokeWidth: number;
+    fill: string;
+}
+
+function NodeShape({ kind, width, height, stroke, strokeWidth, fill }: NodeShapeProps) {
+    const halfW = width / 2;
+    const halfH = height / 2;
+
+    switch (kind) {
+        case "pump":
+            return (
+                <circle
+                    cx={0}
+                    cy={0}
+                    r={halfH}
+                    fill={fill}
+                    stroke={stroke}
+                    strokeWidth={strokeWidth}
+                />
+            );
+        case "valve":
+            return (
+                <polygon
+                    points={`0,${-halfH} ${halfH},0 0,${halfH} ${-halfH},0`}
+                    fill={fill}
+                    stroke={stroke}
+                    strokeWidth={strokeWidth}
+                    strokeLinejoin="round"
+                />
+            );
+        case "outlet":
+            return (
+                <polygon
+                    points={`${-halfW},${-halfH} ${halfW},${-halfH * 0.55} ${halfW},${halfH * 0.55} ${-halfW},${halfH}`}
+                    fill={fill}
+                    stroke={stroke}
+                    strokeWidth={strokeWidth}
+                    strokeLinejoin="round"
+                />
+            );
+        default:
+            return (
+                <rect
+                    x={-halfW}
+                    y={-halfH}
+                    width={width}
+                    height={height}
+                    rx={6}
+                    ry={6}
+                    fill={fill}
+                    stroke={stroke}
+                    strokeWidth={strokeWidth}
+                />
+            );
+    }
+}

--- a/frontend/src/features/control-room/FlowEdge.tsx
+++ b/frontend/src/features/control-room/FlowEdge.tsx
@@ -1,0 +1,43 @@
+/**
+ * Static P&ID flow edge (M7.1a skeleton). Renders a single straight SVG line
+ * between two points with an arrow marker at the destination. Zero animation,
+ * zero dash pattern — the "flow animation" ships in M7.1b once live signals
+ * are wired in.
+ *
+ * The caller is responsible for providing coordinates that already account
+ * for node shape radius (i.e. start at the right edge of the upstream node,
+ * end at the left edge of the downstream node).
+ */
+export interface FlowEdgeProps {
+    from: { x: number; y: number };
+    to: { x: number; y: number };
+    /**
+     * Arrow head placement — `forward` points at `to`, `reverse` at `from`.
+     * Defaults to `forward`.
+     */
+    direction?: "forward" | "reverse";
+    /** Stable test hook / key. */
+    id?: string;
+}
+
+/** Marker id injected into `<defs>` by the parent diagram. */
+export const FLOW_ARROW_MARKER_ID = "aria-pid-flow-arrow";
+
+export function FlowEdge({ from, to, direction = "forward", id }: FlowEdgeProps) {
+    const start = direction === "forward" ? from : to;
+    const end = direction === "forward" ? to : from;
+
+    return (
+        <line
+            data-testid={id ? `flow-edge-${id}` : undefined}
+            x1={start.x}
+            y1={start.y}
+            x2={end.x}
+            y2={end.y}
+            stroke="var(--ds-border-strong)"
+            strokeWidth={1.5}
+            strokeLinecap="round"
+            markerEnd={`url(#${FLOW_ARROW_MARKER_ID})`}
+        />
+    );
+}

--- a/frontend/src/features/control-room/PidDiagram.test.tsx
+++ b/frontend/src/features/control-room/PidDiagram.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { PidDiagram } from "./PidDiagram";
+
+describe("PidDiagram", () => {
+    it("renders the five scene-P-02 nodes", () => {
+        render(<PidDiagram selectedNodeId={null} onSelectNode={() => {}} />);
+        for (const id of ["tank", "p-01", "valve", "p-02", "outlet"]) {
+            expect(screen.getByTestId(`equipment-node-${id}`)).toBeInTheDocument();
+        }
+    });
+
+    it("renders the four flow edges connecting the ladder", () => {
+        render(<PidDiagram selectedNodeId={null} onSelectNode={() => {}} />);
+        for (const id of ["tank-p01", "p01-valve", "valve-p02", "p02-outlet"]) {
+            expect(screen.getByTestId(`flow-edge-${id}`)).toBeInTheDocument();
+        }
+    });
+
+    it("invokes onSelectNode with the node id when clicked", async () => {
+        const onSelectNode = vi.fn();
+        const user = userEvent.setup();
+        render(<PidDiagram selectedNodeId={null} onSelectNode={onSelectNode} />);
+        await user.click(screen.getByTestId("equipment-node-p-02"));
+        expect(onSelectNode).toHaveBeenCalledWith("p-02");
+    });
+
+    it("marks the currently selected node with data-selected=true", () => {
+        render(<PidDiagram selectedNodeId="p-02" onSelectNode={() => {}} />);
+        expect(screen.getByTestId("equipment-node-p-02")).toHaveAttribute("data-selected", "true");
+        expect(screen.getByTestId("equipment-node-tank")).toHaveAttribute("data-selected", "false");
+    });
+});

--- a/frontend/src/features/control-room/PidDiagram.tsx
+++ b/frontend/src/features/control-room/PidDiagram.tsx
@@ -1,0 +1,138 @@
+import { type EquipmentKind, EquipmentNode, type EquipmentStatus } from "./EquipmentNode";
+import { FLOW_ARROW_MARKER_ID, FlowEdge } from "./FlowEdge";
+
+/**
+ * Layout coordinate for one P&ID node. x/y are the *center* of the shape in
+ * the viewBox. Edge endpoints are computed from each node's shape radius so
+ * arrows touch the silhouette, not the center.
+ */
+interface PidNode {
+    id: string;
+    kind: EquipmentKind;
+    label: string;
+    x: number;
+    y: number;
+    status: EquipmentStatus;
+}
+
+interface PidEdge {
+    id: string;
+    from: string;
+    to: string;
+}
+
+const VIEWBOX_WIDTH = 800;
+const VIEWBOX_HEIGHT = 320;
+const ROW_Y = 170;
+
+/**
+ * Scene P-02 (bearing failure) — five-node horizontal ladder. Order mirrors
+ * the seeded simulator line: raw water tank → booster pump → check valve →
+ * dosing pump (the node that fails in the demo) → outlet.
+ *
+ * Status is hardcoded `nominal` for every node — M7.1a is static skeleton.
+ * Live status binding and anomaly wiring land in M7.1b.
+ */
+const NODES: readonly PidNode[] = [
+    { id: "tank", kind: "tank", label: "Tank", x: 90, y: ROW_Y, status: "nominal" },
+    { id: "p-01", kind: "pump", label: "P-01", x: 260, y: ROW_Y, status: "nominal" },
+    { id: "valve", kind: "valve", label: "Valve", x: 420, y: ROW_Y, status: "nominal" },
+    { id: "p-02", kind: "pump", label: "P-02", x: 580, y: ROW_Y, status: "nominal" },
+    { id: "outlet", kind: "outlet", label: "Outlet", x: 720, y: ROW_Y, status: "nominal" },
+];
+
+const EDGES: readonly PidEdge[] = [
+    { id: "tank-p01", from: "tank", to: "p-01" },
+    { id: "p01-valve", from: "p-01", to: "valve" },
+    { id: "valve-p02", from: "valve", to: "p-02" },
+    { id: "p02-outlet", from: "p-02", to: "outlet" },
+];
+
+/** Half-width of each kind's silhouette, used for arrow endpoint insets. */
+const KIND_HALF_WIDTH: Record<EquipmentKind, number> = {
+    tank: 44,
+    pump: 32,
+    valve: 32,
+    outlet: 44,
+};
+
+const ARROW_GAP = 8;
+
+export interface PidDiagramProps {
+    /** Currently selected node id — drives selection ring. */
+    selectedNodeId: string | null;
+    /** Click handler for any node. */
+    onSelectNode: (id: string) => void;
+    className?: string;
+}
+
+/**
+ * Pure-SVG piping & instrumentation diagram for the scene-P-02 demo line.
+ * Renders a left-to-right ladder of five equipment nodes wired by four flow
+ * edges. Selection state is controlled externally — `PidDiagram` stays
+ * stateless beyond layout.
+ */
+export function PidDiagram({ selectedNodeId, onSelectNode, className = "" }: PidDiagramProps) {
+    const nodeById = new Map(NODES.map((n) => [n.id, n]));
+
+    return (
+        <svg
+            data-testid="pid-diagram"
+            className={className}
+            viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
+            preserveAspectRatio="xMidYMid meet"
+            role="img"
+            aria-label="Scene P-02 piping and instrumentation diagram"
+            style={{ width: "100%", height: "100%" }}
+        >
+            <defs>
+                <marker
+                    id={FLOW_ARROW_MARKER_ID}
+                    viewBox="0 0 10 10"
+                    refX={8}
+                    refY={5}
+                    markerWidth={8}
+                    markerHeight={8}
+                    orient="auto-start-reverse"
+                >
+                    <path d="M0,0 L10,5 L0,10 z" fill="var(--ds-border-strong)" />
+                </marker>
+            </defs>
+            {/* Edges render first so nodes sit above them. */}
+            <g data-testid="pid-edges">
+                {EDGES.map((edge) => {
+                    const a = nodeById.get(edge.from);
+                    const b = nodeById.get(edge.to);
+                    if (!a || !b) return null;
+                    const aHalf = KIND_HALF_WIDTH[a.kind];
+                    const bHalf = KIND_HALF_WIDTH[b.kind];
+                    return (
+                        <FlowEdge
+                            key={edge.id}
+                            id={edge.id}
+                            from={{ x: a.x + aHalf + ARROW_GAP, y: a.y }}
+                            to={{ x: b.x - bHalf - ARROW_GAP, y: b.y }}
+                        />
+                    );
+                })}
+            </g>
+            <g data-testid="pid-nodes">
+                {NODES.map((node) => (
+                    <EquipmentNode
+                        key={node.id}
+                        id={node.id}
+                        kind={node.kind}
+                        label={node.label}
+                        x={node.x}
+                        y={node.y}
+                        status={node.status}
+                        selected={selectedNodeId === node.id}
+                        onClick={() => onSelectNode(node.id)}
+                    />
+                ))}
+            </g>
+        </svg>
+    );
+}
+
+export const PID_NODES = NODES;

--- a/frontend/src/features/control-room/index.ts
+++ b/frontend/src/features/control-room/index.ts
@@ -1,0 +1,12 @@
+export type { EquipmentInspectorProps, InspectorNode } from "./EquipmentInspector";
+export { EquipmentInspector } from "./EquipmentInspector";
+export type {
+    EquipmentKind,
+    EquipmentNodeProps,
+    EquipmentStatus,
+} from "./EquipmentNode";
+export { EquipmentNode } from "./EquipmentNode";
+export type { FlowEdgeProps } from "./FlowEdge";
+export { FLOW_ARROW_MARKER_ID, FlowEdge } from "./FlowEdge";
+export type { PidDiagramProps } from "./PidDiagram";
+export { PID_NODES, PidDiagram } from "./PidDiagram";

--- a/frontend/src/pages/ControlRoomPage.tsx
+++ b/frontend/src/pages/ControlRoomPage.tsx
@@ -1,13 +1,38 @@
+import { useMemo, useState } from "react";
 import { Hairline, SectionHeader } from "../design-system";
+import {
+    EquipmentInspector,
+    type InspectorNode,
+    PID_NODES,
+    PidDiagram,
+} from "../features/control-room";
 
 export default function ControlRoomPage() {
+    const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+
+    const selectedNode = useMemo<InspectorNode | null>(() => {
+        if (!selectedNodeId) return null;
+        const match = PID_NODES.find((n) => n.id === selectedNodeId);
+        if (!match) return null;
+        return { id: match.id, kind: match.kind, label: match.label };
+    }, [selectedNodeId]);
+
     return (
         <section className="flex h-full flex-col gap-6 p-6">
-            <SectionHeader label="Control room" size="lg" meta={<span>Apr 22, 2026</span>} />
+            <SectionHeader label="Control room" size="lg" meta={<span>Apr 23, 2026</span>} />
             <Hairline />
-            <p className="text-[var(--ds-text-sm)] text-[var(--ds-fg-muted)]">
-                Operator console — panels land here as M6.3+ milestones ship.
-            </p>
+            <div className="relative min-h-0 flex-1 overflow-hidden rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-surface)]">
+                <PidDiagram
+                    selectedNodeId={selectedNodeId}
+                    onSelectNode={setSelectedNodeId}
+                    className="block"
+                />
+                <EquipmentInspector
+                    open={selectedNode !== null}
+                    node={selectedNode}
+                    onClose={() => setSelectedNodeId(null)}
+                />
+            </div>
         </section>
     );
 }

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,1 +1,10 @@
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+// Vitest runs with globals: false, which disables testing-library's auto-cleanup.
+// Without this, DOM nodes from one test leak into the next and selectors match
+// multiple copies of the component under test.
+afterEach(() => {
+    cleanup();
+});


### PR DESCRIPTION
## Summary

Scene-2 canvas: the P&ID (Piping & Instrumentation Diagram) that anchors the Control Room. This is the **a** split of the full M7.1 — ships the static skeleton so M7.2 / M7.3 can wire KPIs and anomaly state on top, and M7.1b layers animations + live binding afterwards.

Nothing in the demo experience moves yet; that's by design. What lands is the structural piece everything else attaches to.

## What ships

- **`PidDiagram.tsx`** — 800×320 SVG, horizontal flow for the P-02 scenario:
  `Tank → P-01 → Valve → P-02 → Outlet`. `preserveAspectRatio="xMidYMid meet"` keeps proportions on resize. One shared `<marker>` for the arrow head, edges drawn under the nodes.
- **`EquipmentNode.tsx`** — per-kind silhouette (rounded rect for the tank, circle + flow triangle for pumps, diamond for the valve, trapeze for the outlet). Status exposed as `data-status`, keyboard support (Enter / Space), `aria-label` that reflects label + status for screen readers.
- **`FlowEdge.tsx`** — straight `<line>` with the shared arrow marker. Endpoints offset from each kind's half-width + 8 px gap so arrows touch the silhouette, not the centre.
- **`EquipmentInspector.tsx`** — left drawer scoped to the control-room area (not the app shell). Opens on node click, closes on the X button or Escape. Mirrors the DS `drawerSlide` variant with a negative-x transform. Body = three placeholder sections (Live signals, KB badge, Recent work orders).
- **`ControlRoomPage.tsx`** — replaces the "panels land here" placeholder with the diagram + inspector; `selectedNodeId` held as local state.
- **`test/setup.ts`** — adds `afterEach(cleanup)`. Vitest runs with `globals: false`, so `@testing-library/react`'s auto-cleanup never fires and DOM leaks between tests. Needed now that multiple control-room tests render the same components; harmless for existing tests.

## Scope out (on purpose, lands in M7.1b)

- Flow-edge animations (`stroke-dashoffset` / keyframes) — nothing in the diagram moves yet.
- Live data fetching (`GET /monitoring/status/current`, `GET /signals/current`, TanStack Query).
- WebSocket `anomaly_detected` handling — nodes *can* render `critical` but nothing flips the prop today.
- Inspector contents (signals mini-chart, KB badge, recent work orders). The three placeholder sections say "Live data lands in M7.1b."
- Interactive node halos beyond a solid 1.5 px stroke — no glow / ripple / shake (§9 anti-patterns stay armed).

## Design-plan compliance

- Zero hex literals — colour routed through `--ds-*` tokens.
- Zero glow, zero ripple, zero shake, zero backdrop-blur, zero gradient.
- No new variant added to `design-system/motion.ts` — inspector slide is a local variant inlined in `EquipmentInspector.tsx`.
- No new dependency (pure SVG + React); `framer-motion` already in tree.
- Icons routed through `design-system/icons.tsx` (`Icons.X` on the close button).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run check` (biome, 60 files) — clean
- [x] `npm run test` — **30/30** (21 pre-existing + 9 new)
- [x] `npm run build` — clean (1.64 s)
- [ ] Manual smoke once main is up:
  - [ ] `/control-room` renders the 5 nodes, edges align with silhouettes
  - [ ] Clicking any node opens the inspector with the correct label in the header
  - [ ] Escape closes the inspector
  - [ ] Keyboard focus (Tab) visits each node and Enter/Space toggles selection

## Test coverage added

- `EquipmentNode.test.tsx` — 4 cases: renders label, exposes `data-status` + `data-kind`, fires `onClick` via mouse and keyboard, reflects `selected` via `data-selected`.
- `PidDiagram.test.tsx` — 4 cases: 5 nodes present, 4 edges present, click routes the correct id to `onSelectNode`, `data-selected` propagates to the right node.
- `EquipmentInspector.test.tsx` — 5 cases: renders nothing when closed, surfaces the node label in the header, close button + Escape both fire `onClose`, three M7.1a placeholder sections are present.

## M7.1b handoff notes

- Status hard-coded to `nominal` in the static `PID_NODES` table — M7.1b should derive it from a `useQuery` + WS subscription and merge into a `Record<nodeId, status>`.
- Endpoint offsets via `KIND_HALF_WIDTH` map — bump together if any node silhouette resizes.
- Inspector is `absolute` + `z-20` so it overlays the left of the canvas; if the overlap hides too much in the demo, M7.1b can either shift the SVG right with a padding transition or dim the diagram while open.

## Related

- #40 — umbrella issue (this is split **a**)
- #41 M7.2 — KPI bar (consumes the same monitoring APIs)
- #42 M7.3 — anomaly banner (ships the `anomaly_detected` wire that M7.1b then feeds into the P&ID)
- #44 (#112) — M7.5 artifact registry, merges first or in parallel; no file overlap

Closes #40 partially (M7.1a scope). Full #40 closes when M7.1b lands.