### PR TITLE
feat(control-room): M7.1b — wire live anomaly status onto EquipmentGrid (#40)

### DIFF
--- a/frontend/src/features/control-room/EquipmentGrid.test.tsx
+++ b/frontend/src/features/control-room/EquipmentGrid.test.tsx
@@ -1,8 +1,48 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EquipmentGrid } from "./EquipmentGrid";
+import type { AnomalyEvent } from "./useAnomalyStream";
 import type { EquipmentEntry } from "./useEquipmentList";
+
+const useAnomalyStreamMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./useAnomalyStream", () => ({
+    useAnomalyStream: useAnomalyStreamMock,
+}));
+
+function anomaly(partial: Partial<AnomalyEvent> & { cell_id: number }): AnomalyEvent {
+    return {
+        cell_id: partial.cell_id,
+        signal_def_id: partial.signal_def_id ?? 11,
+        value: partial.value ?? 5,
+        threshold: partial.threshold ?? 4,
+        work_order_id: partial.work_order_id ?? 101,
+        time: partial.time ?? "2026-04-24T12:00:00.000Z",
+        severity: partial.severity ?? "alert",
+        direction: partial.direction ?? "high",
+        id:
+            partial.id ??
+            `${partial.cell_id}-${partial.signal_def_id ?? 11}-${partial.time ?? "t"}`,
+        receivedAt: partial.receivedAt ?? 0,
+    };
+}
+
+function mockStream(active: AnomalyEvent[]): void {
+    useAnomalyStreamMock.mockReturnValue({
+        active,
+        latest: active[0] ?? null,
+        count: active.length,
+        dismissAll: vi.fn(),
+        dismissLatest: vi.fn(),
+        connectionStatus: "open" as const,
+    });
+}
+
+beforeEach(() => {
+    useAnomalyStreamMock.mockReset();
+    mockStream([]);
+});
 
 const mockEntries: readonly EquipmentEntry[] = [
     {
@@ -81,5 +121,36 @@ describe("EquipmentGrid", () => {
         render(<EquipmentGrid entries={[]} selectedNodeId={null} onSelectNode={() => {}} />);
         expect(screen.getByTestId("equipment-grid")).toHaveAttribute("data-state", "empty");
         expect(screen.getByText("No equipment in scope.")).toBeInTheDocument();
+    });
+
+    it("overrides a backend-nominal status with a live trip anomaly for that cell", () => {
+        mockStream([anomaly({ cell_id: 1, severity: "trip" })]);
+        render(
+            <EquipmentGrid entries={mockEntries} selectedNodeId={null} onSelectNode={() => {}} />,
+        );
+        expect(screen.getByTestId("equipment-node-cell:1")).toHaveAttribute(
+            "data-status",
+            "critical",
+        );
+        // Unaffected cells keep their backend-provided baseline.
+        expect(screen.getByTestId("equipment-node-cell:2")).toHaveAttribute(
+            "data-status",
+            "nominal",
+        );
+        expect(screen.getByTestId("equipment-node-cell:3")).toHaveAttribute(
+            "data-status",
+            "nominal",
+        );
+    });
+
+    it("maps a live alert anomaly to the 'warning' status on the matching card", () => {
+        mockStream([anomaly({ cell_id: 2, severity: "alert" })]);
+        render(
+            <EquipmentGrid entries={mockEntries} selectedNodeId={null} onSelectNode={() => {}} />,
+        );
+        expect(screen.getByTestId("equipment-node-cell:2")).toHaveAttribute(
+            "data-status",
+            "warning",
+        );
     });
 });

--- a/frontend/src/features/control-room/EquipmentGrid.tsx
+++ b/frontend/src/features/control-room/EquipmentGrid.tsx
@@ -1,4 +1,5 @@
 import { EquipmentNode } from "./EquipmentNode";
+import { useAnomalyStatusMap } from "./useAnomalyStatusMap";
 import type { EquipmentEntry } from "./useEquipmentList";
 
 export interface EquipmentGridProps {
@@ -39,6 +40,10 @@ export function EquipmentGrid({
     isLoading = false,
     className = "",
 }: EquipmentGridProps) {
+    // M7.1b: overlay the live anomaly stream on top of the backend baseline.
+    // Absence from the map = keep the entry's own status (nominal by default).
+    const anomalyStatusMap = useAnomalyStatusMap();
+
     if (isLoading) {
         return (
             <div
@@ -70,18 +75,24 @@ export function EquipmentGrid({
             className={`grid h-full auto-rows-min list-none grid-cols-2 gap-[var(--ds-space-3,12px)] overflow-auto p-[var(--ds-space-4,16px)] md:grid-cols-3 lg:grid-cols-4 ${className}`}
             aria-label="Equipment cells"
         >
-            {entries.map((entry) => (
-                <li key={entry.id}>
-                    <EquipmentNode
-                        id={entry.id}
-                        label={entry.label}
-                        sublabel={entry.sublabel}
-                        status={entry.status}
-                        selected={selectedNodeId === entry.id}
-                        onClick={() => onSelectNode(entry.id)}
-                    />
-                </li>
-            ))}
+            {entries.map((entry) => {
+                // Live anomaly severity wins over the backend-hardcoded
+                // status; absence of a live entry falls back cleanly.
+                const liveStatus = anomalyStatusMap.get(entry.cellId);
+                const status = liveStatus ?? entry.status;
+                return (
+                    <li key={entry.id}>
+                        <EquipmentNode
+                            id={entry.id}
+                            label={entry.label}
+                            sublabel={entry.sublabel}
+                            status={status}
+                            selected={selectedNodeId === entry.id}
+                            onClick={() => onSelectNode(entry.id)}
+                        />
+                    </li>
+                );
+            })}
         </ul>
     );
 }

--- a/frontend/src/features/control-room/index.ts
+++ b/frontend/src/features/control-room/index.ts
@@ -14,6 +14,8 @@ export type { KpiBarProps } from "./KpiBar";
 export { KpiBar } from "./KpiBar";
 export type { SparklineProps } from "./Sparkline";
 export { Sparkline } from "./Sparkline";
+export type { AnomalyStatus, LiveAnomalyStatus } from "./useAnomalyStatusMap";
+export { useAnomalyStatusMap } from "./useAnomalyStatusMap";
 export type {
     AnomalyConnectionStatus,
     AnomalyEvent,

--- a/frontend/src/features/control-room/useAnomalyStatusMap.test.ts
+++ b/frontend/src/features/control-room/useAnomalyStatusMap.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Unit tests for `useAnomalyStatusMap` — the M7.1b live status overlay hook.
+ *
+ * We mock `useAnomalyStream` directly (rather than driving the WS mock) so
+ * each case narrates a single transformation: a fixed set of active anomalies
+ * in, a `cell_id → status` map out. The mock-WS integration path is already
+ * covered by `useAnomalyStream.test.ts`.
+ */
+
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useAnomalyStatusMap } from "./useAnomalyStatusMap";
+import type { AnomalyEvent } from "./useAnomalyStream";
+
+const useAnomalyStreamMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./useAnomalyStream", () => ({
+    useAnomalyStream: useAnomalyStreamMock,
+}));
+
+function anomaly(partial: Partial<AnomalyEvent> & { cell_id: number }): AnomalyEvent {
+    return {
+        cell_id: partial.cell_id,
+        signal_def_id: partial.signal_def_id ?? 11,
+        value: partial.value ?? 5,
+        threshold: partial.threshold ?? 4,
+        work_order_id: partial.work_order_id ?? 101,
+        time: partial.time ?? "2026-04-24T12:00:00.000Z",
+        severity: partial.severity ?? "alert",
+        direction: partial.direction ?? "high",
+        id:
+            partial.id ??
+            `${partial.cell_id}-${partial.signal_def_id ?? 11}-${partial.time ?? "t"}`,
+        receivedAt: partial.receivedAt ?? 0,
+    };
+}
+
+function mockStream(active: AnomalyEvent[]): void {
+    useAnomalyStreamMock.mockReturnValue({
+        active,
+        latest: active[0] ?? null,
+        count: active.length,
+        dismissAll: vi.fn(),
+        dismissLatest: vi.fn(),
+        connectionStatus: "open" as const,
+    });
+}
+
+beforeEach(() => {
+    useAnomalyStreamMock.mockReset();
+});
+
+describe("useAnomalyStatusMap", () => {
+    it("returns an empty map when no anomaly is active", () => {
+        mockStream([]);
+        const { result } = renderHook(() => useAnomalyStatusMap());
+        expect(result.current.size).toBe(0);
+    });
+
+    it("maps a single alert anomaly to 'warning'", () => {
+        mockStream([anomaly({ cell_id: 1, severity: "alert" })]);
+        const { result } = renderHook(() => useAnomalyStatusMap());
+        expect(result.current.get(1)).toBe("warning");
+        expect(result.current.size).toBe(1);
+    });
+
+    it("maps a single trip anomaly to 'critical'", () => {
+        mockStream([anomaly({ cell_id: 2, severity: "trip" })]);
+        const { result } = renderHook(() => useAnomalyStatusMap());
+        expect(result.current.get(2)).toBe("critical");
+        expect(result.current.size).toBe(1);
+    });
+
+    it("lets trip win over alert when both target the same cell", () => {
+        mockStream([
+            anomaly({ cell_id: 1, severity: "alert", time: "2026-04-24T12:00:00.000Z" }),
+            anomaly({ cell_id: 1, severity: "trip", time: "2026-04-24T12:00:01.000Z" }),
+        ]);
+        const { result } = renderHook(() => useAnomalyStatusMap());
+        expect(result.current.get(1)).toBe("critical");
+        expect(result.current.size).toBe(1);
+    });
+
+    it("keeps trip on a cell even if a later alert arrives for the same cell", () => {
+        // Stream is newest-first; insertion order can vary, so assert the
+        // outcome not the iteration path.
+        mockStream([
+            anomaly({ cell_id: 1, severity: "trip", time: "2026-04-24T12:00:00.000Z" }),
+            anomaly({ cell_id: 1, severity: "alert", time: "2026-04-24T12:00:01.000Z" }),
+        ]);
+        const { result } = renderHook(() => useAnomalyStatusMap());
+        expect(result.current.get(1)).toBe("critical");
+    });
+
+    it("handles multiple cells independently", () => {
+        mockStream([
+            anomaly({ cell_id: 1, severity: "alert" }),
+            anomaly({ cell_id: 2, severity: "trip" }),
+            anomaly({ cell_id: 3, severity: "alert" }),
+        ]);
+        const { result } = renderHook(() => useAnomalyStatusMap());
+        expect(result.current.get(1)).toBe("warning");
+        expect(result.current.get(2)).toBe("critical");
+        expect(result.current.get(3)).toBe("warning");
+        expect(result.current.get(99)).toBeUndefined();
+        expect(result.current.size).toBe(3);
+    });
+
+    it("never emits 'nominal' or 'unknown' — absence carries that meaning", () => {
+        mockStream([
+            anomaly({ cell_id: 1, severity: "alert" }),
+            anomaly({ cell_id: 2, severity: "trip" }),
+        ]);
+        const { result } = renderHook(() => useAnomalyStatusMap());
+        for (const value of result.current.values()) {
+            expect(value === "warning" || value === "critical").toBe(true);
+        }
+    });
+
+    it("is memoized across re-renders when the active array reference is stable", () => {
+        const active = [anomaly({ cell_id: 1, severity: "alert" })];
+        mockStream(active);
+        const { result, rerender } = renderHook(() => useAnomalyStatusMap());
+        const first = result.current;
+        rerender();
+        expect(result.current).toBe(first);
+    });
+
+    it("recomputes the map when the active array reference changes", () => {
+        mockStream([anomaly({ cell_id: 1, severity: "alert" })]);
+        const { result, rerender } = renderHook(() => useAnomalyStatusMap());
+        const first = result.current;
+
+        mockStream([
+            anomaly({ cell_id: 1, severity: "alert" }),
+            anomaly({ cell_id: 2, severity: "trip" }),
+        ]);
+        rerender();
+
+        expect(result.current).not.toBe(first);
+        expect(result.current.get(2)).toBe("critical");
+    });
+});

--- a/frontend/src/features/control-room/useAnomalyStatusMap.ts
+++ b/frontend/src/features/control-room/useAnomalyStatusMap.ts
@@ -1,0 +1,58 @@
+/**
+ * M7.1b — Derive an equipment status map from the live anomaly stream.
+ *
+ * `EquipmentGrid` renders a backend-driven list of cells whose `status` is
+ * still hardcoded to `nominal` (see `useEquipmentList`). This hook overlays
+ * the live Sentinel stream on top of that baseline: when an anomaly lands
+ * for `cell_id=N`, the map exposes `warning` or `critical` for that cell
+ * and the caller can override its own fallback.
+ *
+ * Severity rules (trip always beats alert):
+ *  - any active anomaly with `severity="trip"` on cell X → `critical`
+ *  - otherwise any active anomaly with `severity="alert"` on cell X → `warning`
+ *  - no active anomaly on cell X → absent from the map (caller falls back
+ *    to its own baseline, typically `nominal`)
+ *
+ * `unknown` is intentionally *not* produced here — that status is reserved
+ * for disabled / offline equipment surfaced by the backend hierarchy, not
+ * for "no anomaly seen yet".
+ *
+ * The returned map is memoized against the `active` array reference from
+ * `useAnomalyStream`, so re-renders without new anomalies yield the same
+ * identity — keeps `EquipmentGrid`'s render cheap and React keys stable.
+ */
+
+import { useMemo } from "react";
+import { useAnomalyStream } from "./useAnomalyStream";
+
+export type AnomalyStatus = "nominal" | "warning" | "critical" | "unknown";
+
+/** Severity-derived statuses only. Absence = nominal at the caller. */
+export type LiveAnomalyStatus = "warning" | "critical";
+
+/**
+ * Build a `cell_id → status` map from the currently active anomaly stream.
+ *
+ * @returns A readonly map keyed by numeric cell id. Cells without any active
+ *          anomaly are absent from the map — callers should fall back to
+ *          their own default (typically the backend-provided `nominal`).
+ */
+export function useAnomalyStatusMap(): ReadonlyMap<number, LiveAnomalyStatus> {
+    const { active } = useAnomalyStream();
+
+    return useMemo(() => {
+        const map = new Map<number, LiveAnomalyStatus>();
+        for (const evt of active) {
+            const existing = map.get(evt.cell_id);
+            // Trip wins over alert. Once a cell is marked critical, nothing
+            // downgrades it in this pass.
+            if (existing === "critical") continue;
+            if (evt.severity === "trip") {
+                map.set(evt.cell_id, "critical");
+            } else if (evt.severity === "alert" && existing !== "warning") {
+                map.set(evt.cell_id, "warning");
+            }
+        }
+        return map;
+    }, [active]);
+}


### PR DESCRIPTION
## Summary

Closes the M7.1 loop. The adaptive equipment grid shipped in #115, the anomaly event bus in #116 — this PR plugs them together. When Sentinel detects a breach on `cell_id=N`, the matching card in the Control Room grid now flips from `nominal` (green rail) to `warning` (amber) or `critical` (red) live, without a refresh.

## What ships

### `useAnomalyStatusMap` — derived overlay hook

New hook in `frontend/src/features/control-room/useAnomalyStatusMap.ts`.

- Consumes `useAnomalyStream().active` and returns a `ReadonlyMap<number, "warning" | "critical">`.
- Rules: any `severity="trip"` for cell X → `critical`; otherwise any `alert` → `warning`. Trip beats alert on the same cell regardless of arrival order.
- Absence from the map means "no active anomaly" — the caller falls back to its own baseline (today the backend-served `nominal`, tomorrow potentially `unknown` for offline cells). Cleaner than forcing a ternary on every entry.
- Memoized over the identity of `active` so the React tree doesn't re-render unnecessarily on `requestFocus` churn.

### `EquipmentGrid` — status override

One-line override on the per-entry status:

```ts
const statusMap = useAnomalyStatusMap();
// ...
status={statusMap.get(entry.cellId) ?? entry.status}
```

Nothing else in the grid changes. `EquipmentNode` already handles the four status values (`nominal` / `warning` / `critical` / `unknown`) via the DS `Card` rail — no visual change needed inside the node.

### No new animation

Per DESIGN_PLAN §9, this PR **does not add** a pulse, a glow, a ripple, a neon tint, or a shake. The rail tone shift from green to amber/red is already a strong enough signal on an industrial-operator console, and the existing `transition-[box-shadow,border-color] duration-[var(--ds-motion-fast)]` on the node smooths the change over ~160 ms. That's it.

## Scope out (deliberate)

- **Bonus: auto-prefill the chat on clicking a critical card.** Considered and skipped — would need to thread `statusMap` or `useAnomalyStream` into `ControlRoomPage`, parse the `cell:N` id, and reach into `useChatStore.sendMessage` from a click handler. Non-trivial refactor for a nice-to-have. The `Investigate` CTA inside the M7.3 AnomalyBanner already covers that hand-off and is the canonical path.
- **Node animations** — not in this PR, probably never. §9 stays armed.
- **Inspector body upgrade** (signals / KB / recent WOs) — still placeholders, lives in M8.x.

## Design compliance

- Zero hex literal. Zero gradient. Zero glow / pulse / ripple / shimmer / backdrop-blur. §9 respected.
- No new dependency — hook is a thin `useMemo` on top of `useAnomalyStream`.
- No new motion variant added to `design-system/motion.ts`.
- No refactor of `EquipmentNode`, `EquipmentInspector`, `AppShell`, `TopBar`, or any peer module.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run check` (biome, 86 files) — clean
- [x] `npm run test` — **79/79** (baseline 68 + 11 new: 9 `useAnomalyStatusMap` + 2 `EquipmentGrid` status override)
- [x] `npm run build` — clean
- [x] Manual smoke against a live backend:
  - [x] Cancel the recent open WOs so Sentinel's 30 min debounce lifts: `docker exec aria-timescaledb psql -U aria -d aria -c "UPDATE work_order SET status='cancelled' WHERE cell_id=1 AND created_at > NOW() - INTERVAL '30 minutes' AND status != 'cancelled';"`
  - [x] Wait up to 30 s for the next Sentinel tick
  - [x] P-02 card rail flips from green to amber/red depending on severity
  - [x] Dismissing the banner (×) leaves the card state as-is; a new `anomaly_detected` frame or `dismissAll` brings it back

## Test coverage added

**`useAnomalyStatusMap.test.ts`** — 9 cases
- Empty active list → empty map
- Single `alert` on cell N → `{N: "warning"}`
- Single `trip` on cell N → `{N: "critical"}`
- Trip + alert on same cell → `critical` (trip wins, regardless of order)
- Multi-cell independence (cell 1 alert + cell 2 trip → `{1: warning, 2: critical}`)
- Never emits `nominal` or `unknown` (those are caller-side semantics)
- Stable reference across re-renders with the same `active` array (memoization invariant)
- Recomputes when `active` gets a new reference

**`EquipmentGrid.test.tsx`** — 2 new cases
- A mocked `trip` anomaly on cell 1 → cell 1 renders `data-status="critical"` while cells 2 and 3 stay `nominal`
- An `alert` anomaly maps to `data-status="warning"`

## Related

- #40 — umbrella issue (this PR closes the M7.1 scope: M7.1a #113 skeleton, #115 adaptive refactor, **this** M7.1b wire)
- #42 (PR #116) — anomaly stream feeding this overlay
- #41 (PR #114) — KPI bar, peer consumer of live cell data

Closes #40