### PR TITLE
fix: post-audit J-2 bundle (3 frontend findings)

### DIFF
--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useId, useRef } from "react";
 import { Outlet } from "react-router-dom";
 import { AnomalyBanner, KpiBar } from "../features/control-room";
+import { EQUIPMENT_KEY, validateEquipmentSelection } from "../lib/equipmentSelection";
 import type { EquipmentSelection } from "../lib/hierarchy";
 import { useLocalStorage } from "../lib/useLocalStorage";
 import { ChatPanel } from "./chat/ChatPanel";
@@ -14,7 +15,6 @@ interface ChatDrawerState {
 }
 
 const CHAT_DRAWER_KEY = "aria.chatDrawer";
-const EQUIPMENT_KEY = "aria.selectedEquipment";
 
 const DEFAULT_DRAWER_STATE: ChatDrawerState = {
     open: true,
@@ -29,15 +29,6 @@ function sanitizeDrawer(state: ChatDrawerState): ChatDrawerState {
             Math.min(DRAWER_MAX_WIDTH, Math.round(state.width ?? DRAWER_DEFAULT_WIDTH)),
         ),
     };
-}
-
-function validateEquipmentSelection(raw: unknown): EquipmentSelection | null {
-    if (!raw || typeof raw !== "object") return null;
-    const r = raw as Record<string, unknown>;
-    if (typeof r.cellId !== "number" || typeof r.lineId !== "number") return null;
-    if (typeof r.cellName !== "string" || typeof r.lineName !== "string") return null;
-    if (typeof r.areaName !== "string" || typeof r.siteName !== "string") return null;
-    return raw as EquipmentSelection;
 }
 
 function isTypingTarget(target: EventTarget | null) {

--- a/frontend/src/app/chat/chatStore.ts
+++ b/frontend/src/app/chat/chatStore.ts
@@ -83,6 +83,8 @@ interface InternalState {
     handle: ChatWsClient | null;
     currentAgentMessageId: string | null;
     idCounter: number;
+    /** FIFO of user messages queued while the socket is CONNECTING. */
+    pendingSends: string[];
 }
 
 function nextId(internal: InternalState, prefix: string): string {
@@ -95,6 +97,7 @@ export const useChatStore = create<ChatState>((set, get) => {
         handle: null,
         currentAgentMessageId: null,
         idCounter: 0,
+        pendingSends: [],
     };
 
     const upsertAgentMessage = (update: (msg: AgentMessage) => AgentMessage) => {
@@ -234,20 +237,37 @@ export const useChatStore = create<ChatState>((set, get) => {
         void (type as any);
     };
 
+    const flushPending = () => {
+        const handle = internal.handle;
+        if (!handle) return;
+        while (internal.pendingSends.length > 0) {
+            const content = internal.pendingSends.shift() as string;
+            handle.send({ type: "user", content });
+        }
+    };
+
     const ensureConnected = () => {
         if (internal.handle) return;
         set({ status: "connecting", error: null });
         internal.handle = createChatWsClient<ChatMap>({
             url: CHAT_WS_URL,
-            onOpen: () => set({ status: "open", error: null }),
+            onOpen: () => {
+                set({ status: "open", error: null });
+                // Defensive: avoid microtask busy-loop while CONNECTING — event-driven flush on open.
+                flushPending();
+            },
             onClose: (code) => {
+                internal.pendingSends.length = 0;
                 if (code === 4401) {
                     set({ status: "error", error: AUTH_EXPIRED_MESSAGE });
                     return;
                 }
                 set({ status: "closed" });
             },
-            onError: (err) => set({ status: "error", error: err.message }),
+            onError: (err) => {
+                internal.pendingSends.length = 0;
+                set({ status: "error", error: err.message });
+            },
             onEvent: handleEvent,
         });
     };
@@ -264,6 +284,7 @@ export const useChatStore = create<ChatState>((set, get) => {
             internal.handle?.close(1000, "disconnect");
             internal.handle = null;
             internal.currentAgentMessageId = null;
+            internal.pendingSends.length = 0;
             set({ status: "closed" });
         },
 
@@ -291,28 +312,22 @@ export const useChatStore = create<ChatState>((set, get) => {
 
             set((state) => ({ messages: [...state.messages, userMsg, agentMsg] }));
 
-            // Drain after OPEN — socket may still be connecting on first send.
-            // Guard with a microtask retry until we hit OPEN or the store
-            // transitions to an error state (cookie rejected, exhausted
-            // reconnect attempts, etc.).
-            const dispatch = () => {
-                const handle = internal.handle;
-                if (!handle) return;
-                const status = get().status;
-                if (status === "open") {
-                    handle.send({ type: "user", content: trimmed });
-                    return;
-                }
-                if (status === "error" || status === "closed") return;
-                queueMicrotask(dispatch);
-            };
-            dispatch();
+            const handle = internal.handle;
+            const status = get().status;
+            if (handle && status === "open") {
+                handle.send({ type: "user", content: trimmed });
+                return;
+            }
+            if (status === "error" || status === "closed") return;
+            // Socket still CONNECTING — queue; flushed event-driven on onOpen.
+            internal.pendingSends.push(trimmed);
         },
 
         reset: () => {
             internal.handle?.close(1000, "reset");
             internal.handle = null;
             internal.currentAgentMessageId = null;
+            internal.pendingSends.length = 0;
             set({ messages: [], status: "idle", error: null });
         },
 

--- a/frontend/src/lib/date.ts
+++ b/frontend/src/lib/date.ts
@@ -1,0 +1,9 @@
+const HEADER_DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+});
+
+export function formatHeaderDate(date: Date = new Date()): string {
+    return HEADER_DATE_FORMATTER.format(date);
+}

--- a/frontend/src/lib/equipmentSelection.ts
+++ b/frontend/src/lib/equipmentSelection.ts
@@ -1,0 +1,12 @@
+import type { EquipmentSelection } from "./hierarchy";
+
+export const EQUIPMENT_KEY = "aria.selectedEquipment";
+
+export function validateEquipmentSelection(raw: unknown): EquipmentSelection | null {
+    if (!raw || typeof raw !== "object") return null;
+    const r = raw as Record<string, unknown>;
+    if (typeof r.cellId !== "number" || typeof r.lineId !== "number") return null;
+    if (typeof r.cellName !== "string" || typeof r.lineName !== "string") return null;
+    if (typeof r.areaName !== "string" || typeof r.siteName !== "string") return null;
+    return raw as EquipmentSelection;
+}

--- a/frontend/src/pages/ControlRoomPage.tsx
+++ b/frontend/src/pages/ControlRoomPage.tsx
@@ -7,19 +7,10 @@ import {
     type InspectorNode,
     useEquipmentList,
 } from "../features/control-room";
+import { formatHeaderDate } from "../lib/date";
+import { EQUIPMENT_KEY, validateEquipmentSelection } from "../lib/equipmentSelection";
 import type { EquipmentSelection } from "../lib/hierarchy";
 import { useLocalStorage } from "../lib/useLocalStorage";
-
-const EQUIPMENT_KEY = "aria.selectedEquipment";
-
-function validateEquipmentSelection(raw: unknown): EquipmentSelection | null {
-    if (!raw || typeof raw !== "object") return null;
-    const r = raw as Record<string, unknown>;
-    if (typeof r.cellId !== "number" || typeof r.lineId !== "number") return null;
-    if (typeof r.cellName !== "string" || typeof r.lineName !== "string") return null;
-    if (typeof r.areaName !== "string" || typeof r.siteName !== "string") return null;
-    return raw as EquipmentSelection;
-}
 
 /**
  * Control room landing page — M7.1 refactor (#40).
@@ -56,13 +47,18 @@ export default function ControlRoomPage() {
     }, [selectedNodeId, entries]);
 
     const scopeLabel = selection?.lineName ?? "All lines";
+    const today = useMemo(() => formatHeaderDate(), []);
 
     return (
         <section className="flex h-full flex-col gap-6 p-6">
             <SectionHeader
                 label="Control room"
                 size="lg"
-                meta={<span>{scopeLabel} · Apr 23, 2026</span>}
+                meta={
+                    <span>
+                        {scopeLabel} · {today}
+                    </span>
+                }
             />
             <Hairline />
             <div className="relative min-h-0 flex-1 overflow-hidden rounded-[var(--ds-radius-md)] border border-[var(--ds-border)] bg-[var(--ds-bg-surface)]">


### PR DESCRIPTION
## Summary

Bundle of 3 findings confirmed by QA audit + chef cross-check. No behaviour change, no new deps, no refactor beyond the targeted cleanup.

- **fix(ui): dynamic date in Control Room header** — replaces the hardcoded `Apr 23, 2026` in `ControlRoomPage.tsx` with a runtime-formatted date via `Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric" })`. Helper extracted to `frontend/src/lib/date.ts` (`formatHeaderDate`).
- **refactor(equipment): dedup `EQUIPMENT_KEY` + `validateEquipmentSelection`** — moved the copy-pasted definitions from `AppShell.tsx` and `ControlRoomPage.tsx` into `frontend/src/lib/equipmentSelection.ts`. `EquipmentSelection` type keeps its home in `lib/hierarchy.ts`.
- **fix(chat): replace microtask busy-loop in `sendMessage`** — while the WS was `CONNECTING`, the previous `queueMicrotask(dispatch)` retry starved the event loop (microtasks drain before macrotasks, and `onopen` is a macrotask) → tab freeze on slow networks / cold-start backends. Now uses a FIFO `pendingSends` queue inside `internal`, flushed event-driven from the `onOpen` callback. Queue is cleared on `error` / `closed` / `disconnect` / `reset` to avoid resending after an ambiguous reconnect.

## Test plan

- [x] Control Room header reads today's date (e.g. `Apr 24, 2026` on 2026-04-24).
- [x] Reloading the tab after picking an equipment in the TopBar persists the selection — both `AppShell` (topbar badge) and `ControlRoomPage` (`scopeLabel`) recover it from localStorage.
- [x] Sending a message while the chat WS is still `CONNECTING` does not freeze the tab; the message flushes as soon as the socket opens.
- [x] Sending while `error` / `closed` is a no-op (existing behavior preserved).

## Gates

- `npm run typecheck` ✓
- `npm run build` ✓
- `npm run check` (Biome) ✓
- `npm run test` (vitest) ✓ — 97/97