### PR TITLE
feat(artifacts): M8.1 — live SignalChart via recharts (#45)

### DIFF
--- a/frontend/src/artifacts/placeholders/SignalChart.test.tsx
+++ b/frontend/src/artifacts/placeholders/SignalChart.test.tsx
@@ -1,0 +1,215 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Recharts ResponsiveContainer measures its parent with ResizeObserver; in JSDom
+// this returns 0×0 and the inner chart never renders its SVG children. Replace
+// with a pass-through that injects explicit width/height into the inner chart
+// (Recharts honors direct `width`/`height` props as an explicit mode).
+vi.mock("recharts", async () => {
+    const actual = await vi.importActual<typeof import("recharts")>("recharts");
+    const { cloneElement, isValidElement } = await import("react");
+    return {
+        ...actual,
+        ResponsiveContainer: ({ children }: { children: ReactNode }) => {
+            if (isValidElement(children)) {
+                return cloneElement(
+                    children as React.ReactElement<{ width?: number; height?: number }>,
+                    { width: 400, height: 200 },
+                );
+            }
+            return <>{children}</>;
+        },
+    };
+});
+
+import { SignalChart } from "./SignalChart";
+
+// ---------- Helpers ----------
+
+function makeClient(): QueryClient {
+    return new QueryClient({
+        defaultOptions: {
+            queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity },
+        },
+    });
+}
+
+function withClient(ui: ReactNode, client = makeClient()) {
+    return <QueryClientProvider client={client}>{ui}</QueryClientProvider>;
+}
+
+function jsonResponse(data: unknown, status = 200): Response {
+    return new Response(JSON.stringify({ status, message: "OK", data }), {
+        status,
+        headers: { "Content-Type": "application/json" },
+    });
+}
+
+const DEF_FIXTURE = {
+    id: 42,
+    cell_id: 3,
+    display_name: "Bearing vibration",
+    unit_name: "mm/s",
+    signal_type_name: "vibration",
+};
+
+function makeSeries(n: number, baseIso = "2026-04-24T10:00:00Z") {
+    const start = new Date(baseIso).getTime();
+    return Array.from({ length: n }, (_, i) => ({
+        time: new Date(start + i * 60_000).toISOString(),
+        raw_value: 3 + Math.sin(i / 5),
+    }));
+}
+
+// ResponsiveContainer needs a measurable parent in JSDom — wrap every render.
+function Sized({ children }: { children: ReactNode }) {
+    return <div style={{ width: 400, height: 200 }}>{children}</div>;
+}
+
+describe("SignalChart", () => {
+    let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        fetchSpy = vi.spyOn(globalThis, "fetch");
+    });
+
+    afterEach(() => {
+        fetchSpy.mockRestore();
+        vi.restoreAllMocks();
+    });
+
+    it("renders the header with display name and chart container on happy path", async () => {
+        fetchSpy.mockImplementation(async (input: Request | string | URL) => {
+            const url = typeof input === "string" ? input : input.toString();
+            if (url.includes("/signals/definitions/42")) return jsonResponse(DEF_FIXTURE);
+            if (url.includes("/signals/data/42")) return jsonResponse(makeSeries(30));
+            return jsonResponse(null);
+        });
+
+        render(
+            withClient(
+                <Sized>
+                    <SignalChart cell_id={3} signal_def_id={42} window_hours={6} />
+                </Sized>,
+            ),
+        );
+
+        await waitFor(() => expect(screen.getByText("Bearing vibration")).toBeInTheDocument());
+        expect(screen.getByText(/Last 6h · Cell 3/)).toBeInTheDocument();
+        expect(screen.getByTestId("signal-chart-container")).toBeInTheDocument();
+    });
+
+    it("shows the loading state while requests are pending", () => {
+        // Keep fetches unresolved so isLoading stays true.
+        fetchSpy.mockImplementation(() => new Promise(() => {}));
+
+        render(
+            withClient(
+                <Sized>
+                    <SignalChart cell_id={3} signal_def_id={42} window_hours={24} />
+                </Sized>,
+            ),
+        );
+
+        expect(screen.getByText(/Loading signal/i)).toBeInTheDocument();
+    });
+
+    it("renders the error fallback when the data query fails", async () => {
+        fetchSpy.mockImplementation(async (input: Request | string | URL) => {
+            const url = typeof input === "string" ? input : input.toString();
+            if (url.includes("/signals/definitions/42")) return jsonResponse(DEF_FIXTURE);
+            if (url.includes("/signals/data/42")) {
+                return new Response(JSON.stringify({ message: "boom" }), { status: 500 });
+            }
+            return jsonResponse(null);
+        });
+
+        render(
+            withClient(
+                <Sized>
+                    <SignalChart cell_id={3} signal_def_id={42} window_hours={24} />
+                </Sized>,
+            ),
+        );
+
+        await waitFor(() =>
+            expect(screen.getByText(/No data for signal #42 in the last 24h/)).toBeInTheDocument(),
+        );
+    });
+
+    it("renders the empty fallback when series is empty", async () => {
+        fetchSpy.mockImplementation(async (input: Request | string | URL) => {
+            const url = typeof input === "string" ? input : input.toString();
+            if (url.includes("/signals/definitions/42")) return jsonResponse(DEF_FIXTURE);
+            if (url.includes("/signals/data/42")) return jsonResponse([]);
+            return jsonResponse(null);
+        });
+
+        render(
+            withClient(
+                <Sized>
+                    <SignalChart cell_id={3} signal_def_id={42} window_hours={12} />
+                </Sized>,
+            ),
+        );
+
+        await waitFor(() =>
+            expect(screen.getByText(/No data for signal #42 in the last 12h/)).toBeInTheDocument(),
+        );
+    });
+
+    it("renders a reference line when threshold is provided", async () => {
+        fetchSpy.mockImplementation(async (input: Request | string | URL) => {
+            const url = typeof input === "string" ? input : input.toString();
+            if (url.includes("/signals/definitions/42")) return jsonResponse(DEF_FIXTURE);
+            if (url.includes("/signals/data/42")) return jsonResponse(makeSeries(30));
+            return jsonResponse(null);
+        });
+
+        const { container } = render(
+            withClient(
+                <Sized>
+                    <SignalChart cell_id={3} signal_def_id={42} window_hours={6} threshold={7.1} />
+                </Sized>,
+            ),
+        );
+
+        await waitFor(() => expect(screen.getByText("Bearing vibration")).toBeInTheDocument());
+        // Recharts renders ReferenceLine as an SVG group with class recharts-reference-line.
+        await waitFor(() => {
+            expect(container.querySelector(".recharts-reference-line")).not.toBeNull();
+        });
+    });
+
+    it("renders an anomaly marker when mark_anomaly_at matches a point", async () => {
+        const series = makeSeries(30);
+        const anomalyIso = series[10]!.time;
+
+        fetchSpy.mockImplementation(async (input: Request | string | URL) => {
+            const url = typeof input === "string" ? input : input.toString();
+            if (url.includes("/signals/definitions/42")) return jsonResponse(DEF_FIXTURE);
+            if (url.includes("/signals/data/42")) return jsonResponse(series);
+            return jsonResponse(null);
+        });
+
+        const { container } = render(
+            withClient(
+                <Sized>
+                    <SignalChart
+                        cell_id={3}
+                        signal_def_id={42}
+                        window_hours={6}
+                        mark_anomaly_at={anomalyIso}
+                    />
+                </Sized>,
+            ),
+        );
+
+        await waitFor(() => expect(screen.getByText("Bearing vibration")).toBeInTheDocument());
+        await waitFor(() => {
+            expect(container.querySelector(".recharts-reference-dot")).not.toBeNull();
+        });
+    });
+});

--- a/frontend/src/artifacts/placeholders/SignalChart.tsx
+++ b/frontend/src/artifacts/placeholders/SignalChart.tsx
@@ -1,14 +1,298 @@
-// Placeholder for M8.1. Real component TBD.
+/**
+ * SignalChart — M8.1 real artifact.
+ *
+ * Renders a live time-series area chart for a signal definition. Mounted inline
+ * inside chat messages when the Q&A agent emits `render_signal_chart`.
+ *
+ * - Pulls `{display_name, unit_name}` once (staleTime: Infinity — definitions
+ *   are quasi-static) and series data every 30 s (matches the telemetry beat).
+ * - Downsamples to 200 points client-side so Recharts stays responsive on
+ *   long windows (hacks of 86 k points at 1 Hz are not useful in a tooltip).
+ * - Tokens only (DS vars). No drop-shadow, no glow, no animation loop —
+ *   DESIGN_PLAN_v2 §9 anti-patterns.
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { useId, useMemo } from "react";
+import {
+    Area,
+    AreaChart,
+    ReferenceDot,
+    ReferenceLine,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis,
+} from "recharts";
+import { apiFetch } from "../../lib/api";
 import type { SignalChartProps } from "../schemas";
-import { dumpJson, PlaceholderShell } from "./PlaceholderShell";
+
+// ---------- Types ----------
+
+interface SignalDefinition {
+    id: number;
+    cell_id: number;
+    display_name: string;
+    unit_name: string | null;
+    signal_type_name?: string | null;
+}
+
+interface SignalPoint {
+    time: string;
+    raw_value: number;
+}
+
+// ---------- Helpers ----------
+
+/** Keeps at most `maxPoints` by strided downsampling. */
+function downsample<T>(arr: T[], maxPoints = 200): T[] {
+    if (arr.length <= maxPoints) return arr;
+    const step = Math.ceil(arr.length / maxPoints);
+    return arr.filter((_, i) => i % step === 0);
+}
+
+function formatTimeLabel(iso: string): string {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return "";
+    return d.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" });
+}
+
+function formatTooltipTime(iso: string): string {
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return iso;
+    return d.toLocaleTimeString("en-GB", {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+    });
+}
+
+function formatValue(v: number): string {
+    // 3 significant digits is enough for operator context.
+    if (!Number.isFinite(v)) return "—";
+    const abs = Math.abs(v);
+    if (abs >= 100) return v.toFixed(0);
+    if (abs >= 10) return v.toFixed(1);
+    return v.toFixed(2);
+}
+
+function findValueAtTime(series: SignalPoint[] | undefined, iso: string): number | null {
+    if (!series || series.length === 0) return null;
+    const target = new Date(iso).getTime();
+    if (Number.isNaN(target)) return null;
+    let best: SignalPoint | null = null;
+    let bestDelta = Number.POSITIVE_INFINITY;
+    for (const p of series) {
+        const t = new Date(p.time).getTime();
+        if (Number.isNaN(t)) continue;
+        const delta = Math.abs(t - target);
+        if (delta < bestDelta) {
+            best = p;
+            bestDelta = delta;
+        }
+    }
+    return best ? best.raw_value : null;
+}
+
+// ---------- Fetchers (use centralised apiFetch) ----------
+
+function fetchSignalDef(id: number): Promise<SignalDefinition> {
+    return apiFetch<SignalDefinition>(`/signals/definitions/${id}`);
+}
+
+function fetchSignalData(id: number, windowHours: number): Promise<SignalPoint[]> {
+    const end = new Date();
+    const start = new Date(end.getTime() - windowHours * 3600 * 1000);
+    return apiFetch<SignalPoint[]>(`/signals/data/${id}`, {
+        params: {
+            window_start: start.toISOString(),
+            window_end: end.toISOString(),
+        },
+    });
+}
+
+// ---------- Tooltip ----------
+
+interface TooltipPayload {
+    payload?: SignalPoint;
+    value?: number;
+}
+interface CustomTooltipProps {
+    active?: boolean;
+    payload?: TooltipPayload[];
+    unitName?: string | null;
+}
+
+function CustomTooltip({ active, payload, unitName }: CustomTooltipProps) {
+    if (!active || !payload || payload.length === 0) return null;
+    const point = payload[0]?.payload;
+    if (!point) return null;
+    return (
+        <div className="rounded-[var(--ds-radius-sm)] border border-[var(--ds-border)] bg-[var(--ds-bg-elevated)] px-2 py-1.5 text-[var(--ds-text-xs)] shadow-[var(--ds-shadow-overlay)]">
+            <div className="font-mono text-[var(--ds-fg-muted)]">
+                {formatTooltipTime(point.time)}
+            </div>
+            <div className="mt-0.5 text-[var(--ds-fg-primary)]">
+                <span className="font-mono">{formatValue(point.raw_value)}</span>
+                {unitName ? (
+                    <span className="ml-1 text-[var(--ds-fg-muted)]">{unitName}</span>
+                ) : null}
+            </div>
+        </div>
+    );
+}
+
+// ---------- Main component ----------
 
 export function SignalChart(props: SignalChartProps) {
+    const { cell_id, signal_def_id, window_hours = 24, mark_anomaly_at, threshold } = props;
+
+    const gradientId = useId();
+
+    const { data: definition } = useQuery<SignalDefinition>({
+        queryKey: ["signal-def", signal_def_id],
+        queryFn: () => fetchSignalDef(signal_def_id),
+        staleTime: Number.POSITIVE_INFINITY,
+    });
+
+    const {
+        data: series,
+        isLoading,
+        isError,
+    } = useQuery<SignalPoint[]>({
+        queryKey: ["signal-data", signal_def_id, window_hours],
+        queryFn: () => fetchSignalData(signal_def_id, window_hours),
+        staleTime: 10_000,
+        refetchInterval: 30_000,
+    });
+
+    const chartData = useMemo(() => downsample(series ?? []), [series]);
+    const unitName = definition?.unit_name ?? null;
+    const displayName = definition?.display_name ?? `Signal #${signal_def_id}`;
+
+    // Loading — sober text, no shimmer (§9).
+    if (isLoading) {
+        return (
+            <div className="flex h-[200px] w-full max-w-[400px] items-center justify-center rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-surface)]">
+                <span className="text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+                    Loading signal…
+                </span>
+            </div>
+        );
+    }
+
+    // Error / empty — inline card, retry handled by TanStack Query.
+    if (isError || !series || series.length === 0) {
+        return (
+            <div className="w-full max-w-[400px] rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-surface)] p-3">
+                <div className="mb-1 text-[var(--ds-text-sm)] font-medium text-[var(--ds-fg-primary)]">
+                    {displayName}
+                </div>
+                <div className="text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
+                    No data for signal #{signal_def_id} in the last {window_hours}h.
+                </div>
+            </div>
+        );
+    }
+
+    const anomalyValue = mark_anomaly_at ? findValueAtTime(series, mark_anomaly_at) : null;
+
     return (
-        <PlaceholderShell
-            label="Signal chart"
-            detail={`cell ${props.cell_id} · signal ${props.signal_def_id} · ${props.window_hours ?? 24}h`}
-        >
-            <pre className="whitespace-pre-wrap">{dumpJson(props)}</pre>
-        </PlaceholderShell>
+        <div className="w-full max-w-[400px] rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-surface)] p-3">
+            <div className="mb-2 flex items-baseline justify-between gap-3">
+                <span className="text-[var(--ds-text-sm)] font-medium text-[var(--ds-fg-primary)]">
+                    {displayName}
+                </span>
+                <span className="font-mono text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+                    Last {window_hours}h · Cell {cell_id}
+                </span>
+            </div>
+
+            <div
+                className="h-[160px] w-full"
+                data-testid="signal-chart-container"
+                role="img"
+                aria-label={`${displayName} — ${series.length} samples over the last ${window_hours} hours`}
+            >
+                <ResponsiveContainer width="100%" height="100%">
+                    <AreaChart data={chartData} margin={{ top: 4, right: 8, left: 0, bottom: 4 }}>
+                        <defs>
+                            <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
+                                <stop offset="0%" stopColor="var(--ds-accent)" stopOpacity={0.3} />
+                                <stop
+                                    offset="100%"
+                                    stopColor="var(--ds-accent)"
+                                    stopOpacity={0.05}
+                                />
+                            </linearGradient>
+                        </defs>
+                        <XAxis
+                            dataKey="time"
+                            tickFormatter={formatTimeLabel}
+                            tick={{
+                                fill: "var(--ds-fg-subtle)",
+                                fontSize: 10,
+                                fontFamily: "var(--ds-font-mono)",
+                            }}
+                            tickLine={false}
+                            axisLine={{ stroke: "var(--ds-border)" }}
+                            minTickGap={40}
+                        />
+                        <YAxis
+                            tick={{
+                                fill: "var(--ds-fg-subtle)",
+                                fontSize: 10,
+                                fontFamily: "var(--ds-font-mono)",
+                            }}
+                            tickLine={false}
+                            axisLine={{ stroke: "var(--ds-border)" }}
+                            width={36}
+                            unit={unitName ?? undefined}
+                        />
+                        <Tooltip
+                            content={<CustomTooltip unitName={unitName} />}
+                            cursor={{
+                                stroke: "var(--ds-border-strong)",
+                                strokeDasharray: "2 2",
+                            }}
+                        />
+                        <Area
+                            type="monotone"
+                            dataKey="raw_value"
+                            stroke="var(--ds-accent)"
+                            strokeWidth={1.5}
+                            fill={`url(#${gradientId})`}
+                            isAnimationActive={false}
+                            dot={false}
+                            activeDot={{
+                                r: 3,
+                                fill: "var(--ds-accent)",
+                                stroke: "var(--ds-bg-surface)",
+                                strokeWidth: 1,
+                            }}
+                        />
+                        {threshold !== undefined && (
+                            <ReferenceLine
+                                y={threshold}
+                                stroke="var(--ds-status-warning)"
+                                strokeDasharray="4 4"
+                                strokeWidth={1}
+                                ifOverflow="extendDomain"
+                            />
+                        )}
+                        {mark_anomaly_at && anomalyValue !== null && (
+                            <ReferenceDot
+                                x={mark_anomaly_at}
+                                y={anomalyValue}
+                                r={4}
+                                fill="var(--ds-status-critical)"
+                                stroke="var(--ds-status-critical)"
+                                ifOverflow="extendDomain"
+                            />
+                        )}
+                    </AreaChart>
+                </ResponsiveContainer>
+            </div>
+        </div>
     );
 }


### PR DESCRIPTION
## Summary

First real artifact backing the generative UI registry. The placeholder that M7.5 landed for `render_signal_chart` is now a **live recharts AreaChart**: the Q&A agent can call the tool, the frontend fetches the corresponding signal series, renders a proper chart inline in the chat.

Unlocks the first visually convincing beat of the demo — when Sentinel flags a vibration trip and the operator asks "what happened on P-02", the agent answers with a chart of the last 24 h, threshold line and anomaly marker included.

## What ships

### Component rewrite — `frontend/src/artifacts/placeholders/SignalChart.tsx`

- **Signal definition** fetched once via `GET /api/v1/signals/definitions/{id}` (TanStack Query, `staleTime: Infinity`) → surfaces `display_name` + `unit_name` in the header and tooltip.
- **Signal data** polled via `GET /api/v1/signals/data/{id}?window_start=...&window_end=...` every 30 s (`refetchInterval: 30_000`, `staleTime: 10_000`). Window driven by the `window_hours` prop with a default of 24.
- **Downsampling**: stride filter kicks in above 200 points (24 h at 1 Hz = 86 400 samples, recharts chokes above ~500) — memoised in a `useMemo`.
- **Chart** — `AreaChart` inside a `ResponsiveContainer`, monotone trace at `stroke=var(--ds-accent)` width 1.5 px, subtle vertical gradient (opacity `0.3 → 0.05`), axes in `--ds-fg-subtle` mono, 10 px tick labels.
- **Threshold**: `ReferenceLine` at `y={threshold}` with `stroke="var(--ds-status-warning)" strokeDasharray="4 4"` when the prop is provided.
- **Anomaly marker**: `ReferenceDot` placed on the series point closest to `mark_anomaly_at`, `r=4`, `fill="var(--ds-status-critical)"`.
- **Tooltip**: compact card, mono timestamp (HH:mm:ss en-GB), adaptive-precision value (2 / 1 / 0 decimals), muted unit.
- **A11y**: `role="img"` + `aria-label="{displayName} — {N} samples over the last {H} hours"`.

### States

- Loading → sober `Loading signal…` muted text, 200 px container to prevent layout shift. No shimmer (§9).
- Error / empty series → inline card with `"No data for signal #{id} in the last {H}h."`, no toast (TanStack retries).

### Fetch helper

Uses the existing `apiFetch<T>` from `frontend/src/lib/api.ts` — it already handles cookie auth, 401 refresh, and unwraps the `{status, message, data}` envelope. No change to `api.ts`.

## Design-plan compliance

- Every colour routes through `--ds-*` tokens. Zero hex literal.
- `isAnimationActive={false}` on `<Area>` — respects `prefers-reduced-motion` by default, no motion loop.
- No drop-shadow, no glow, no blur, no gradient-on-trace, no neon — §9 stays armed.
- Single dep used: `recharts@3.8.1` already in tree since M6.1. No new dependency.

## Scope out (deliberate)

- No zoom / pan / brush — hors scope hackathon, `recharts` exposes them behind the same lib if we need them later.
- No multi-signal overlay — the tool schema allows `signal_def_ids: list[int]` in theory but today only the primary `signal_def_id` is surfaced; multi-series handling deferred.
- No toast library — inline fallback card is the only error surface.
- Other 7 placeholders untouched (M8.2 EquipmentKbCard, M8.3 bundle).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run check` (biome, 87 files) — clean
- [x] `npm run test` — **88/88** (baseline 82 + 6 new `SignalChart.test.tsx`)
- [x] `npm run build` — clean (2.53 s)
- [ ] Manual smoke once a backend stack is running:
  - [ ] Ask the Q&A agent "show me the vibration trend on P-02 over the last 6 hours" → agent calls `render_signal_chart` → chart arrives inline with the real series
  - [ ] Sentinel fires an anomaly on P-02 → chat agent replies with a chart marking the breach with the dashed threshold + red anomaly dot

## Test coverage added

`SignalChart.test.tsx` — 6 cases:
1. Happy path — header displays `display_name`, subtitle `Last 6h · Cell 3`, chart container mounts
2. Loading — fetch pending → `Loading signal…` fallback
3. Error — forced 500 on `/signals/data` → `No data...` fallback
4. Empty series — `data: []` → same fallback
5. Threshold — `threshold=7.1` renders a `.recharts-reference-line`
6. Anomaly marker — aligned `mark_anomaly_at` renders a `.recharts-reference-dot`

### JSDom note

`ResponsiveContainer` relies on `ResizeObserver` which returns 0×0 in JSDom, so `AreaChart` and its references don't render by default. Tests mock `recharts` locally to replace `ResponsiveContainer` with a pass-through that `cloneElement`s its child with explicit `width=400, height=200`. The production component is unaffected.

## Related

- #45 — M8.1 (this PR)
- #44 PR #112 — M7.5 artifact registry, which dispatches `render_signal_chart` here
- #46 M8.2 — EquipmentKbCard, next artifact in the bundle
- `backend/agents/ui_tools.py:71-109` — the `render_signal_chart` tool schema this PR implements the other side of

Closes #45