### PR TITLE
feat(artifacts): M8.2 — EquipmentKbCard with live KB fetch + inline threshold editing (#46)

### DIFF
--- a/frontend/src/artifacts/placeholders/EquipmentKbCard.test.tsx
+++ b/frontend/src/artifacts/placeholders/EquipmentKbCard.test.tsx
@@ -1,0 +1,344 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { EquipmentKbCard } from "./EquipmentKbCard";
+
+// ---------- Helpers ----------
+
+function makeClient(): QueryClient {
+    return new QueryClient({
+        defaultOptions: {
+            queries: { retry: false, refetchOnWindowFocus: false, staleTime: Infinity },
+            mutations: { retry: false },
+        },
+    });
+}
+
+function withClient(ui: ReactNode, client = makeClient()) {
+    return <QueryClientProvider client={client}>{ui}</QueryClientProvider>;
+}
+
+function jsonResponse(data: unknown, status = 200): Response {
+    return new Response(JSON.stringify({ status, message: "OK", data }), {
+        status,
+        headers: { "Content-Type": "application/json" },
+    });
+}
+
+function errorResponse(status = 500): Response {
+    return new Response(JSON.stringify({ message: "boom" }), {
+        status,
+        headers: { "Content-Type": "application/json" },
+    });
+}
+
+const KB_FIXTURE = {
+    id: 1,
+    cell_id: 1,
+    cell_name: "P-02",
+    equipment_type: "Centrifugal Pump",
+    manufacturer: "Grundfos",
+    model: "CR 32-2",
+    installation_date: "2024-10-23",
+    structured_data: {
+        equipment: {
+            equipment_type: "Centrifugal Pump",
+            manufacturer: "Grundfos",
+            model: "CR 32-2",
+            motor_power_kw: 7.5,
+            rpm_nominal: 2900,
+            service_description: "Boiler feed water",
+        },
+        thresholds: {
+            vibration_mm_s: {
+                nominal: 2.2,
+                alert: 4.5,
+                trip: 7.1,
+                unit: "mm/s",
+                source: "ISO 10816",
+                confidence: 0.9,
+            },
+            bearing_temp_c: {
+                nominal: 48,
+                alert: 75,
+                trip: 90,
+                unit: "°C",
+                source: "ISO 10816",
+                confidence: 0.8,
+            },
+            flow_l_min: {
+                nominal: 533,
+                low_alert: 480,
+                high_alert: 580,
+                unit: "L/min",
+                source: "Spec",
+                confidence: 0.75,
+            },
+            pressure_bar: {
+                nominal: 5.5,
+                low_alert: 4.5,
+                high_alert: 6.5,
+                unit: "bar",
+                source: "Spec",
+                confidence: 0.8,
+            },
+        },
+    },
+    confidence_score: 0.85,
+    onboarding_complete: true,
+    last_updated_by: "operator",
+    last_updated_at: "2026-04-24T10:00:00Z",
+    created_at: "2024-10-23T10:00:00Z",
+};
+
+describe("EquipmentKbCard", () => {
+    let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        fetchSpy = vi.spyOn(globalThis, "fetch");
+    });
+
+    afterEach(() => {
+        fetchSpy.mockRestore();
+        vi.restoreAllMocks();
+    });
+
+    it("renders header, thresholds sections and footer on happy path", async () => {
+        fetchSpy.mockImplementation(async (input: Request | string | URL) => {
+            const url = typeof input === "string" ? input : input.toString();
+            if (url.includes("/kb/equipment/1")) return jsonResponse(KB_FIXTURE);
+            return jsonResponse(null);
+        });
+
+        render(withClient(<EquipmentKbCard cell_id={1} />));
+
+        // Header
+        await waitFor(() => expect(screen.getByText("P-02")).toBeInTheDocument());
+        expect(screen.getByText(/· Centrifugal Pump/)).toBeInTheDocument();
+        expect(screen.getByText(/Grundfos · CR 32-2 · Installed 2024-10-23/)).toBeInTheDocument();
+
+        // Thresholds section (4 calibrated)
+        expect(screen.getByText("Thresholds (4)")).toBeInTheDocument();
+        expect(screen.getByText("Vibration (mm/s)")).toBeInTheDocument();
+        expect(screen.getByText("Bearing temp (°C)")).toBeInTheDocument();
+        expect(screen.getByText("Flow (L/min)")).toBeInTheDocument();
+        expect(screen.getByText("Pressure (bar)")).toBeInTheDocument();
+
+        // Some threshold values
+        expect(
+            screen.getByTestId("threshold-value-thresholds.vibration_mm_s.alert"),
+        ).toHaveTextContent("4.5");
+        expect(
+            screen.getByTestId("threshold-value-thresholds.vibration_mm_s.trip"),
+        ).toHaveTextContent("7.1");
+
+        // Footer
+        expect(screen.getByText(/Confidence 85%/)).toBeInTheDocument();
+        expect(screen.getByText(/operator/)).toBeInTheDocument();
+    });
+
+    it("shows loading state while KB query is pending", () => {
+        fetchSpy.mockImplementation(() => new Promise(() => {}));
+
+        render(withClient(<EquipmentKbCard cell_id={1} />));
+
+        expect(screen.getByText(/Loading equipment KB/i)).toBeInTheDocument();
+    });
+
+    it("renders the error fallback when the KB query fails", async () => {
+        fetchSpy.mockImplementation(async () => errorResponse(500));
+
+        render(withClient(<EquipmentKbCard cell_id={7} />));
+
+        await waitFor(() => expect(screen.getByText(/No KB data for cell 7/)).toBeInTheDocument());
+    });
+
+    it("switches a threshold value to an input when clicked (autofocus + prefilled)", async () => {
+        fetchSpy.mockImplementation(async (input: Request | string | URL) => {
+            const url = typeof input === "string" ? input : input.toString();
+            if (url.includes("/kb/equipment/1")) return jsonResponse(KB_FIXTURE);
+            return jsonResponse(null);
+        });
+
+        const user = userEvent.setup();
+        render(withClient(<EquipmentKbCard cell_id={1} />));
+
+        const button = await screen.findByTestId("threshold-value-thresholds.vibration_mm_s.alert");
+        await user.click(button);
+
+        const input = screen.getByLabelText("Vibration (mm/s) alert") as HTMLInputElement;
+        expect(input).toBeInTheDocument();
+        expect(input.value).toBe("4.5");
+        expect(document.activeElement).toBe(input);
+    });
+
+    it("cancels edit on Escape without firing a mutation", async () => {
+        fetchSpy.mockImplementation(async (input: Request | string | URL) => {
+            const url = typeof input === "string" ? input : input.toString();
+            if (url.includes("/kb/equipment/1")) return jsonResponse(KB_FIXTURE);
+            return jsonResponse(null);
+        });
+
+        const user = userEvent.setup();
+        render(withClient(<EquipmentKbCard cell_id={1} />));
+
+        const button = await screen.findByTestId("threshold-value-thresholds.vibration_mm_s.alert");
+        await user.click(button);
+
+        const input = screen.getByLabelText("Vibration (mm/s) alert") as HTMLInputElement;
+        await user.clear(input);
+        await user.type(input, "9.9");
+        await user.keyboard("{Escape}");
+
+        // Button is back with the original value, no PUT fired
+        await waitFor(() =>
+            expect(
+                screen.getByTestId("threshold-value-thresholds.vibration_mm_s.alert"),
+            ).toHaveTextContent("4.5"),
+        );
+
+        const putCalls = fetchSpy.mock.calls.filter((c: unknown[]) => {
+            const init = c[1] as RequestInit | undefined;
+            return init?.method === "PUT";
+        });
+        expect(putCalls).toHaveLength(0);
+    });
+
+    it("commits edit on Enter → optimistic update + PUT body contains the new threshold", async () => {
+        // Server reflects the last PUT on subsequent GETs (so invalidation doesn't
+        // stomp the optimistic value).
+        let serverKb: typeof KB_FIXTURE = KB_FIXTURE;
+        fetchSpy.mockImplementation(async (input: Request | string | URL, init?: RequestInit) => {
+            const url = typeof input === "string" ? input : input.toString();
+            if (init?.method === "PUT" && url.includes("/kb/equipment")) {
+                const sent = JSON.parse(init.body as string) as {
+                    structured_data: typeof KB_FIXTURE.structured_data;
+                    last_updated_by: string;
+                };
+                serverKb = {
+                    ...serverKb,
+                    structured_data: sent.structured_data,
+                    last_updated_by: sent.last_updated_by,
+                };
+                return jsonResponse(serverKb);
+            }
+            if (url.includes("/kb/equipment/1")) return jsonResponse(serverKb);
+            return jsonResponse(null);
+        });
+
+        const user = userEvent.setup();
+        render(withClient(<EquipmentKbCard cell_id={1} />));
+
+        const button = await screen.findByTestId("threshold-value-thresholds.vibration_mm_s.alert");
+        await user.click(button);
+
+        const input = screen.getByLabelText("Vibration (mm/s) alert") as HTMLInputElement;
+        await user.clear(input);
+        await user.type(input, "5.2");
+        await user.keyboard("{Enter}");
+
+        // Optimistic: input disappears, value reflects the edit
+        await waitFor(() =>
+            expect(
+                screen.getByTestId("threshold-value-thresholds.vibration_mm_s.alert"),
+            ).toHaveTextContent("5.2"),
+        );
+
+        // A PUT was fired with the expected body shape
+        const putCall = fetchSpy.mock.calls.find((c: unknown[]) => {
+            const init = c[1] as RequestInit | undefined;
+            return init?.method === "PUT";
+        });
+        expect(putCall).toBeDefined();
+        const body = JSON.parse((putCall?.[1] as RequestInit).body as string) as {
+            cell_id: number;
+            last_updated_by: string;
+            structured_data: {
+                thresholds: { vibration_mm_s: { alert: number; trip: number } };
+            };
+        };
+        expect(body.cell_id).toBe(1);
+        expect(body.last_updated_by).toBe("operator");
+        expect(body.structured_data.thresholds.vibration_mm_s.alert).toBe(5.2);
+        // Other fields preserved
+        expect(body.structured_data.thresholds.vibration_mm_s.trip).toBe(7.1);
+    });
+
+    it("rollbacks to original value when the PUT mutation fails", async () => {
+        fetchSpy.mockImplementation(async (input: Request | string | URL, init?: RequestInit) => {
+            const url = typeof input === "string" ? input : input.toString();
+            if (init?.method === "PUT" && url.includes("/kb/equipment")) {
+                return errorResponse(500);
+            }
+            if (url.includes("/kb/equipment/1")) return jsonResponse(KB_FIXTURE);
+            return jsonResponse(null);
+        });
+
+        const user = userEvent.setup();
+        render(withClient(<EquipmentKbCard cell_id={1} />));
+
+        const button = await screen.findByTestId("threshold-value-thresholds.vibration_mm_s.alert");
+        await user.click(button);
+
+        const input = screen.getByLabelText("Vibration (mm/s) alert") as HTMLInputElement;
+        await user.clear(input);
+        await user.type(input, "5.2");
+        await user.keyboard("{Enter}");
+
+        // Wait for the mutation to fail and rollback
+        await waitFor(() =>
+            expect(
+                screen.getByTestId("threshold-value-thresholds.vibration_mm_s.alert"),
+            ).toHaveTextContent("4.5"),
+        );
+    });
+
+    it('marks highlighted threshold fields with data-highlight="true"', async () => {
+        fetchSpy.mockImplementation(async (input: Request | string | URL) => {
+            const url = typeof input === "string" ? input : input.toString();
+            if (url.includes("/kb/equipment/1")) return jsonResponse(KB_FIXTURE);
+            return jsonResponse(null);
+        });
+
+        render(
+            withClient(
+                <EquipmentKbCard
+                    cell_id={1}
+                    highlight_fields={["thresholds.vibration_mm_s.alert"]}
+                />,
+            ),
+        );
+
+        const highlighted = await screen.findByTestId(
+            "threshold-value-thresholds.vibration_mm_s.alert",
+        );
+        expect(highlighted).toHaveAttribute("data-highlight", "true");
+
+        // Non-highlighted sibling has no highlight attr
+        const nonHighlighted = screen.getByTestId("threshold-value-thresholds.vibration_mm_s.trip");
+        expect(nonHighlighted).not.toHaveAttribute("data-highlight");
+    });
+
+    it("renders a fallback message when thresholds are empty", async () => {
+        fetchSpy.mockImplementation(async (input: Request | string | URL) => {
+            const url = typeof input === "string" ? input : input.toString();
+            if (url.includes("/kb/equipment/1"))
+                return jsonResponse({
+                    ...KB_FIXTURE,
+                    structured_data: {
+                        equipment: KB_FIXTURE.structured_data.equipment,
+                        thresholds: {},
+                    },
+                });
+            return jsonResponse(null);
+        });
+
+        render(withClient(<EquipmentKbCard cell_id={1} />));
+
+        await waitFor(() => expect(screen.getByText("Thresholds (0)")).toBeInTheDocument());
+        expect(screen.getByText(/No thresholds calibrated yet/)).toBeInTheDocument();
+    });
+});

--- a/frontend/src/artifacts/placeholders/EquipmentKbCard.tsx
+++ b/frontend/src/artifacts/placeholders/EquipmentKbCard.tsx
@@ -1,11 +1,448 @@
-// Placeholder for M8.2. Real component TBD.
+/**
+ * EquipmentKbCard — M8.2 real artifact.
+ *
+ * Mounted inline inside chat when the agent emits `render_equipment_kb_card`.
+ *
+ * Responsibilities:
+ * - Fetch the full equipment KB for a given cell via `GET /kb/equipment/{cell_id}`.
+ * - Display header / thresholds / specs / footer (see DESIGN_PLAN §5).
+ * - Allow the operator to calibrate threshold values inline (click-to-edit +
+ *   optimistic `PUT /kb/equipment` + rollback on error).
+ * - Highlight the specific threshold fields listed in `highlight_fields` with
+ *   a static accent ring (no pulse — DESIGN_PLAN §6 / §9).
+ *
+ * Design constraints:
+ * - Tokens only (no hex, no gradients) — §2.
+ * - Sentence case headers, Inter everywhere, mono *only* on numeric cells
+ *   (with `tabular-nums`) — §3.
+ * - Collapsible sections use native `<details>` — no new deps.
+ * - No animation loops, no shimmer, no glow — §6, §9.
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
+import { ChevronDown } from "../../design-system/icons";
+import { apiFetch } from "../../lib/api";
+import type { EquipmentKB, EquipmentKbOut, ThresholdValue } from "../../lib/kb.types";
 import type { EquipmentKbCardProps } from "../schemas";
-import { dumpJson, PlaceholderShell } from "./PlaceholderShell";
+
+// ---------- Types ----------
+
+interface UpsertBody {
+    cell_id: number;
+    structured_data: EquipmentKB;
+    equipment_type?: string | null;
+    manufacturer?: string | null;
+    model?: string | null;
+    installation_date?: string | null;
+    last_updated_by: string;
+}
+
+type ThresholdNumKey = "nominal" | "alert" | "trip" | "low_alert" | "high_alert";
+
+interface EditState {
+    value: string; // kept as string for the controlled input (allows empty/partial typing)
+    original: number;
+}
+
+// ---------- Helpers ----------
+
+/**
+ * Human label for a threshold key like `vibration_mm_s` → `Vibration (mm/s)`.
+ * Unit suffix (`_mm_s`, `_c`, `_l_min`, `_bar`, `_kpa`…) is extracted into
+ * parentheses when present; everything else is sentence-cased.
+ */
+const UNIT_SUFFIXES: Array<{ match: string; unit: string }> = [
+    { match: "_mm_s", unit: "mm/s" },
+    { match: "_l_min", unit: "L/min" },
+    { match: "_m3_h", unit: "m³/h" },
+    { match: "_kpa", unit: "kPa" },
+    { match: "_bar", unit: "bar" },
+    { match: "_rpm", unit: "rpm" },
+    { match: "_hz", unit: "Hz" },
+    // Temperature — strip only the `_c`/`_f` so the label keeps `temp`.
+    { match: "_c", unit: "°C" },
+    { match: "_f", unit: "°F" },
+];
+
+export function humanizeThresholdKey(key: string): string {
+    let base = key;
+    let unit: string | null = null;
+    for (const { match, unit: u } of UNIT_SUFFIXES) {
+        if (base.endsWith(match)) {
+            base = base.slice(0, -match.length);
+            unit = u;
+            break;
+        }
+    }
+    const label = base
+        .split("_")
+        .filter(Boolean)
+        .map((w, i) => (i === 0 ? w.charAt(0).toUpperCase() + w.slice(1) : w))
+        .join(" ");
+    return unit ? `${label} (${unit})` : label;
+}
+
+const SPEC_LABELS: Record<string, string> = {
+    equipment_type: "Equipment type",
+    manufacturer: "Manufacturer",
+    model: "Model",
+    motor_power_kw: "Motor power (kW)",
+    rpm_nominal: "Rated speed (rpm)",
+    service_description: "Service",
+    installation_date: "Installed",
+    cell_id: "Cell",
+};
+
+function formatSpecValue(v: unknown): string {
+    if (v === null || v === undefined || v === "") return "—";
+    if (typeof v === "number") return String(v);
+    return String(v);
+}
+
+/**
+ * Ordered list of numeric threshold fields we display.
+ * Skip null/undefined at render time.
+ */
+const THRESHOLD_FIELDS: ThresholdNumKey[] = ["nominal", "low_alert", "alert", "high_alert", "trip"];
+
+const THRESHOLD_FIELD_LABELS: Record<ThresholdNumKey, string> = {
+    nominal: "nominal",
+    alert: "alert",
+    trip: "trip",
+    low_alert: "low",
+    high_alert: "high",
+};
+
+function fetchEquipmentKb(cellId: number): Promise<EquipmentKbOut> {
+    return apiFetch<EquipmentKbOut>(`/kb/equipment/${cellId}`);
+}
+
+// ---------- Main component ----------
 
 export function EquipmentKbCard(props: EquipmentKbCardProps) {
+    const { cell_id, highlight_fields } = props;
+    const highlightSet = new Set(highlight_fields ?? []);
+    const queryClient = useQueryClient();
+
+    const queryKey = ["kb-equipment", cell_id] as const;
+
+    const {
+        data: kb,
+        isLoading,
+        isError,
+    } = useQuery<EquipmentKbOut>({
+        queryKey,
+        queryFn: () => fetchEquipmentKb(cell_id),
+        staleTime: 60_000,
+    });
+
+    const [edits, setEdits] = useState<Record<string, EditState>>({});
+
+    const mutation = useMutation({
+        mutationFn: (body: UpsertBody) =>
+            apiFetch<EquipmentKbOut>("/kb/equipment", { method: "PUT", body }),
+        onMutate: async (body) => {
+            await queryClient.cancelQueries({ queryKey });
+            const prev = queryClient.getQueryData<EquipmentKbOut>(queryKey);
+            if (prev) {
+                // Optimistic: merge the body's structured_data + meta into the cached KB.
+                queryClient.setQueryData<EquipmentKbOut>(queryKey, {
+                    ...prev,
+                    equipment_type: body.equipment_type ?? prev.equipment_type,
+                    manufacturer: body.manufacturer ?? prev.manufacturer,
+                    model: body.model ?? prev.model,
+                    installation_date: body.installation_date ?? prev.installation_date,
+                    structured_data: body.structured_data,
+                    last_updated_by: body.last_updated_by,
+                });
+            }
+            return { prev };
+        },
+        onError: (_err, _body, ctx) => {
+            if (ctx?.prev) queryClient.setQueryData(queryKey, ctx.prev);
+        },
+        onSettled: () => {
+            queryClient.invalidateQueries({ queryKey });
+        },
+    });
+
+    // ---------- Loading / error fallbacks ----------
+
+    if (isLoading) {
+        return (
+            <div
+                className="flex w-full max-w-[440px] items-center justify-center rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-surface)] p-4"
+                role="status"
+            >
+                <span className="text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+                    Loading equipment KB…
+                </span>
+            </div>
+        );
+    }
+
+    if (isError || !kb) {
+        return (
+            <div className="w-full max-w-[440px] rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-surface)] p-3">
+                <div className="mb-1 text-[var(--ds-text-sm)] font-medium text-[var(--ds-fg-primary)]">
+                    Equipment
+                </div>
+                <div className="text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
+                    No KB data for cell {cell_id}.
+                </div>
+            </div>
+        );
+    }
+
+    // ---------- Derived data ----------
+
+    const kbData: EquipmentKbOut = kb;
+    const structured: EquipmentKB = kbData.structured_data ?? {};
+    const thresholds: Record<string, ThresholdValue> = structured.thresholds ?? {};
+    const equipment = structured.equipment ?? {};
+
+    const thresholdKeys = Object.keys(thresholds);
+    const displayName = kbData.cell_name ?? `Cell ${cell_id}`;
+    const equipmentType = kbData.equipment_type ?? equipment.equipment_type ?? "Equipment";
+
+    const subParts: string[] = [];
+    if (kbData.manufacturer) subParts.push(kbData.manufacturer);
+    if (kbData.model) subParts.push(kbData.model);
+    if (kbData.installation_date) subParts.push(`Installed ${kbData.installation_date}`);
+
+    // Specifications: equipment.* fields that aren't redundant with the header.
+    const specEntries: Array<[string, unknown]> = Object.entries(equipment).filter(
+        ([k, v]) => v !== null && v !== undefined && v !== "" && k !== "cell_id",
+    );
+
+    const confidencePct =
+        typeof kbData.confidence_score === "number"
+            ? Math.round(kbData.confidence_score * 100)
+            : null;
+
+    // ---------- Threshold edit flow ----------
+
+    function pathFor(key: string, field: ThresholdNumKey): string {
+        return `thresholds.${key}.${field}`;
+    }
+
+    function startEdit(path: string, value: number | null | undefined): void {
+        const original = typeof value === "number" ? value : 0;
+        setEdits((prev) => ({
+            ...prev,
+            [path]: { value: String(original), original },
+        }));
+    }
+
+    function cancelEdit(path: string): void {
+        setEdits((prev) => {
+            const next = { ...prev };
+            delete next[path];
+            return next;
+        });
+    }
+
+    function changeEdit(path: string, raw: string): void {
+        setEdits((prev) => {
+            const cur = prev[path];
+            if (!cur) return prev;
+            return { ...prev, [path]: { ...cur, value: raw } };
+        });
+    }
+
+    function commitEdit(path: string, key: string, field: ThresholdNumKey): void {
+        const edit = edits[path];
+        if (!edit) return;
+        const parsed = Number.parseFloat(edit.value);
+        if (!Number.isFinite(parsed) || parsed === edit.original) {
+            cancelEdit(path);
+            return;
+        }
+
+        // Rebuild full structured_data, changing only the target field.
+        const currentThreshold = thresholds[key] ?? {};
+        const nextThresholds: Record<string, ThresholdValue> = {
+            ...thresholds,
+            [key]: { ...currentThreshold, [field]: parsed },
+        };
+        const nextStructured: EquipmentKB = {
+            ...structured,
+            thresholds: nextThresholds,
+        };
+
+        mutation.mutate({
+            cell_id: kbData.cell_id,
+            structured_data: nextStructured,
+            equipment_type: kbData.equipment_type ?? null,
+            manufacturer: kbData.manufacturer ?? null,
+            model: kbData.model ?? null,
+            installation_date: kbData.installation_date ?? null,
+            last_updated_by: "operator",
+        });
+
+        cancelEdit(path);
+    }
+
+    // ---------- Render ----------
+
     return (
-        <PlaceholderShell label="Equipment KB" detail={`cell ${props.cell_id}`}>
-            <pre className="whitespace-pre-wrap">{dumpJson(props)}</pre>
-        </PlaceholderShell>
+        <section
+            aria-label={`Equipment KB for ${displayName}`}
+            className="w-full max-w-[440px] overflow-hidden rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-surface)]"
+        >
+            {/* Header */}
+            <div className="px-4 pt-3 pb-2">
+                <div className="flex items-baseline gap-2">
+                    <span className="text-[var(--ds-text-lg)] font-semibold text-[var(--ds-fg-primary)]">
+                        {displayName}
+                    </span>
+                    <span className="text-[var(--ds-text-sm)] text-[var(--ds-fg-muted)]">
+                        · {equipmentType}
+                    </span>
+                </div>
+                {subParts.length > 0 && (
+                    <div className="mt-0.5 text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+                        {subParts.join(" · ")}
+                    </div>
+                )}
+            </div>
+
+            <div aria-hidden="true" className="h-px w-full bg-[var(--ds-border)]" />
+
+            {/* Thresholds */}
+            <details open className="group/thresholds">
+                <summary className="flex cursor-pointer list-none items-center justify-between px-4 py-2 text-[var(--ds-text-sm)] font-medium text-[var(--ds-fg-primary)] hover:bg-[var(--ds-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)]">
+                    <span>Thresholds ({thresholdKeys.length})</span>
+                    <ChevronDown
+                        className="size-4 text-[var(--ds-fg-muted)] transition-transform [details:not([open])_&]:-rotate-90"
+                        aria-hidden="true"
+                    />
+                </summary>
+
+                {thresholdKeys.length === 0 ? (
+                    <div className="px-4 pb-3 text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
+                        No thresholds calibrated yet.
+                    </div>
+                ) : (
+                    <div className="px-4 pb-3">
+                        {thresholdKeys.map((key) => {
+                            const t = thresholds[key] ?? {};
+                            const presentFields = THRESHOLD_FIELDS.filter(
+                                (f) => typeof t[f] === "number" && t[f] !== null,
+                            );
+                            return (
+                                <div key={key} className="py-2">
+                                    <div className="mb-1 text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+                                        {humanizeThresholdKey(key)}
+                                    </div>
+                                    <div className="flex flex-wrap gap-x-4 gap-y-1">
+                                        {presentFields.map((field) => {
+                                            const path = pathFor(key, field);
+                                            const value = t[field] as number;
+                                            const editing = edits[path];
+                                            const highlighted = highlightSet.has(path);
+
+                                            return (
+                                                <div
+                                                    key={field}
+                                                    className="flex items-baseline gap-1.5"
+                                                >
+                                                    <span className="text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
+                                                        {THRESHOLD_FIELD_LABELS[field]}
+                                                    </span>
+                                                    {editing ? (
+                                                        <input
+                                                            // biome-ignore lint/a11y/noAutofocus: intentional — user clicked to edit
+                                                            autoFocus
+                                                            type="number"
+                                                            inputMode="decimal"
+                                                            step="any"
+                                                            aria-label={`${humanizeThresholdKey(key)} ${THRESHOLD_FIELD_LABELS[field]}`}
+                                                            value={editing.value}
+                                                            onChange={(e) =>
+                                                                changeEdit(path, e.target.value)
+                                                            }
+                                                            onBlur={() =>
+                                                                commitEdit(path, key, field)
+                                                            }
+                                                            onKeyDown={(e) => {
+                                                                if (e.key === "Enter") {
+                                                                    e.preventDefault();
+                                                                    commitEdit(path, key, field);
+                                                                } else if (e.key === "Escape") {
+                                                                    e.preventDefault();
+                                                                    cancelEdit(path);
+                                                                }
+                                                            }}
+                                                            className="w-16 rounded-[var(--ds-radius-sm)] border border-[var(--ds-border-strong)] bg-[var(--ds-bg-elevated)] px-1.5 py-0.5 font-mono text-[var(--ds-text-sm)] text-[var(--ds-fg-primary)] tabular-nums focus-visible:border-[var(--ds-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)]"
+                                                        />
+                                                    ) : (
+                                                        <button
+                                                            type="button"
+                                                            data-highlight={
+                                                                highlighted ? "true" : undefined
+                                                            }
+                                                            data-testid={`threshold-value-${path}`}
+                                                            onClick={() => startEdit(path, value)}
+                                                            className={`cursor-pointer rounded-[var(--ds-radius-sm)] px-1.5 py-0.5 font-mono text-[var(--ds-text-sm)] text-[var(--ds-fg-primary)] tabular-nums transition-colors hover:bg-[var(--ds-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)] ${highlighted ? "ring-1 ring-[var(--ds-accent)]" : ""}`}
+                                                        >
+                                                            {value}
+                                                        </button>
+                                                    )}
+                                                </div>
+                                            );
+                                        })}
+                                    </div>
+                                </div>
+                            );
+                        })}
+                    </div>
+                )}
+            </details>
+
+            <div aria-hidden="true" className="h-px w-full bg-[var(--ds-border)]" />
+
+            {/* Specifications */}
+            <details className="group/specs">
+                <summary className="flex cursor-pointer list-none items-center justify-between px-4 py-2 text-[var(--ds-text-sm)] font-medium text-[var(--ds-fg-primary)] hover:bg-[var(--ds-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)]">
+                    <span>Specifications</span>
+                    <ChevronDown
+                        className="size-4 text-[var(--ds-fg-muted)] transition-transform [details:not([open])_&]:-rotate-90"
+                        aria-hidden="true"
+                    />
+                </summary>
+
+                {specEntries.length === 0 ? (
+                    <div className="px-4 pb-3 text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
+                        No specifications recorded.
+                    </div>
+                ) : (
+                    <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1 px-4 pb-3">
+                        {specEntries.map(([k, v]) => (
+                            <div key={k} className="contents">
+                                <dt className="text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+                                    {SPEC_LABELS[k] ?? humanizeThresholdKey(k)}
+                                </dt>
+                                <dd className="text-[var(--ds-text-xs)] text-[var(--ds-fg-primary)]">
+                                    {formatSpecValue(v)}
+                                </dd>
+                            </div>
+                        ))}
+                    </dl>
+                )}
+            </details>
+
+            <div aria-hidden="true" className="h-px w-full bg-[var(--ds-border)]" />
+
+            {/* Footer */}
+            <div className="flex items-center justify-between px-4 py-2 text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+                <span>
+                    {confidencePct !== null ? `Confidence ${confidencePct}%` : "Confidence —"}
+                    {" · "}
+                    {kbData.last_updated_by ? kbData.last_updated_by : "KB Builder agent"}
+                </span>
+            </div>
+        </section>
     );
 }


### PR DESCRIPTION
## Summary

Second real artifact — the one that matches the "operator enriches the KB" demo claim head-on. The placeholder becomes a full card that pulls the live equipment KB for a cell, lays out specs and thresholds, and lets the operator tweak threshold values in place with optimistic persistence.

## What ships

### Component rewrite — `frontend/src/artifacts/placeholders/EquipmentKbCard.tsx`

- **Fetch** via `apiFetch` + TanStack Query: `GET /api/v1/kb/equipment/{cell_id}` (staleTime 60s). Reuses the same pattern landed with `SignalChart` in #121.
- **Layout**
  - Header: `{cell_name} · {equipment_type}` + muted sub `{manufacturer} {model} · Installed YYYY-MM-DD`.
  - Thresholds section (collapsible via native `<details>` + `<summary>`, open by default) — one row per threshold key, values (`nominal / low / alert / high / trip`) on a mono tabular-nums line.
  - Specifications section (collapsed by default) — read-only display of `structured_data.equipment.*` non-null fields.
  - Footer muted: `Confidence {N}% · {last_updated_by}`.
- **Threshold key humanisation**: small heuristic that strips unit suffixes (`_mm_s`, `_l_min`, `_bar`, `_c`, `_f`, ...) and sentence-cases the rest. `bearing_temp_c → Bearing temp (°C)`.

### Inline edit

- Each threshold value is a button. Click → replaces with an `<input type="number">` pre-filled + autofocused.
- Commit on **Enter** or blur; cancel on **Escape**.
- Parsed value identical to the original → no mutation fired, just close the input.
- `useMutation` PUT `/api/v1/kb/equipment` with the **full** `EquipmentKbUpsert` body (meta + `structured_data` with only the edited threshold changed). Optimistic cache update, rollback via `ctx.prev` on error, `invalidateQueries` on settle.

### `highlight_fields`

When passed an array of dotted paths (e.g. `["thresholds.vibration_mm_s.alert"]`), the matching threshold button gets a solid `ring-1 ring-[var(--ds-accent)]` and `data-highlight="true"`. No animation loop — the issue said "pulse" but §9 stays armed; the static ring is enough to catch the eye and the reference test confirms it.

## Scope out

- No edit on the Specifications section (threshold-first, scope focus).
- No custom select / date picker — all edits are numeric inputs.
- No toast — inline error card for fetch failures, silent rollback for mutation failures (the value reverts visually).

## Design-plan compliance

- Zero hex literal — every colour routes through `--ds-*` tokens.
- Zero animation loop, no shimmer, no pulse keyframes, no gradient, no drop-shadow — §6 and §9 respected.
- Icons via `design-system/icons.tsx` only (`ChevronDown` on the `<summary>`).
- Typography: sentence-case labels, mono tabular-nums for numeric values, muted captions.
- No new dependency — `recharts` already present, not used here; this component is HTML+CSS only.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run check` (biome, 88 files) — clean
- [x] `npm run test` — **97/97** (baseline 88 + **9 new** `EquipmentKbCard.test.tsx`)
- [x] `npm run build` — clean
- [ ] Manual smoke once a backend stack is running:
  - [ ] Ask the agent "show me the current KB for P-02" → `render_equipment_kb_card` fires, card renders with live thresholds
  - [ ] Click the `vibration_mm_s · alert` value, change to `4.8`, press Enter → PUT fires, card reflects the new value
  - [ ] Force a 500 on the PUT → value reverts to the original on error
  - [ ] Pass `highlight_fields: ["thresholds.vibration_mm_s.alert"]` from the tool → target cell has the accent ring

## Test coverage added

`EquipmentKbCard.test.tsx` — 9 cases:
1. Happy path — header, 4 threshold sections, values on a mono row, confidence+operator footer
2. Loading — `Loading equipment KB…` fallback
3. Fetch 500 — `No KB data for cell 7` fallback
4. Click → input autofocus + prefilled
5. `Escape` → revert + **zero PUT**
6. `Enter` → optimistic update + PUT body shape (`cell_id`, `last_updated_by`, full threshold dict preserved)
7. PUT error → rollback to original displayed value
8. `highlight_fields` → `data-highlight="true"` on the targeted cell, absent elsewhere
9. Empty thresholds → `No thresholds calibrated yet` fallback

Skipped the collapsible `<details>` toggle test — jsdom doesn't reliably fire the native `open` property on `<summary>` clicks.

## Notes for reviewer

- `apiFetch` already `JSON.stringify`'s plain objects, so the call site passes `body: <object>` rather than manually stringifying.
- `<details>` + `<summary>` used for the collapsibles to avoid a useState + CSS rotation dance; saves code, keyboard-accessible by default, ChevronDown rotates via `[details:not([open])_&]:-rotate-90`.
- Wrapper is a `<section aria-label="...">`; biome enforces `useSemanticElements` which rejected `<div role="region">`.

## Related

- #46 M8.2 (this PR)
- PR #121 #45 — M8.1 SignalChart (pattern reused)
- #44 PR #112 — M7.5 artifact registry
- `backend/modules/kb/router.py:111` `PUT /kb/equipment` — the endpoint this persists to
- `backend/agents/ui_tools.py` `RENDER_EQUIPMENT_KB_CARD` — tool spec

Closes #46