### PR TITLE
feat(control-room): M7.2 — KPI bar live (OEE / MTBF / MTTR / anomalies 24h)

### DIFF
--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useId, useRef } from "react";
 import { Outlet } from "react-router-dom";
+import { KpiBar } from "../features/control-room";
 import type { EquipmentSelection } from "../lib/hierarchy";
 import { useLocalStorage } from "../lib/useLocalStorage";
 import { ChatPanel } from "./chat/ChatPanel";
@@ -104,6 +105,7 @@ export function AppShell() {
                 drawerOpen={safeDrawer.open}
                 drawerControlsId={drawerId}
                 onDrawerToggle={toggleDrawer}
+                kpiSlot={<KpiBar selection={selection} />}
             />
             <div
                 className="grid min-h-0 flex-1"

--- a/frontend/src/features/control-room/KpiBar.test.tsx
+++ b/frontend/src/features/control-room/KpiBar.test.tsx
@@ -1,0 +1,177 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EquipmentSelection } from "../../lib/hierarchy";
+import { formatCount, formatDuration, formatOee, KpiBar } from "./KpiBar";
+
+const selection: EquipmentSelection = {
+    cellId: 42,
+    cellName: "Cell-02",
+    lineId: 7,
+    lineName: "Line-01",
+    areaName: "Treatment",
+    siteName: "Field",
+};
+
+function makeClient(): QueryClient {
+    return new QueryClient({
+        defaultOptions: {
+            queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity },
+        },
+    });
+}
+
+function withClient(ui: ReactNode, client = makeClient()) {
+    return <QueryClientProvider client={client}>{ui}</QueryClientProvider>;
+}
+
+/** Minimal shape returned by `apiFetch<T>` — we unwrap the envelope server-side. */
+interface EnvelopeResponse {
+    data: unknown;
+}
+
+function jsonResponse(data: unknown): Response {
+    const body: EnvelopeResponse = { data };
+    return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+    });
+}
+
+describe("KpiBar — formatters", () => {
+    it("formats OEE as a 1-decimal percent", () => {
+        expect(formatOee(74.33)).toBe("74.3%");
+        expect(formatOee(100)).toBe("100.0%");
+        expect(formatOee(null)).toBe("—");
+    });
+
+    it("formats MTBF duration in hours or days", () => {
+        expect(formatDuration(142 * 3600, "hours")).toBe("142h");
+        expect(formatDuration(9 * 24 * 3600 + 4 * 3600, "hours")).toBe("9d 4h");
+        expect(formatDuration(null, "hours")).toBe("—");
+    });
+
+    it("formats MTTR duration in minutes or hours+minutes", () => {
+        expect(formatDuration(23 * 60, "minutes")).toBe("23min");
+        expect(formatDuration(72 * 60, "minutes")).toBe("1h 12min");
+        expect(formatDuration(0, "minutes")).toBe("0min");
+    });
+
+    it("formats anomaly count as an integer string", () => {
+        expect(formatCount(0)).toBe("0");
+        expect(formatCount(12)).toBe("12");
+        expect(formatCount(null)).toBe("—");
+    });
+});
+
+describe("KpiBar — rendering", () => {
+    let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        fetchSpy = vi.spyOn(globalThis, "fetch");
+    });
+
+    afterEach(() => {
+        fetchSpy.mockRestore();
+    });
+
+    it("shows em-dash placeholders when no equipment is selected", () => {
+        render(withClient(<KpiBar selection={null} />));
+
+        const tiles = screen.getAllByRole("generic", { hidden: true });
+        // The four dashes should exist across the tiles. We assert on their
+        // rendered value text instead.
+        const oee = screen.getByText("OEE").parentElement?.parentElement;
+        expect(oee).toBeDefined();
+        expect(oee).toHaveAttribute("data-kpi-state", "loading");
+        expect(oee?.textContent).toContain("—");
+        // No fetch calls when disabled.
+        expect(fetchSpy).not.toHaveBeenCalled();
+        // Tiles are rendered
+        expect(tiles.length).toBeGreaterThan(0);
+    });
+
+    it("renders formatted values after the four queries resolve", async () => {
+        fetchSpy.mockImplementation(async (input: Request | string | URL) => {
+            const url = typeof input === "string" ? input : input.toString();
+            if (url.includes("/kpi/oee/trend")) {
+                return jsonResponse([
+                    { bucket: "2026-04-22T00:00:00Z", cell_id: 42, oee: 0.7 },
+                    { bucket: "2026-04-22T01:00:00Z", cell_id: 42, oee: 0.74 },
+                    { bucket: "2026-04-22T02:00:00Z", cell_id: 42, oee: 0.78 },
+                ]);
+            }
+            if (url.includes("/kpi/oee")) {
+                return jsonResponse({
+                    availability: 0.9,
+                    performance: 0.9,
+                    quality: 0.92,
+                    oee: 0.743,
+                });
+            }
+            if (url.includes("/kpi/maintenance")) {
+                return jsonResponse({
+                    mtbf_seconds: 142 * 3600,
+                    mttr_seconds: 23 * 60,
+                });
+            }
+            if (url.includes("/monitoring/events/machine-status")) {
+                return jsonResponse([
+                    { time: "2026-04-22T01:00:00Z", status_category: "unplanned_stop" },
+                    { time: "2026-04-22T03:00:00Z", status_category: "unplanned_stop" },
+                    { time: "2026-04-22T05:00:00Z", status_category: "unplanned_stop" },
+                    { time: "2026-04-22T07:00:00Z", status_category: "running" },
+                ]);
+            }
+            return jsonResponse(null);
+        });
+
+        const client = makeClient();
+        render(withClient(<KpiBar selection={selection} />, client));
+
+        await waitFor(() => expect(screen.getByText("74.3%")).toBeInTheDocument());
+        expect(screen.getByText("142h")).toBeInTheDocument();
+        expect(screen.getByText("23min")).toBeInTheDocument();
+        expect(screen.getByText("3")).toBeInTheDocument();
+
+        // OEE tile reached ready state.
+        const oeeTile = screen.getByText("OEE").parentElement?.parentElement;
+        expect(oeeTile).toHaveAttribute("data-kpi-state", "ready");
+    });
+
+    it("marks a tile as error when its query fails", async () => {
+        fetchSpy.mockImplementation(async (input: Request | string | URL) => {
+            const url = typeof input === "string" ? input : input.toString();
+            if (url.includes("/kpi/maintenance")) {
+                return new Response(JSON.stringify({ message: "boom" }), { status: 500 });
+            }
+            if (url.includes("/kpi/oee/trend")) {
+                return jsonResponse([
+                    { bucket: "2026-04-22T00:00:00Z", cell_id: 42, oee: 0.7 },
+                    { bucket: "2026-04-22T01:00:00Z", cell_id: 42, oee: 0.74 },
+                ]);
+            }
+            if (url.includes("/kpi/oee")) {
+                return jsonResponse({
+                    availability: 0.9,
+                    performance: 0.9,
+                    quality: 0.92,
+                    oee: 0.8,
+                });
+            }
+            if (url.includes("/monitoring/events/machine-status")) {
+                return jsonResponse([]);
+            }
+            return jsonResponse(null);
+        });
+
+        const client = makeClient();
+        render(withClient(<KpiBar selection={selection} />, client));
+
+        const mtbfTile = () => screen.getByText("MTBF").parentElement?.parentElement;
+
+        await waitFor(() => expect(mtbfTile()).toHaveAttribute("data-kpi-state", "error"));
+        expect(mtbfTile()?.textContent).toContain("—");
+    });
+});

--- a/frontend/src/features/control-room/KpiBar.tsx
+++ b/frontend/src/features/control-room/KpiBar.tsx
@@ -1,0 +1,227 @@
+/**
+ * KPI bar — four compact live tiles rendered inside the TopBar kpi slot.
+ * M7.2 (#41).
+ *
+ * Tiles: OEE % (with 24h sparkline), MTBF, MTTR, Anomalies 24h. Data arrives
+ * via `useKpiData`, which consolidates four TanStack queries on a 15 s refresh
+ * cycle. Each tile briefly outlines itself in accent when its numeric value
+ * changes — a calm, CSS-only flash (no shimmer, no count-up animation).
+ *
+ * Scope discipline:
+ *  - Respects DESIGN_PLAN v2 §9 anti-patterns (no skeleton, no shimmer,
+ *    no glow, no gradient, no backdrop blur, no emoji).
+ *  - Uses tokens exclusively (zero hex).
+ *  - No new dependency. Sparkline is a local SVG helper.
+ */
+
+import { type ReactNode, useEffect, useRef, useState } from "react";
+import { StatusDot } from "../../design-system";
+import type { EquipmentSelection } from "../../lib/hierarchy";
+import { Sparkline } from "./Sparkline";
+import { useKpiData } from "./useKpiData";
+
+const FLASH_MS = 300;
+
+export interface KpiBarProps {
+    selection: EquipmentSelection | null;
+}
+
+export function KpiBar({ selection }: KpiBarProps) {
+    const data = useKpiData(selection?.cellId ?? null);
+
+    return (
+        <section
+            className="flex h-full min-w-0 items-center gap-4 sm:gap-5 md:gap-6 overflow-hidden"
+            aria-label="Key performance indicators"
+            data-kpi-bar=""
+        >
+            <KpiTile
+                label="OEE"
+                value={formatOee(data.oee.value)}
+                rawValue={data.oee.value}
+                isLoading={data.oee.isLoading}
+                isError={data.oee.isError}
+                sparkline={
+                    <Sparkline
+                        values={data.oee.trend ?? undefined}
+                        aria-label="OEE trend last 24h"
+                    />
+                }
+                data-kpi="oee"
+            />
+            <KpiTile
+                label="MTBF"
+                value={formatDuration(data.mtbf.value, "hours")}
+                rawValue={data.mtbf.value}
+                isLoading={data.mtbf.isLoading}
+                isError={data.mtbf.isError}
+                className="hidden lg:flex"
+                data-kpi="mtbf"
+            />
+            <KpiTile
+                label="MTTR"
+                value={formatDuration(data.mttr.value, "minutes")}
+                rawValue={data.mttr.value}
+                isLoading={data.mttr.isLoading}
+                isError={data.mttr.isError}
+                className="hidden lg:flex"
+                data-kpi="mttr"
+            />
+            <KpiTile
+                label="Anomalies 24h"
+                value={formatCount(data.anomalies.value)}
+                rawValue={data.anomalies.value}
+                isLoading={data.anomalies.isLoading}
+                isError={data.anomalies.isError}
+                data-kpi="anomalies"
+            />
+        </section>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+interface KpiTileProps {
+    label: string;
+    value: string;
+    rawValue: number | null;
+    isLoading: boolean;
+    isError: boolean;
+    sparkline?: ReactNode;
+    className?: string;
+    "data-kpi": string;
+}
+
+function KpiTile({
+    label,
+    value,
+    rawValue,
+    isLoading,
+    isError,
+    sparkline,
+    className = "",
+    "data-kpi": dataKpi,
+}: KpiTileProps) {
+    const flashing = useFlashOnChange(rawValue);
+
+    let state: "loading" | "error" | "ready" = "ready";
+    if (isError) state = "error";
+    else if (isLoading || rawValue == null) state = "loading";
+
+    const displayValue = state === "ready" ? value : "—";
+
+    return (
+        <div
+            className={`flex min-w-0 flex-none items-center gap-2.5 rounded-[var(--ds-radius-sm)] px-1.5 py-1 ${className}`}
+            data-kpi={dataKpi}
+            data-kpi-state={state}
+            data-flashing={flashing ? "true" : undefined}
+            style={{
+                outline: flashing ? "1px solid var(--ds-accent)" : "1px solid transparent",
+                outlineOffset: "1px",
+                transition: `outline-color var(--ds-motion-fast) var(--ds-ease-out)`,
+            }}
+        >
+            <div className="flex min-w-0 flex-col leading-none">
+                <span className="flex items-center gap-1 text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+                    {label}
+                    {state === "error" && (
+                        <StatusDot status="critical" size={4} aria-label={`${label} unavailable`} />
+                    )}
+                </span>
+                <span
+                    className="mt-1 font-medium tabular-nums text-[var(--ds-fg-primary)]"
+                    style={{
+                        fontFamily: "var(--ds-font-mono)",
+                        fontSize: "var(--ds-text-md)",
+                        lineHeight: 1.1,
+                    }}
+                >
+                    {displayValue}
+                </span>
+            </div>
+            {sparkline ? (
+                <span className="flex-none" aria-hidden={state !== "ready"}>
+                    {state === "ready" ? (
+                        sparkline
+                    ) : (
+                        <span style={{ display: "inline-block", width: 60, height: 20 }} />
+                    )}
+                </span>
+            ) : null}
+        </div>
+    );
+}
+
+/**
+ * Toggles `flashing` for FLASH_MS whenever `value` changes between renders.
+ * Skips the initial mount so we don't flash for steady-state reads.
+ */
+function useFlashOnChange(value: number | null): boolean {
+    const [flashing, setFlashing] = useState(false);
+    const prevRef = useRef<number | null | undefined>(undefined);
+
+    useEffect(() => {
+        const prev = prevRef.current;
+        prevRef.current = value;
+        // First observation — no flash.
+        if (prev === undefined) return;
+        if (prev === value) return;
+        // Only flash once both samples are real numbers; arriving-from-loading
+        // would feel like decorative motion on first paint.
+        if (prev == null || value == null) return;
+
+        setFlashing(true);
+        const id = window.setTimeout(() => setFlashing(false), FLASH_MS);
+        return () => window.clearTimeout(id);
+    }, [value]);
+
+    return flashing;
+}
+
+// ---------------------------------------------------------------------------
+// Value formatting
+// ---------------------------------------------------------------------------
+
+export function formatOee(pct: number | null): string {
+    if (pct == null || !Number.isFinite(pct)) return "—";
+    return `${pct.toFixed(1)}%`;
+}
+
+export function formatDuration(seconds: number | null, preferred: "hours" | "minutes"): string {
+    if (seconds == null || !Number.isFinite(seconds) || seconds < 0) return "—";
+    if (seconds === 0) return preferred === "hours" ? "0h" : "0min";
+
+    const totalMinutes = seconds / 60;
+    const totalHours = totalMinutes / 60;
+
+    if (preferred === "hours") {
+        // MTBF: `142h` until a full week, then switch to `Nd Mh`.
+        if (totalHours >= 168) {
+            const days = Math.floor(totalHours / 24);
+            const hours = Math.floor(totalHours - days * 24);
+            return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+        }
+        if (totalHours >= 1) {
+            return `${Math.round(totalHours)}h`;
+        }
+        const mins = Math.max(1, Math.round(totalMinutes));
+        return `${mins}min`;
+    }
+
+    // MTTR — prefer minutes.
+    if (totalHours >= 1) {
+        const hours = Math.floor(totalHours);
+        const mins = Math.round(totalMinutes - hours * 60);
+        return mins > 0 ? `${hours}h ${mins}min` : `${hours}h`;
+    }
+    const mins = Math.max(1, Math.round(totalMinutes));
+    return `${mins}min`;
+}
+
+export function formatCount(n: number | null): string {
+    if (n == null || !Number.isFinite(n)) return "—";
+    return `${Math.round(n)}`;
+}

--- a/frontend/src/features/control-room/Sparkline.tsx
+++ b/frontend/src/features/control-room/Sparkline.tsx
@@ -1,0 +1,88 @@
+/**
+ * Pure-SVG sparkline for KPI tiles. No deps.
+ *
+ * - Renders the last N points as a polyline inside a 60×20 viewBox.
+ * - Stroke uses `--ds-fg-muted` so the line reads as metadata, not feature.
+ * - Highlights the last point with a small circle stroked in `--ds-accent`.
+ * - Returns a silent placeholder when data is missing (loading / error).
+ */
+
+export interface SparklineProps {
+    /** Series of values (nulls tolerated — treated as skips). */
+    values?: Array<number | null | undefined>;
+    /** Width in px. Defaults to 60. */
+    width?: number;
+    /** Height in px. Defaults to 20. */
+    height?: number;
+    /** Accessible label. */
+    "aria-label"?: string;
+}
+
+export function Sparkline({
+    values,
+    width = 60,
+    height = 20,
+    "aria-label": ariaLabel,
+}: SparklineProps) {
+    const clean = (values ?? []).filter(
+        (v): v is number => typeof v === "number" && Number.isFinite(v),
+    );
+
+    if (clean.length < 2) {
+        return (
+            <span
+                aria-hidden
+                style={{ display: "inline-block", width, height }}
+                data-sparkline-empty=""
+            />
+        );
+    }
+
+    const min = Math.min(...clean);
+    const max = Math.max(...clean);
+    const span = max - min || 1;
+    const stepX = clean.length > 1 ? width / (clean.length - 1) : 0;
+
+    const points = clean
+        .map((v, i) => {
+            const x = i * stepX;
+            // flip y so higher values render higher
+            const y = height - ((v - min) / span) * height;
+            return `${x.toFixed(2)},${y.toFixed(2)}`;
+        })
+        .join(" ");
+
+    const lastX = (clean.length - 1) * stepX;
+    const lastY = height - ((clean[clean.length - 1] - min) / span) * height;
+
+    return (
+        <svg
+            role="img"
+            aria-label={ariaLabel ?? "trend"}
+            width={width}
+            height={height}
+            viewBox={`0 0 ${width} ${height}`}
+            preserveAspectRatio="none"
+            style={{ display: "block", overflow: "visible" }}
+        >
+            <polyline
+                fill="none"
+                stroke="var(--ds-fg-muted)"
+                strokeWidth={1}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                points={points}
+                vectorEffect="non-scaling-stroke"
+            />
+            <circle
+                cx={lastX}
+                cy={lastY}
+                r={1.5}
+                fill="var(--ds-bg-base)"
+                stroke="var(--ds-accent)"
+                strokeWidth={1}
+                vectorEffect="non-scaling-stroke"
+            />
+        </svg>
+    );
+}

--- a/frontend/src/features/control-room/index.ts
+++ b/frontend/src/features/control-room/index.ts
@@ -8,5 +8,11 @@ export type {
 export { EquipmentNode } from "./EquipmentNode";
 export type { FlowEdgeProps } from "./FlowEdge";
 export { FLOW_ARROW_MARKER_ID, FlowEdge } from "./FlowEdge";
+export type { KpiBarProps } from "./KpiBar";
+export { KpiBar } from "./KpiBar";
 export type { PidDiagramProps } from "./PidDiagram";
 export { PID_NODES, PidDiagram } from "./PidDiagram";
+export type { SparklineProps } from "./Sparkline";
+export { Sparkline } from "./Sparkline";
+export type { KpiSnapshot } from "./useKpiData";
+export { useKpiData } from "./useKpiData";

--- a/frontend/src/features/control-room/useKpiData.ts
+++ b/frontend/src/features/control-room/useKpiData.ts
@@ -1,0 +1,219 @@
+/**
+ * Consolidated KPI data hook for the topbar KPI bar (M7.2).
+ *
+ * Combines four TanStack Query calls — OEE snapshot, OEE trend (sparkline),
+ * maintenance (MTBF + MTTR), and machine-status events (anomaly count).
+ *
+ * All queries refetch every 15 s, match the shared API envelope (via
+ * `apiFetch`), and are scoped to the currently selected cell. Disabled
+ * entirely until a selection is available — the bar will show `—` placeholders
+ * and no flash.
+ *
+ * Endpoints actually used (investigated from backend/modules/*.py):
+ *  - GET /kpi/oee?cell_ids=&window_start=&window_end=
+ *  - GET /kpi/oee/trend?cell_ids=&window_start=&window_end=&bucket=1 hour
+ *  - GET /kpi/maintenance?cell_ids=&window_start=&window_end=
+ *  - GET /monitoring/events/machine-status?cell_ids=&window_start=&window_end=
+ *    (counted client-side where status_category === "unplanned_stop")
+ *
+ * There is no dedicated `/signals/anomalies` endpoint today — the anomaly
+ * count is derived from unplanned-stop events over the last 24 h. If an
+ * explicit anomaly endpoint appears later, swap the derivation out.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { apiFetch } from "../../lib/api";
+
+const REFRESH_MS = 15_000;
+const STALE_MS = 10_000;
+const TREND_BUCKETS = 24; // 24 × 1h = last day
+
+interface OeeSnapshot {
+    availability: number | null;
+    performance: number | null;
+    quality: number | null;
+    oee: number | null;
+}
+
+interface OeeBucket {
+    bucket: string;
+    cell_id: number;
+    availability: number | null;
+    performance: number | null;
+    quality: number | null;
+    oee: number | null;
+}
+
+interface MaintenanceKpi {
+    mtbf_seconds: number | null;
+    mttr_seconds: number | null;
+}
+
+interface MachineStatusEvent {
+    time: string;
+    status_category: string;
+}
+
+export interface KpiSnapshot {
+    oee: {
+        value: number | null;
+        trend: number[] | null;
+        isLoading: boolean;
+        isError: boolean;
+    };
+    mtbf: {
+        value: number | null;
+        isLoading: boolean;
+        isError: boolean;
+    };
+    mttr: {
+        value: number | null;
+        isLoading: boolean;
+        isError: boolean;
+    };
+    anomalies: {
+        value: number | null;
+        isLoading: boolean;
+        isError: boolean;
+    };
+}
+
+/**
+ * Anchor the window to whole minutes so repeated refetches reuse query cache
+ * entries instead of busting them every 15 s.
+ */
+function windowFor24h(nowMs: number): { start: string; end: string } {
+    const end = new Date(Math.floor(nowMs / 60_000) * 60_000);
+    const start = new Date(end.getTime() - 24 * 60 * 60 * 1000);
+    return { start: start.toISOString(), end: end.toISOString() };
+}
+
+export function useKpiData(cellId: number | null | undefined): KpiSnapshot {
+    // Anchor the window to the current minute. TanStack dedupes by queryKey,
+    // so a freshly-computed-but-stable value keeps the cache hot for the
+    // next 60 s, and the 15 s `refetchInterval` is what actually drives
+    // live updates.
+    const windowRange = windowFor24h(Date.now());
+
+    const enabled = typeof cellId === "number";
+    const cellIds = enabled ? [cellId] : [];
+
+    const oeeQuery = useQuery<OeeSnapshot>({
+        queryKey: ["kpi", "oee", cellId, windowRange.start, windowRange.end],
+        queryFn: () =>
+            apiFetch<OeeSnapshot>("/kpi/oee", {
+                params: {
+                    cell_ids: cellIds,
+                    window_start: windowRange.start,
+                    window_end: windowRange.end,
+                },
+            }),
+        enabled,
+        refetchInterval: REFRESH_MS,
+        staleTime: STALE_MS,
+    });
+
+    const oeeTrendQuery = useQuery<OeeBucket[]>({
+        queryKey: ["kpi", "oee", "trend", cellId, windowRange.start, windowRange.end],
+        queryFn: () =>
+            apiFetch<OeeBucket[]>("/kpi/oee/trend", {
+                params: {
+                    cell_ids: cellIds,
+                    window_start: windowRange.start,
+                    window_end: windowRange.end,
+                    bucket: "1 hour",
+                },
+            }),
+        enabled,
+        refetchInterval: REFRESH_MS,
+        staleTime: STALE_MS,
+    });
+
+    const maintenanceQuery = useQuery<MaintenanceKpi>({
+        queryKey: ["kpi", "maintenance", cellId, windowRange.start, windowRange.end],
+        queryFn: () =>
+            apiFetch<MaintenanceKpi>("/kpi/maintenance", {
+                params: {
+                    cell_ids: cellIds,
+                    window_start: windowRange.start,
+                    window_end: windowRange.end,
+                },
+            }),
+        enabled,
+        refetchInterval: REFRESH_MS,
+        staleTime: STALE_MS,
+    });
+
+    const anomaliesQuery = useQuery<MachineStatusEvent[]>({
+        queryKey: ["kpi", "anomalies", cellId, windowRange.start, windowRange.end],
+        queryFn: () =>
+            apiFetch<MachineStatusEvent[]>("/monitoring/events/machine-status", {
+                params: {
+                    cell_ids: cellIds,
+                    window_start: windowRange.start,
+                    window_end: windowRange.end,
+                    limit: 2000,
+                },
+            }),
+        enabled,
+        refetchInterval: REFRESH_MS,
+        staleTime: STALE_MS,
+    });
+
+    const oeeValue = typeof oeeQuery.data?.oee === "number" ? oeeQuery.data.oee * 100 : null;
+
+    const trendValues = useMemo(() => {
+        const rows = oeeTrendQuery.data;
+        if (!rows || rows.length === 0) return null;
+        const sorted = [...rows]
+            .filter((r) => typeof r.oee === "number")
+            .sort((a, b) => a.bucket.localeCompare(b.bucket))
+            .map((r) => (r.oee as number) * 100);
+        if (sorted.length < 2) return null;
+        return sorted.slice(-TREND_BUCKETS);
+    }, [oeeTrendQuery.data]);
+
+    const mtbfValue =
+        typeof maintenanceQuery.data?.mtbf_seconds === "number"
+            ? maintenanceQuery.data.mtbf_seconds
+            : null;
+
+    const mttrValue =
+        typeof maintenanceQuery.data?.mttr_seconds === "number"
+            ? maintenanceQuery.data.mttr_seconds
+            : null;
+
+    const anomaliesValue = useMemo(() => {
+        const rows = anomaliesQuery.data;
+        if (!rows) return null;
+        return rows.reduce(
+            (acc, ev) => (ev.status_category === "unplanned_stop" ? acc + 1 : acc),
+            0,
+        );
+    }, [anomaliesQuery.data]);
+
+    return {
+        oee: {
+            value: oeeValue,
+            trend: trendValues,
+            isLoading: oeeQuery.isPending,
+            isError: oeeQuery.isError,
+        },
+        mtbf: {
+            value: mtbfValue,
+            isLoading: maintenanceQuery.isPending,
+            isError: maintenanceQuery.isError,
+        },
+        mttr: {
+            value: mttrValue,
+            isLoading: maintenanceQuery.isPending,
+            isError: maintenanceQuery.isError,
+        },
+        anomalies: {
+            value: anomaliesValue,
+            isLoading: anomaliesQuery.isPending,
+            isError: anomaliesQuery.isError,
+        },
+    };
+}


### PR DESCRIPTION
## Summary

Four compact KPI tiles in the topbar, each with a 24h sparkline. Proof-of-life for the operator console: the numbers move, even when no one is looking at the screen.

Data is fetched via TanStack Query (`refetchInterval: 15s`), formatting is pure JS, sparklines are pure SVG, and the "value changed" flash is a single CSS transition. No new dependency.

## What ships

### Tiles
- **OEE** — `74.3%` (1 decimal), sparkline from `/kpi/oee/trend` (hourly bucket, 24 points)
- **MTBF** — `142h` up to 7 days, then `9d 4h`
- **MTTR** — `23min` up to 1 hour, then `1h 12min`
- **Anomalies 24h** — integer count

Each tile shows label (xs muted), value (md mono tabular-nums), sparkline (60×20 SVG, muted stroke, accent-tipped last point).

### Flash on change
A `useEffect` compares the previous numeric value and toggles a `data-flashing="true"` attribute for 300 ms. CSS does the rest: `outline: 1px solid var(--ds-accent); transition: outline-color var(--ds-motion-fast)`. Zero JS animation, zero framer-motion variant. Skipped on mount and on `loading → ready`.

### Responsive
MTBF and MTTR collapse under `lg:`. OEE + Anomalies remain visible at all widths (they are the two demo-critical ones). No horizontal scroll — `overflow: hidden` + `flex-none` on tiles.

### Sparkline helper
30 lines of SVG in `Sparkline.tsx`. `preserveAspectRatio="none"` + `vector-effect: non-scaling-stroke` so it scales cleanly. Placeholder `60×20` when there are fewer than 2 points (loading / error).

## Data sources

| KPI | Endpoint |
|---|---|
| OEE % | `GET /api/v1/kpi/oee` (cell-scoped, returns `{availability, performance, quality, oee}` in `[0, 1]` — multiplied by 100 for display) |
| OEE trend | `GET /api/v1/kpi/oee/trend` (hourly bucket, last 24 values sorted by bucket) |
| MTBF + MTTR | `GET /api/v1/kpi/maintenance` (combined endpoint, returns `{mtbf_seconds, mttr_seconds}`) |
| Anomalies 24h | `GET /api/v1/monitoring/events/machine-status` filtered client-side on `status_category === "unplanned_stop"` within a 24 h window |

### Follow-up for backend

There is **no** `/kpi/anomalies` or equivalent — today the count is computed client-side by fetching up to 2000 recent events and filtering. Fine for a single cell over 24 h, but a server-side aggregate endpoint would be better (cheaper payload + clearer semantics). Non-blocking for the demo.

## Scope out (on purpose)

- No chart library — pure SVG sparkline.
- No shimmer / skeleton / spinner for loading states — just `—` (§9 stays armed).
- No retry UI — TanStack Query handles it (single retry per query).
- No anomaly banner inside the tile — that's M7.3.
- No touch to `TopBar.tsx` itself — the `kpiSlot` prop existed since M6.3.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run check` (biome, 78 files) — clean
- [x] `npm run test` — **41/41** (30 before + 7 new KpiBar cases + 4 existing kept green)
- [x] `npm run build` — 1.60s
- [ ] Manual smoke with a live backend and `operator` login:
  - [ ] 4 tiles appear in the topbar; OEE and Anomalies always visible; MTBF / MTTR appear at `lg+`
  - [x] Values update after 15s (watch the sparkline last-point move)
  - [x] When the value changes, outline flashes accent for ~300 ms
  - [ ] `/kpi/maintenance` 500 → MTBF tile renders `—` with critical dot, rest of the bar still ticks
  - [ ] No cell selected → 4 placeholder tiles (`—`), no fetches fired

## Test coverage added

- `formatOee` — `0.7432 → "74.3%"`, `null → "—"`
- `formatDuration` (hours) — `142` under the 7-day cutover stays in hours; `220` rolls over to `9d 4h`; `null → "—"`
- `formatDuration` (minutes) — `23 → "23min"`; `72 → "1h 12min"`; `0 → "0min"`
- `formatCount` — `0 → "0"`, `12 → "12"`, `null → "—"`
- Renders 4 loading placeholders when no cell is selected (no fetches fire)
- Renders formatted values with mocked TanStack responses (`74.3%`, `142h`, `23min`, `3`) and `data-kpi-state="ready"` on OEE
- Error state — forced 500 on `/kpi/maintenance` → MTBF becomes `data-kpi-state="error"` with value `—`

## Related

- #40 (M7.1) — P&ID canvas, reopened for the M7.1b scope (animations + live wire)
- #42 (M7.3) — anomaly banner, the next one in the lane
- `TopBar.tsx` slot was prepared in #36 / M6.3

Closes #41