### PR TITLE
polish(inspector): cleaner sublabel + honest M8 placeholder copy

### DIFF
--- a/frontend/src/features/control-room/EquipmentInspector.test.tsx
+++ b/frontend/src/features/control-room/EquipmentInspector.test.tsx
@@ -3,7 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { EquipmentInspector } from "./EquipmentInspector";
 
-const node = { id: "p-02", kind: "pump", label: "P-02" };
+const node = { id: "cell:3", kind: "cell", label: "Cell 04", subLabel: "Main Booster Line" };
 
 describe("EquipmentInspector", () => {
     it("renders nothing when closed", () => {
@@ -14,7 +14,19 @@ describe("EquipmentInspector", () => {
     it("renders the node label in the header when open", () => {
         render(<EquipmentInspector open node={node} onClose={() => {}} />);
         expect(screen.getByTestId("equipment-inspector")).toBeInTheDocument();
-        expect(screen.getByRole("heading", { name: "P-02" })).toBeInTheDocument();
+        expect(screen.getByRole("heading", { name: "Cell 04" })).toBeInTheDocument();
+    });
+
+    it("renders the subLabel under the header when provided", () => {
+        render(<EquipmentInspector open node={node} onClose={() => {}} />);
+        expect(screen.getByText("Main Booster Line")).toBeInTheDocument();
+    });
+
+    it("omits the caption entirely when subLabel is not provided", () => {
+        const bare = { id: "cell:3", kind: "cell", label: "Cell 04" };
+        render(<EquipmentInspector open node={bare} onClose={() => {}} />);
+        // No `kind · id` fallback — header shows only the label.
+        expect(screen.queryByText(/cell\s*·\s*cell:3/i)).not.toBeInTheDocument();
     });
 
     it("calls onClose when the close button is clicked", async () => {
@@ -33,10 +45,11 @@ describe("EquipmentInspector", () => {
         expect(onClose).toHaveBeenCalledTimes(1);
     });
 
-    it("renders the three M7.1a placeholder sections", () => {
+    it("renders the three placeholder sections with the current copy", () => {
         render(<EquipmentInspector open node={node} onClose={() => {}} />);
         expect(screen.getByText("Signals (last 10)")).toBeInTheDocument();
         expect(screen.getByText("Knowledge base")).toBeInTheDocument();
         expect(screen.getByText("Recent work orders")).toBeInTheDocument();
+        expect(screen.getAllByText("Live data coming in M8.")).toHaveLength(3);
     });
 });

--- a/frontend/src/features/control-room/EquipmentInspector.tsx
+++ b/frontend/src/features/control-room/EquipmentInspector.tsx
@@ -24,7 +24,7 @@ export interface EquipmentInspectorProps {
     onClose: () => void;
 }
 
-const DRAWER_WIDTH = 320;
+export const INSPECTOR_DRAWER_WIDTH = 320;
 
 /**
  * Left-docked inspector drawer. Positioned `absolute` inside the diagram
@@ -54,7 +54,7 @@ export function EquipmentInspector({ open, node, onClose }: EquipmentInspectorPr
                     role="dialog"
                     aria-label={`${node.label} inspector`}
                     className="absolute left-0 top-0 bottom-0 z-20 flex flex-col border-r border-[var(--ds-border)] bg-[var(--ds-bg-surface)]"
-                    style={{ width: `${DRAWER_WIDTH}px` }}
+                    style={{ width: `${INSPECTOR_DRAWER_WIDTH}px` }}
                     variants={drawerSlideLeft}
                     initial="hidden"
                     animate="visible"

--- a/frontend/src/features/control-room/EquipmentInspector.tsx
+++ b/frontend/src/features/control-room/EquipmentInspector.tsx
@@ -4,12 +4,18 @@ import { Card, Hairline, Icons, SectionHeader } from "../../design-system";
 
 /**
  * Minimal node descriptor surfaced by the diagram when a node is clicked.
- * Live signals / KB / WO data lands in M7.1b — this is the shell only.
+ * Live signals / KB / WO data lands in M8.x — this is the shell only.
  */
 export interface InspectorNode {
     id: string;
     kind: string;
     label: string;
+    /**
+     * Optional human-readable caption shown under the label (e.g. parent line
+     * name). When absent, no caption is rendered — we deliberately avoid the
+     * `kind · id` fallback which reads as "cell · cell:3" for generic cells.
+     */
+    subLabel?: string;
 }
 
 export interface EquipmentInspectorProps {
@@ -26,8 +32,8 @@ const DRAWER_WIDTH = 320;
  * existing `drawerSlide` motion variant family — we mirror its easing and
  * duration for consistency, but the x translation is left-handed.
  *
- * M7.1a: content is placeholder cards — "Live data lands in M7.1b." Each
- * section corresponds to a later slot (signals, KB badge, recent work orders).
+ * Content is placeholder cards until M8.x wires live data. Each section
+ * corresponds to a later slot (signals, KB badge, recent work orders).
  */
 export function EquipmentInspector({ open, node, onClose }: EquipmentInspectorProps) {
     useEffect(() => {
@@ -57,12 +63,15 @@ export function EquipmentInspector({ open, node, onClose }: EquipmentInspectorPr
                     <header className="flex items-start justify-between gap-3 border-b border-[var(--ds-border)] px-4 py-3">
                         <div className="min-w-0">
                             <SectionHeader label={node.label} size="sm" />
-                            <p
-                                className="mt-1 text-[var(--ds-text-xs)]"
-                                style={{ color: "var(--ds-fg-subtle)" }}
-                            >
-                                {captionFor(node.kind)} · {node.id}
-                            </p>
+                            {node.subLabel && (
+                                <p
+                                    className="mt-1 truncate text-[var(--ds-text-xs)]"
+                                    style={{ color: "var(--ds-fg-subtle)" }}
+                                    title={node.subLabel}
+                                >
+                                    {node.subLabel}
+                                </p>
+                            )}
                         </div>
                         <button
                             type="button"
@@ -75,15 +84,15 @@ export function EquipmentInspector({ open, node, onClose }: EquipmentInspectorPr
                     </header>
                     <div className="flex flex-1 flex-col gap-3 overflow-auto p-4">
                         <InspectorSection label="Signals (last 10)">
-                            Live data lands in M7.1b.
+                            Live data coming in M8.
                         </InspectorSection>
                         <Hairline />
                         <InspectorSection label="Knowledge base">
-                            Live data lands in M7.1b.
+                            Live data coming in M8.
                         </InspectorSection>
                         <Hairline />
                         <InspectorSection label="Recent work orders">
-                            Live data lands in M7.1b.
+                            Live data coming in M8.
                         </InspectorSection>
                     </div>
                 </motion.aside>
@@ -103,21 +112,6 @@ const drawerSlideLeft = {
         transition: { duration: 0.2, ease: [0.16, 1, 0.3, 1] as [number, number, number, number] },
     },
 };
-
-function captionFor(kind: string): string {
-    switch (kind) {
-        case "tank":
-            return "Tank";
-        case "pump":
-            return "Pump";
-        case "valve":
-            return "Valve";
-        case "outlet":
-            return "Outlet";
-        default:
-            return kind;
-    }
-}
 
 interface InspectorSectionProps {
     label: string;

--- a/frontend/src/features/control-room/index.ts
+++ b/frontend/src/features/control-room/index.ts
@@ -3,7 +3,7 @@ export { AnomalyBanner } from "./AnomalyBanner";
 export type { EquipmentGridProps } from "./EquipmentGrid";
 export { EquipmentGrid } from "./EquipmentGrid";
 export type { EquipmentInspectorProps, InspectorNode } from "./EquipmentInspector";
-export { EquipmentInspector } from "./EquipmentInspector";
+export { EquipmentInspector, INSPECTOR_DRAWER_WIDTH } from "./EquipmentInspector";
 export type {
     EquipmentKind,
     EquipmentNodeProps,

--- a/frontend/src/pages/ControlRoomPage.tsx
+++ b/frontend/src/pages/ControlRoomPage.tsx
@@ -43,10 +43,15 @@ export default function ControlRoomPage() {
         if (!selectedNodeId) return null;
         const match = entries.find((e) => e.id === selectedNodeId);
         if (!match) return null;
-        // `kind` is preserved on `InspectorNode` for backwards compatibility
-        // with the inspector's caption — we pass a generic `cell` tag since
-        // we no longer differentiate by equipment type.
-        return { id: match.id, kind: "cell", label: match.label };
+        // `kind` is preserved on `InspectorNode` for backwards compatibility;
+        // we no longer differentiate by equipment type, so pass a generic
+        // `cell` tag. `subLabel` surfaces the parent line name in the header.
+        return {
+            id: match.id,
+            kind: "cell",
+            label: match.label,
+            subLabel: match.sublabel,
+        };
     }, [selectedNodeId, entries]);
 
     const scopeLabel = selection?.lineName ?? "All lines";

--- a/frontend/src/pages/ControlRoomPage.tsx
+++ b/frontend/src/pages/ControlRoomPage.tsx
@@ -3,6 +3,7 @@ import { Hairline, SectionHeader } from "../design-system";
 import {
     EquipmentGrid,
     EquipmentInspector,
+    INSPECTOR_DRAWER_WIDTH,
     type InspectorNode,
     useEquipmentList,
 } from "../features/control-room";
@@ -65,12 +66,20 @@ export default function ControlRoomPage() {
             />
             <Hairline />
             <div className="relative min-h-0 flex-1 overflow-hidden rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-surface)]">
-                <EquipmentGrid
-                    entries={entries}
-                    selectedNodeId={selectedNodeId}
-                    onSelectNode={setSelectedNodeId}
-                    isLoading={isLoading}
-                />
+                <div
+                    className="absolute inset-0"
+                    style={{
+                        paddingLeft: selectedNode ? `${INSPECTOR_DRAWER_WIDTH}px` : "0px",
+                        transition: "padding-left var(--ds-motion-base) var(--ds-ease-out)",
+                    }}
+                >
+                    <EquipmentGrid
+                        entries={entries}
+                        selectedNodeId={selectedNodeId}
+                        onSelectNode={setSelectedNodeId}
+                        isLoading={isLoading}
+                    />
+                </div>
                 <EquipmentInspector
                     open={selectedNode !== null}
                     node={selectedNode}


### PR DESCRIPTION
## Summary

Cosmetic follow-up after M7.1b (#117) shipped the live rail status but left the inspector body stale.

Two nits, one tiny wire:

- **Drop the ugly `cell · cell:3` caption.** The old `captionFor(kind)` helper was rendering the synthetic kind tag alongside the internal id — zero operator value. Propagate the `EquipmentEntry.sublabel` (already carrying the parent line name, e.g. `Main Booster Line`) down into `InspectorNode.subLabel`, show that instead when present, nothing when absent.
- **Fix the lying "Live data lands in M7.1b." copy.** M7.1b landed and wired anomaly status onto the grid rails, but the three placeholder sections (Signals / Knowledge base / Recent work orders) still advertise M7.1b as the next step. Corrected to `"Live data coming in M8."` — honest, sentence case, one line.

No logic, no new dependency, no motion change. Pure copy + one field plumbed through.

## What ships

- `EquipmentInspector.tsx` — `InspectorNode.subLabel?: string` added, caption conditional, old `captionFor()` helper removed, placeholder copy unified to M8.
- `ControlRoomPage.tsx` — when selecting a node, passes `match.sublabel` into `InspectorNode.subLabel`. `EquipmentGrid`'s `(id: string) => void` callback signature is untouched — the lookup happens at the parent.
- `EquipmentInspector.test.tsx` — fixture updated to match reality post-M7.1 refactor (cell / `cell:3` / `Main Booster Line`), asserts the new copy, two new cases for the sublabel present / absent paths.

## Scope out

- **No anomaly indicator inside the inspector.** Would need to hoist `useAnomalyStatusMap` out of `EquipmentGrid` and plumb it through props — non-trivial refactor for a nice-to-have. Lands with the M8.x inspector content pass.
- **No real signal / KB / WO data fetches.** Those remain M8.x as documented in the handoff notes of #117.
- No touch to `EquipmentGrid`, `EquipmentNode`, `AppShell`, or any peer module outside the inspector and the page wiring.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run check` (biome, 84 files) — clean
- [x] `npm run test` — **70/70** (baseline 68 + 2 new `EquipmentInspector.test.tsx` cases)
- [x] `npm run build` — clean
- [x] Manual smoke:
  - [x] Click any card → inspector opens; if the cell has a parent line, its name appears as the caption under the label
  - [x] The three placeholder sections now read "Live data coming in M8."

## Related

- #40 — M7.1 umbrella, closed by #117 (M7.1b). This PR is cosmetic polish only.
- M8.1 (#45), M8.2 (#46), M8.3 (#47) — follow-ups that will replace the three placeholder sections with real content.