### PR TITLE
feat(agents): M8.5 — Agent Inspector + thinking stream

### DIFF
--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useId, useRef } from "react";
 import { Outlet } from "react-router-dom";
+import { AgentInspector, useAgentInspectorStore } from "../features/agents";
 import { AnomalyBanner, KpiBar } from "../features/control-room";
 import { EQUIPMENT_KEY, validateEquipmentSelection } from "../lib/equipmentSelection";
 import type { EquipmentSelection } from "../lib/hierarchy";
@@ -15,6 +16,7 @@ interface ChatDrawerState {
 }
 
 const CHAT_DRAWER_KEY = "aria.chatDrawer";
+const INSPECTOR_HEIGHT = "40vh";
 
 const DEFAULT_DRAWER_STATE: ChatDrawerState = {
     open: true,
@@ -49,6 +51,7 @@ export function AppShell() {
         null,
         { validator: validateEquipmentSelection },
     );
+    const inspectorAgent = useAgentInspectorStore((s) => s.agent);
 
     const safeDrawer = sanitizeDrawer(drawer);
     const drawerOpenRef = useRef(safeDrawer.open);
@@ -108,8 +111,17 @@ export function AppShell() {
                     transition: `grid-template-columns var(--ds-motion-base) var(--ds-ease-out)`,
                 }}
             >
-                <main className="relative min-h-0 overflow-auto">
-                    <Outlet />
+                <main className="relative flex min-h-0 flex-col overflow-hidden">
+                    <div
+                        className="min-h-0 flex-1 overflow-auto"
+                        style={{
+                            paddingBottom: inspectorAgent ? INSPECTOR_HEIGHT : undefined,
+                            transition: "padding-bottom var(--ds-motion-base) var(--ds-ease-out)",
+                        }}
+                    >
+                        <Outlet />
+                    </div>
+                    <AgentInspector />
                 </main>
                 <Drawer
                     id={drawerId}

--- a/frontend/src/app/chat/Message.tsx
+++ b/frontend/src/app/chat/Message.tsx
@@ -1,6 +1,7 @@
 import { memo } from "react";
 import { ArtifactRenderer } from "../../artifacts";
 import { Badge, Icons, StatusDot } from "../../design-system";
+import { useAgentInspectorStore } from "../../features/agents";
 import type { AgentMessage, AgentPart, UserMessage } from "./chatStore";
 import { Markdown } from "./Markdown";
 
@@ -111,10 +112,16 @@ interface AgentRowProps {
 
 function AgentRow({ message, now }: AgentRowProps) {
     const agentKey = KNOWN_AGENTS.has(message.agent) ? (message.agent as never) : undefined;
+    const openInspector = useAgentInspectorStore((s) => s.openForAgent);
 
     return (
         <div className="flex flex-col gap-2">
-            <div className="flex items-center gap-2">
+            <button
+                type="button"
+                onClick={() => openInspector(message.agent)}
+                aria-label={`Open agent inspector for ${formatAgentLabel(message.agent)}`}
+                className="-mx-1 -my-0.5 inline-flex w-fit items-center gap-2 rounded-[var(--ds-radius-sm)] px-1 py-0.5 text-left transition-colors duration-[var(--ds-motion-fast)] hover:bg-[var(--ds-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)]"
+            >
                 {agentKey ? (
                     <Badge variant="agent" agent={agentKey}>
                         {formatAgentLabel(message.agent)}
@@ -126,7 +133,7 @@ function AgentRow({ message, now }: AgentRowProps) {
                     {formatRelativeTime(message.createdAt, now)}
                 </span>
                 {message.streaming && <StatusDot status="warning" size={6} pulse aria-hidden />}
-            </div>
+            </button>
             <div className="flex flex-col gap-2">
                 {message.parts.length === 0 && message.streaming && (
                     <span className="text-[var(--ds-text-sm)] text-[var(--ds-fg-subtle)] italic">

--- a/frontend/src/features/agents/AgentInspector.tsx
+++ b/frontend/src/features/agents/AgentInspector.tsx
@@ -1,0 +1,413 @@
+/**
+ * Agent Inspector — M8.5.
+ *
+ * Bottom drawer (40vh) that exposes the live internals of an agent turn:
+ * thinking stream, tool calls, raw event IO, and a Memory stub derived from
+ * read-style tool calls. Mounts inside the app's `<main>` region so it
+ * never obstructs the chat drawer on the right.
+ *
+ * Open/close is driven by `useAgentInspectorStore.agent`; closing the
+ * inspector does not interrupt the agent — the underlying WS unsubscribes,
+ * the backend run continues independently.
+ */
+
+import { AnimatePresence, motion } from "framer-motion";
+import { memo, useEffect, useMemo, useRef } from "react";
+import { Badge, Icons, Tabs, TabsContent, TabsList, TabsTrigger } from "../../design-system";
+import { useAgentInspectorStore } from "./agentInspectorStore";
+import type { HandoffEvent, ToolRun } from "./types";
+import type { RawAgentEvent } from "./useAgentStream";
+import { useAgentStream } from "./useAgentStream";
+
+const KNOWN_AGENTS = new Set([
+    "sentinel",
+    "investigator",
+    "kb_builder",
+    "work_order",
+    "qa",
+] as const);
+type KnownAgent = "sentinel" | "investigator" | "kb_builder" | "work_order" | "qa";
+
+/**
+ * MCP read-style tool names that populate the Memory tab. Matches the
+ * backend MCP catalog (cf. M2.x) — keep in sync if new read tools land.
+ */
+const MEMORY_TOOLS = new Set([
+    "get_equipment_kb",
+    "get_failure_history",
+    "get_cell_signals",
+    "get_work_order",
+    "search_kb",
+]);
+
+function formatAgentLabel(id: string): string {
+    if (id === "kb_builder") return "KB builder";
+    if (id === "work_order") return "Work order";
+    if (id === "qa") return "QA";
+    return id.charAt(0).toUpperCase() + id.slice(1);
+}
+
+function truncateId(id: string | null): string {
+    if (!id) return "—";
+    if (id.length <= 10) return id;
+    return `${id.slice(0, 8)}…`;
+}
+
+export function AgentInspector() {
+    const agent = useAgentInspectorStore((s) => s.agent);
+    const close = useAgentInspectorStore((s) => s.close);
+
+    // Keep AnimatePresence driven by `open` derived from `agent !== null`.
+    const open = agent !== null;
+
+    return (
+        <AnimatePresence>
+            {open && agent && <AgentInspectorDrawer agent={agent} onClose={close} />}
+        </AnimatePresence>
+    );
+}
+
+interface AgentInspectorDrawerProps {
+    agent: string;
+    onClose: () => void;
+}
+
+const AgentInspectorDrawer = memo(function AgentInspectorDrawer({
+    agent,
+    onClose,
+}: AgentInspectorDrawerProps) {
+    const { thinking, tools, handoffs, rawEvents, turnId, isStreaming } = useAgentStream(agent);
+    const agentKey: KnownAgent | undefined = KNOWN_AGENTS.has(agent as KnownAgent)
+        ? (agent as KnownAgent)
+        : undefined;
+
+    // Esc to close — mirrors DS Drawer behaviour.
+    useEffect(() => {
+        function onKey(e: KeyboardEvent) {
+            if (e.key === "Escape") onClose();
+        }
+        window.addEventListener("keydown", onKey);
+        return () => window.removeEventListener("keydown", onKey);
+    }, [onClose]);
+
+    return (
+        <motion.aside
+            role="dialog"
+            aria-modal={false}
+            aria-labelledby="agent-inspector-heading"
+            initial={{ y: "100%" }}
+            animate={{ y: 0 }}
+            exit={{ y: "100%" }}
+            transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
+            className="absolute inset-x-0 bottom-0 z-30 flex h-[40vh] min-h-[280px] flex-col overflow-hidden rounded-t-[var(--ds-radius-md)] border-t border-[var(--ds-border)] bg-[var(--ds-bg-surface)]"
+            style={{ boxShadow: "var(--ds-shadow-overlay)" }}
+        >
+            <InspectorHeader
+                agent={agent}
+                agentKey={agentKey}
+                turnId={turnId}
+                isStreaming={isStreaming}
+                onClose={onClose}
+            />
+            <Tabs defaultValue="thinking" className="flex min-h-0 flex-1 flex-col">
+                <TabsList className="px-4 pt-2">
+                    <TabsTrigger value="thinking">
+                        <Icons.Cpu className="mr-1.5 size-3.5" aria-hidden />
+                        Thinking
+                    </TabsTrigger>
+                    <TabsTrigger value="tools">
+                        <Icons.Wrench className="mr-1.5 size-3.5" aria-hidden />
+                        Tools used
+                    </TabsTrigger>
+                    <TabsTrigger value="io">
+                        <Icons.FileText className="mr-1.5 size-3.5" aria-hidden />
+                        Inputs & outputs
+                    </TabsTrigger>
+                    <TabsTrigger value="memory">
+                        <Icons.Database className="mr-1.5 size-3.5" aria-hidden />
+                        Memory
+                    </TabsTrigger>
+                </TabsList>
+                <div className="min-h-0 flex-1 overflow-hidden">
+                    <TabsContent value="thinking" className="h-full">
+                        <ThinkingPanel thinking={thinking} isStreaming={isStreaming} />
+                    </TabsContent>
+                    <TabsContent value="tools" className="h-full">
+                        <ToolsPanel tools={tools} handoffs={handoffs} />
+                    </TabsContent>
+                    <TabsContent value="io" className="h-full">
+                        <IoPanel rawEvents={rawEvents} />
+                    </TabsContent>
+                    <TabsContent value="memory" className="h-full">
+                        <MemoryPanel tools={tools} />
+                    </TabsContent>
+                </div>
+            </Tabs>
+        </motion.aside>
+    );
+});
+
+interface InspectorHeaderProps {
+    agent: string;
+    agentKey: KnownAgent | undefined;
+    turnId: string | null;
+    isStreaming: boolean;
+    onClose: () => void;
+}
+
+function InspectorHeader({ agent, agentKey, turnId, isStreaming, onClose }: InspectorHeaderProps) {
+    return (
+        <header className="flex items-center justify-between gap-3 border-b border-[var(--ds-border)] px-4 py-3">
+            <div className="flex min-w-0 items-center gap-3">
+                <h2
+                    id="agent-inspector-heading"
+                    className="flex items-center gap-2 text-[var(--ds-text-lg)] font-semibold text-[var(--ds-fg-primary)]"
+                >
+                    {agentKey ? (
+                        <Badge variant="agent" agent={agentKey} size="md">
+                            {formatAgentLabel(agent)}
+                        </Badge>
+                    ) : (
+                        <Badge variant="default" size="md">
+                            {formatAgentLabel(agent)}
+                        </Badge>
+                    )}
+                    <span>Agent inspector</span>
+                </h2>
+                <span className="text-[var(--ds-text-sm)] text-[var(--ds-fg-muted)]">
+                    Turn <span className="font-mono">{truncateId(turnId)}</span>
+                    {" · "}
+                    {isStreaming ? "Streaming" : "Idle"}
+                </span>
+            </div>
+            <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close agent inspector"
+                className="inline-flex size-8 items-center justify-center rounded-[var(--ds-radius-sm)] text-[var(--ds-fg-muted)] hover:bg-[var(--ds-bg-hover)] hover:text-[var(--ds-fg-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)]"
+            >
+                <Icons.X className="size-4" aria-hidden />
+            </button>
+        </header>
+    );
+}
+
+interface ThinkingPanelProps {
+    thinking: string;
+    isStreaming: boolean;
+}
+
+function ThinkingPanel({ thinking, isStreaming }: ThinkingPanelProps) {
+    const scrollRef = useRef<HTMLDivElement | null>(null);
+
+    // Auto-scroll to bottom on every thinking delta. `thinking` itself is not
+    // read in the callback (we only touch the DOM ref), so Biome's
+    // `useExhaustiveDependencies` flags it as "unnecessary" — but without it
+    // the effect never re-runs and the stream stops scrolling. Intentional.
+    // biome-ignore lint/correctness/useExhaustiveDependencies: re-run per thinking delta
+    useEffect(() => {
+        const el = scrollRef.current;
+        if (!el) return;
+        el.scrollTop = el.scrollHeight;
+    }, [thinking]);
+
+    const hasContent = thinking.length > 0;
+
+    return (
+        <section
+            ref={scrollRef}
+            className="h-full overflow-y-auto px-4 py-3"
+            aria-live="polite"
+            aria-busy={isStreaming}
+            aria-label="Agent extended thinking stream"
+        >
+            {hasContent ? (
+                <pre
+                    className="whitespace-pre-wrap break-words font-mono text-[var(--ds-text-sm)] leading-[1.55]"
+                    style={{
+                        color: "color-mix(in oklab, var(--ds-agent-investigator), var(--ds-fg-muted) 45%)",
+                    }}
+                >
+                    {thinking}
+                    {isStreaming && (
+                        <span className="ml-0.5 inline-block h-[1em] w-[2px] translate-y-[2px] animate-pulse bg-[var(--ds-accent)] align-middle" />
+                    )}
+                </pre>
+            ) : isStreaming ? (
+                <p className="flex items-center gap-2 text-[var(--ds-text-sm)] text-[var(--ds-fg-muted)]">
+                    <Icons.Activity className="size-3.5 animate-pulse" aria-hidden />
+                    <span>Thinking…</span>
+                </p>
+            ) : (
+                <p className="text-[var(--ds-text-sm)] text-[var(--ds-fg-subtle)]">
+                    No extended thinking captured for this turn yet.
+                </p>
+            )}
+        </section>
+    );
+}
+
+interface ToolsPanelProps {
+    tools: ToolRun[];
+    handoffs: HandoffEvent[];
+}
+
+function ToolsPanel({ tools, handoffs }: ToolsPanelProps) {
+    const empty = tools.length === 0 && handoffs.length === 0;
+    return (
+        <div className="h-full overflow-y-auto px-4 py-3">
+            {empty ? (
+                <p className="text-[var(--ds-text-sm)] text-[var(--ds-fg-subtle)]">
+                    No tool activity yet.
+                </p>
+            ) : (
+                <ul className="flex flex-col gap-1.5">
+                    {tools.map((run) => (
+                        <ToolRow key={run.id} run={run} />
+                    ))}
+                    {handoffs.map((h) => (
+                        <HandoffRow key={h.id} handoff={h} />
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}
+
+function ToolRow({ run }: { run: ToolRun }) {
+    const argsPreview = useMemo(() => {
+        try {
+            const raw = JSON.stringify(run.args);
+            return raw.length > 120 ? `${raw.slice(0, 117)}…` : raw;
+        } catch {
+            return "{…}";
+        }
+    }, [run.args]);
+
+    return (
+        <li>
+            <details className="group rounded-[var(--ds-radius-sm)] border border-[var(--ds-border)] bg-[var(--ds-bg-elevated)]">
+                <summary className="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-[var(--ds-text-xs)]">
+                    {run.status === "running" ? (
+                        <Icons.Activity
+                            className="size-3.5 flex-none animate-pulse text-[var(--ds-fg-subtle)]"
+                            aria-hidden
+                        />
+                    ) : (
+                        <Icons.Check
+                            className="size-3.5 flex-none text-[var(--ds-status-nominal)]"
+                            aria-hidden
+                        />
+                    )}
+                    <span className="font-mono text-[var(--ds-fg-primary)]">{run.toolName}</span>
+                    <span className="truncate font-mono text-[var(--ds-fg-subtle)]">
+                        {argsPreview}
+                    </span>
+                    <span className="ml-auto flex-none text-[var(--ds-fg-muted)]">
+                        {run.durationMs != null ? `${run.durationMs} ms` : "—"}
+                    </span>
+                </summary>
+                <pre className="whitespace-pre-wrap break-words border-t border-[var(--ds-border)] px-3 py-2 font-mono text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+                    {safeStringify(run.args)}
+                </pre>
+            </details>
+        </li>
+    );
+}
+
+function HandoffRow({ handoff }: { handoff: HandoffEvent }) {
+    return (
+        <li className="flex items-center gap-2 rounded-[var(--ds-radius-sm)] border border-dashed border-[var(--ds-border)] px-3 py-2 text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+            <Icons.ArrowRight className="size-3.5 flex-none" aria-hidden />
+            <span>Handoff</span>
+            <span className="font-mono text-[var(--ds-fg-primary)]">{handoff.from_agent}</span>
+            <Icons.ChevronRight
+                className="size-3 flex-none text-[var(--ds-fg-subtle)]"
+                aria-hidden
+            />
+            <span className="font-mono text-[var(--ds-fg-primary)]">{handoff.to_agent}</span>
+            <span className="ml-1 truncate text-[var(--ds-fg-subtle)]">· {handoff.reason}</span>
+        </li>
+    );
+}
+
+function IoPanel({ rawEvents }: { rawEvents: RawAgentEvent[] }) {
+    if (rawEvents.length === 0) {
+        return (
+            <div className="h-full overflow-y-auto px-4 py-3">
+                <p className="text-[var(--ds-text-sm)] text-[var(--ds-fg-subtle)]">
+                    No events received yet for this turn.
+                </p>
+            </div>
+        );
+    }
+    return (
+        <div className="h-full overflow-y-auto px-4 py-3">
+            <ol className="flex flex-col gap-2">
+                {rawEvents.map((evt) => (
+                    <li
+                        key={evt.id}
+                        className="rounded-[var(--ds-radius-sm)] border border-[var(--ds-border)] bg-[var(--ds-bg-elevated)]"
+                    >
+                        <div className="flex items-center gap-2 border-b border-[var(--ds-border)] px-3 py-1.5 text-[var(--ds-text-xs)]">
+                            <span className="font-mono text-[var(--ds-accent)]">{evt.type}</span>
+                            <span className="ml-auto text-[var(--ds-fg-subtle)]">
+                                {new Date(evt.at).toLocaleTimeString()}
+                            </span>
+                        </div>
+                        <pre className="whitespace-pre-wrap break-words px-3 py-2 font-mono text-[var(--ds-text-xs)] text-[var(--ds-fg-muted)]">
+                            {safeStringify(evt.payload)}
+                        </pre>
+                    </li>
+                ))}
+            </ol>
+        </div>
+    );
+}
+
+function MemoryPanel({ tools }: { tools: ToolRun[] }) {
+    const memoryHits = useMemo(() => tools.filter((t) => MEMORY_TOOLS.has(t.toolName)), [tools]);
+    if (memoryHits.length === 0) {
+        return (
+            <div className="h-full overflow-y-auto px-4 py-3">
+                <p className="text-[var(--ds-text-sm)] text-[var(--ds-fg-subtle)]">
+                    No KB or failure-history entries touched yet.
+                </p>
+                <p className="mt-2 text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
+                    Inferred from read-style MCP tools: {Array.from(MEMORY_TOOLS).join(", ")}.
+                </p>
+            </div>
+        );
+    }
+    return (
+        <div className="h-full overflow-y-auto px-4 py-3">
+            <ul className="flex flex-col gap-1.5">
+                {memoryHits.map((hit) => (
+                    <li
+                        key={hit.id}
+                        className="flex items-center gap-2 rounded-[var(--ds-radius-sm)] border border-[var(--ds-border)] bg-[var(--ds-bg-elevated)] px-3 py-2 text-[var(--ds-text-xs)]"
+                    >
+                        <Icons.Database
+                            className="size-3.5 flex-none text-[var(--ds-fg-muted)]"
+                            aria-hidden
+                        />
+                        <span className="font-mono text-[var(--ds-fg-primary)]">
+                            {hit.toolName}
+                        </span>
+                        <span className="truncate font-mono text-[var(--ds-fg-subtle)]">
+                            {safeStringify(hit.args)}
+                        </span>
+                    </li>
+                ))}
+            </ul>
+        </div>
+    );
+}
+
+function safeStringify(value: unknown): string {
+    try {
+        return JSON.stringify(value, null, 2);
+    } catch {
+        return String(value);
+    }
+}

--- a/frontend/src/features/agents/agentInspectorStore.ts
+++ b/frontend/src/features/agents/agentInspectorStore.ts
@@ -1,0 +1,25 @@
+/**
+ * Global open/close state for the Agent Inspector drawer. Kept minimal —
+ * just the agent being inspected. The actual stream state lives inside
+ * `useAgentStream`, scoped to the open agent.
+ *
+ * Any chat row (or future activity feed row) calls `openForAgent(id)` to
+ * surface the inspector for that agent's active turn.
+ */
+
+import { create } from "zustand";
+
+export interface AgentInspectorState {
+    /** Agent currently being inspected, or null when closed. */
+    agent: string | null;
+    /** Open (or switch) the inspector to a given agent. */
+    openForAgent: (agent: string) => void;
+    /** Close the drawer. */
+    close: () => void;
+}
+
+export const useAgentInspectorStore = create<AgentInspectorState>((set) => ({
+    agent: null,
+    openForAgent: (agent) => set({ agent }),
+    close: () => set({ agent: null }),
+}));

--- a/frontend/src/features/agents/index.ts
+++ b/frontend/src/features/agents/index.ts
@@ -1,0 +1,6 @@
+export { AgentInspector } from "./AgentInspector";
+export type { AgentInspectorState } from "./agentInspectorStore";
+export { useAgentInspectorStore } from "./agentInspectorStore";
+export type { HandoffEvent, ToolRun } from "./types";
+export type { AgentStreamStatus, RawAgentEvent, UseAgentStreamResult } from "./useAgentStream";
+export { useAgentStream } from "./useAgentStream";

--- a/frontend/src/features/agents/types.ts
+++ b/frontend/src/features/agents/types.ts
@@ -1,0 +1,27 @@
+import type { EventBusMap } from "../../lib/ws.types";
+
+export type AgentStreamAgentId = string;
+
+/**
+ * Snapshot of a tool call the agent emitted during a turn.
+ * Started when `tool_call_started` arrives; sealed when the matching
+ * `tool_call_completed` arrives (same turn_id + tool_name, FIFO match).
+ */
+export interface ToolRun {
+    id: string;
+    toolName: string;
+    args: Record<string, unknown>;
+    startedAt: number;
+    /** Fills on `tool_call_completed`. */
+    durationMs?: number;
+    /** UI status — "done" once the completed event arrives. */
+    status: "running" | "done";
+}
+
+export type HandoffEvent = EventBusMap["agent_handoff"] & {
+    /** `Date.now()` at reception — for stable ordering. */
+    receivedAt: number;
+    id: string;
+};
+
+export type ThinkingDeltaEvent = EventBusMap["thinking_delta"];

--- a/frontend/src/features/agents/useAgentStream.test.ts
+++ b/frontend/src/features/agents/useAgentStream.test.ts
@@ -1,0 +1,202 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { installMockWebSocket, MockWebSocket, restoreWebSocket } from "../../test/mock-websocket";
+import { useAgentStream } from "./useAgentStream";
+
+beforeEach(() => {
+    installMockWebSocket();
+});
+
+afterEach(() => {
+    restoreWebSocket();
+});
+
+describe("useAgentStream", () => {
+    it("is idle when agent is null (no socket opened)", () => {
+        const { result } = renderHook(() => useAgentStream(null));
+        expect(result.current.isStreaming).toBe(false);
+        expect(result.current.turnId).toBeNull();
+        expect(result.current.thinking).toBe("");
+        expect(result.current.connectionStatus).toBe("closed");
+    });
+
+    it("opens a turn and accumulates thinking for the tracked agent", () => {
+        const { result } = renderHook(() => useAgentStream("investigator"));
+        act(() => {
+            MockWebSocket.last.simulateOpen();
+            MockWebSocket.last.simulateMessage({
+                type: "agent_start",
+                agent: "investigator",
+                turn_id: "turn-1",
+            });
+            MockWebSocket.last.simulateMessage({
+                type: "thinking_delta",
+                agent: "investigator",
+                content: "Observing ",
+                turn_id: "turn-1",
+            });
+            MockWebSocket.last.simulateMessage({
+                type: "thinking_delta",
+                agent: "investigator",
+                content: "vibration spike.",
+                turn_id: "turn-1",
+            });
+        });
+
+        expect(result.current.turnId).toBe("turn-1");
+        expect(result.current.thinking).toBe("Observing vibration spike.");
+        expect(result.current.isStreaming).toBe(true);
+    });
+
+    it("flips isStreaming off on agent_end but keeps buffers", () => {
+        const { result } = renderHook(() => useAgentStream("investigator"));
+        act(() => {
+            MockWebSocket.last.simulateOpen();
+            MockWebSocket.last.simulateMessage({
+                type: "agent_start",
+                agent: "investigator",
+                turn_id: "turn-1",
+            });
+            MockWebSocket.last.simulateMessage({
+                type: "thinking_delta",
+                agent: "investigator",
+                content: "done.",
+                turn_id: "turn-1",
+            });
+            MockWebSocket.last.simulateMessage({
+                type: "agent_end",
+                agent: "investigator",
+                turn_id: "turn-1",
+                finish_reason: "end_turn",
+            });
+        });
+
+        expect(result.current.isStreaming).toBe(false);
+        expect(result.current.thinking).toBe("done.");
+    });
+
+    it("ignores events for other agents on the shared bus", () => {
+        const { result } = renderHook(() => useAgentStream("investigator"));
+        act(() => {
+            MockWebSocket.last.simulateOpen();
+            MockWebSocket.last.simulateMessage({
+                type: "agent_start",
+                agent: "sentinel",
+                turn_id: "other-turn",
+            });
+            MockWebSocket.last.simulateMessage({
+                type: "thinking_delta",
+                agent: "sentinel",
+                content: "nope",
+                turn_id: "other-turn",
+            });
+        });
+
+        expect(result.current.turnId).toBeNull();
+        expect(result.current.thinking).toBe("");
+        expect(result.current.isStreaming).toBe(false);
+    });
+
+    it("ignores events with a stale turn_id for the same agent", () => {
+        const { result } = renderHook(() => useAgentStream("investigator"));
+        act(() => {
+            MockWebSocket.last.simulateOpen();
+            MockWebSocket.last.simulateMessage({
+                type: "agent_start",
+                agent: "investigator",
+                turn_id: "turn-2",
+            });
+            // Stray event from a previous turn leaking in.
+            MockWebSocket.last.simulateMessage({
+                type: "thinking_delta",
+                agent: "investigator",
+                content: "stale",
+                turn_id: "turn-1",
+            });
+            MockWebSocket.last.simulateMessage({
+                type: "thinking_delta",
+                agent: "investigator",
+                content: "current",
+                turn_id: "turn-2",
+            });
+        });
+
+        expect(result.current.turnId).toBe("turn-2");
+        expect(result.current.thinking).toBe("current");
+    });
+
+    it("tracks tool call lifecycle with duration on completion", () => {
+        const { result } = renderHook(() => useAgentStream("investigator"));
+        act(() => {
+            MockWebSocket.last.simulateOpen();
+            MockWebSocket.last.simulateMessage({
+                type: "agent_start",
+                agent: "investigator",
+                turn_id: "turn-1",
+            });
+            MockWebSocket.last.simulateMessage({
+                type: "tool_call_started",
+                agent: "investigator",
+                tool_name: "get_equipment_kb",
+                args: { cell_id: 2 },
+                turn_id: "turn-1",
+            });
+        });
+
+        expect(result.current.tools).toHaveLength(1);
+        expect(result.current.tools[0].status).toBe("running");
+        expect(result.current.tools[0].toolName).toBe("get_equipment_kb");
+
+        act(() => {
+            MockWebSocket.last.simulateMessage({
+                type: "tool_call_completed",
+                agent: "investigator",
+                tool_name: "get_equipment_kb",
+                duration_ms: 123,
+                turn_id: "turn-1",
+            });
+        });
+
+        expect(result.current.tools[0].status).toBe("done");
+        expect(result.current.tools[0].durationMs).toBe(123);
+    });
+
+    it("resets buffers when a new turn starts for the same agent", () => {
+        const { result } = renderHook(() => useAgentStream("investigator"));
+        act(() => {
+            MockWebSocket.last.simulateOpen();
+            MockWebSocket.last.simulateMessage({
+                type: "agent_start",
+                agent: "investigator",
+                turn_id: "turn-1",
+            });
+            MockWebSocket.last.simulateMessage({
+                type: "thinking_delta",
+                agent: "investigator",
+                content: "first",
+                turn_id: "turn-1",
+            });
+            MockWebSocket.last.simulateMessage({
+                type: "agent_end",
+                agent: "investigator",
+                turn_id: "turn-1",
+                finish_reason: "end_turn",
+            });
+            MockWebSocket.last.simulateMessage({
+                type: "agent_start",
+                agent: "investigator",
+                turn_id: "turn-2",
+            });
+            MockWebSocket.last.simulateMessage({
+                type: "thinking_delta",
+                agent: "investigator",
+                content: "second",
+                turn_id: "turn-2",
+            });
+        });
+
+        expect(result.current.turnId).toBe("turn-2");
+        expect(result.current.thinking).toBe("second");
+        expect(result.current.isStreaming).toBe(true);
+    });
+});

--- a/frontend/src/features/agents/useAgentStream.ts
+++ b/frontend/src/features/agents/useAgentStream.ts
@@ -1,0 +1,264 @@
+/**
+ * Subscribes to `/api/v1/events` for a given agent and exposes a turn-scoped
+ * buffer (thinking delta cumul, tool call lifecycle, handoffs, streaming
+ * flag). Mirrors the `useAnomalyStream` pattern (M7.3) — one socket per
+ * hook instance, filter inside `onEvent`.
+ *
+ * Turn semantics:
+ * - `agent_start` for the tracked agent → opens a new turn, resets buffers,
+ *   flips `isStreaming` to true.
+ * - `agent_end` for the tracked agent → keeps buffers, flips `isStreaming`
+ *   to false.
+ * - All intermediate events (`thinking_delta`, `tool_call_started`,
+ *   `tool_call_completed`, `agent_handoff`) are scoped to the active
+ *   `turnId`. Events with a different `turn_id` are ignored defensively
+ *   (the bus is global, simultaneous agents can interleave).
+ *
+ * No persistence. Closing the inspector unmounts → socket closes, buffer
+ * garbage-collected. Re-opening the inspector starts fresh.
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { createWsClient } from "../../lib/ws";
+import type { EventBusMap } from "../../lib/ws.types";
+import type { HandoffEvent, ToolRun } from "./types";
+
+const EVENTS_WS_URL = "/api/v1/events";
+
+export type AgentStreamStatus = "connecting" | "open" | "closed" | "error";
+
+export interface UseAgentStreamResult {
+    /** Current turn id — null before the first `agent_start`. */
+    turnId: string | null;
+    /** Cumulative `thinking_delta` content for the current turn. */
+    thinking: string;
+    /** Tool calls emitted during the current turn, in start order. */
+    tools: ToolRun[];
+    /** Handoffs originating from this agent during the current turn. */
+    handoffs: HandoffEvent[];
+    /** Raw bus events for this agent's active turn — used by the IO tab. */
+    rawEvents: RawAgentEvent[];
+    /** True between `agent_start` and `agent_end` for the tracked agent. */
+    isStreaming: boolean;
+    /** Socket lifecycle. */
+    connectionStatus: AgentStreamStatus;
+}
+
+export interface RawAgentEvent {
+    id: string;
+    type: keyof EventBusMap;
+    at: number;
+    payload: Record<string, unknown>;
+}
+
+interface MutableTurnState {
+    turnId: string | null;
+    thinking: string;
+    tools: ToolRun[];
+    handoffs: HandoffEvent[];
+    rawEvents: RawAgentEvent[];
+    counter: number;
+}
+
+const emptyTurn = (): MutableTurnState => ({
+    turnId: null,
+    thinking: "",
+    tools: [],
+    handoffs: [],
+    rawEvents: [],
+    counter: 0,
+});
+
+/**
+ * Subscribe to the event bus for `agent`. Pass `null` to keep the hook
+ * idle (no socket opened).
+ */
+export function useAgentStream(agent: string | null): UseAgentStreamResult {
+    const [turnId, setTurnId] = useState<string | null>(null);
+    const [thinking, setThinking] = useState("");
+    const [tools, setTools] = useState<ToolRun[]>([]);
+    const [handoffs, setHandoffs] = useState<HandoffEvent[]>([]);
+    const [rawEvents, setRawEvents] = useState<RawAgentEvent[]>([]);
+    const [isStreaming, setIsStreaming] = useState(false);
+    const [connectionStatus, setConnectionStatus] = useState<AgentStreamStatus>("connecting");
+
+    const stateRef = useRef<MutableTurnState>(emptyTurn());
+
+    useEffect(() => {
+        if (!agent) {
+            stateRef.current = emptyTurn();
+            setTurnId(null);
+            setThinking("");
+            setTools([]);
+            setHandoffs([]);
+            setRawEvents([]);
+            setIsStreaming(false);
+            setConnectionStatus("closed");
+            return;
+        }
+
+        const controller = new AbortController();
+        setConnectionStatus("connecting");
+        stateRef.current = emptyTurn();
+        setTurnId(null);
+        setThinking("");
+        setTools([]);
+        setHandoffs([]);
+        setRawEvents([]);
+        setIsStreaming(false);
+
+        const nextId = (prefix: string): string => {
+            stateRef.current.counter += 1;
+            return `${prefix}-${stateRef.current.counter}`;
+        };
+
+        const pushRaw = (type: keyof EventBusMap, payload: Record<string, unknown>) => {
+            const entry: RawAgentEvent = {
+                id: nextId("raw"),
+                type,
+                at: Date.now(),
+                payload,
+            };
+            stateRef.current.rawEvents = [...stateRef.current.rawEvents, entry];
+            setRawEvents(stateRef.current.rawEvents);
+        };
+
+        const client = createWsClient<EventBusMap>({
+            url: EVENTS_WS_URL,
+            signal: controller.signal,
+            onOpen: () => setConnectionStatus("open"),
+            onClose: () => setConnectionStatus("closed"),
+            onError: () => setConnectionStatus("error"),
+            onEvent: (type, payload) => {
+                // Only claim events that reference our agent.
+                const p = payload as Record<string, unknown>;
+                const isForAgent =
+                    (type === "agent_start" ||
+                        type === "agent_end" ||
+                        type === "thinking_delta" ||
+                        type === "tool_call_started" ||
+                        type === "tool_call_completed" ||
+                        type === "agent_handoff") &&
+                    agentFromPayload(type, p) === agent;
+                if (!isForAgent) return;
+
+                switch (type) {
+                    case "agent_start": {
+                        const e = payload as EventBusMap["agent_start"];
+                        // New turn — clear buffers.
+                        stateRef.current = {
+                            ...emptyTurn(),
+                            turnId: e.turn_id,
+                            counter: stateRef.current.counter,
+                        };
+                        setTurnId(e.turn_id);
+                        setThinking("");
+                        setTools([]);
+                        setHandoffs([]);
+                        setRawEvents([]);
+                        setIsStreaming(true);
+                        pushRaw(type, e as unknown as Record<string, unknown>);
+                        break;
+                    }
+                    case "agent_end": {
+                        const e = payload as EventBusMap["agent_end"];
+                        if (e.turn_id !== stateRef.current.turnId) return;
+                        setIsStreaming(false);
+                        pushRaw(type, e as unknown as Record<string, unknown>);
+                        break;
+                    }
+                    case "thinking_delta": {
+                        const e = payload as EventBusMap["thinking_delta"];
+                        if (e.turn_id !== stateRef.current.turnId) return;
+                        stateRef.current.thinking += e.content;
+                        setThinking(stateRef.current.thinking);
+                        pushRaw(type, e as unknown as Record<string, unknown>);
+                        break;
+                    }
+                    case "tool_call_started": {
+                        const e = payload as EventBusMap["tool_call_started"];
+                        if (e.turn_id !== stateRef.current.turnId) return;
+                        const run: ToolRun = {
+                            id: nextId("tc"),
+                            toolName: e.tool_name,
+                            args: e.args,
+                            startedAt: Date.now(),
+                            status: "running",
+                        };
+                        stateRef.current.tools = [...stateRef.current.tools, run];
+                        setTools(stateRef.current.tools);
+                        pushRaw(type, e as unknown as Record<string, unknown>);
+                        break;
+                    }
+                    case "tool_call_completed": {
+                        const e = payload as EventBusMap["tool_call_completed"];
+                        if (e.turn_id !== stateRef.current.turnId) return;
+                        // FIFO match on tool_name against the oldest running run.
+                        const idx = stateRef.current.tools.findIndex(
+                            (t) => t.toolName === e.tool_name && t.status === "running",
+                        );
+                        if (idx >= 0) {
+                            const next = [...stateRef.current.tools];
+                            next[idx] = {
+                                ...next[idx],
+                                durationMs: e.duration_ms,
+                                status: "done",
+                            };
+                            stateRef.current.tools = next;
+                            setTools(next);
+                        }
+                        pushRaw(type, e as unknown as Record<string, unknown>);
+                        break;
+                    }
+                    case "agent_handoff": {
+                        const e = payload as EventBusMap["agent_handoff"];
+                        if (e.turn_id !== stateRef.current.turnId) return;
+                        const entry: HandoffEvent = {
+                            ...e,
+                            id: nextId("ho"),
+                            receivedAt: Date.now(),
+                        };
+                        stateRef.current.handoffs = [...stateRef.current.handoffs, entry];
+                        setHandoffs(stateRef.current.handoffs);
+                        pushRaw(type, e as unknown as Record<string, unknown>);
+                        break;
+                    }
+                    default:
+                        break;
+                }
+            },
+        });
+
+        return () => {
+            controller.abort();
+            client.close(1000, "unmount");
+        };
+    }, [agent]);
+
+    return {
+        turnId,
+        thinking,
+        tools,
+        handoffs,
+        rawEvents,
+        isStreaming,
+        connectionStatus,
+    };
+}
+
+/**
+ * Extract the `agent` field from an event payload. `agent_handoff` uses
+ * `from_agent` (the outgoing speaker); that's still the agent this inspector
+ * tracks when we're watching them delegate.
+ */
+function agentFromPayload(
+    type: keyof EventBusMap,
+    payload: Record<string, unknown>,
+): string | null {
+    if (type === "agent_handoff") {
+        const v = payload.from_agent;
+        return typeof v === "string" ? v : null;
+    }
+    const v = payload.agent;
+    return typeof v === "string" ? v : null;
+}


### PR DESCRIPTION
## Summary

The **Opus 4.7 wow-factor panel** — shows the investigator's extended thinking streaming live, plus tool calls, raw IO, and a KB/failure-history memory trace for the current turn.

- **Drawer bottom (40vh)** mounted inside `<main>` so it never obstructs the right-docked chat. Main content reserves `padding-bottom: 40vh` while open, so nothing in the Control Room is hidden behind it.
- **4 tabs** via `design-system/Tabs` primitive:
  - **Thinking** — cumulative `thinking_delta` render in mono, muted investigator-purple, auto-scroll on each delta. `aria-live=polite` + `aria-busy` for screen readers.
  - **Tools used** — expandable FIFO-matched tool runs (`tool_call_started` → `tool_call_completed`) with `duration_ms`. Handoffs (`agent_handoff`) listed alongside.
  - **Inputs & outputs** — dev-style pretty-printed JSON of every raw event the agent emitted on this turn, timestamped.
  - **Memory** — derived from read-style MCP tools (`get_equipment_kb`, `get_failure_history`, `get_cell_signals`, `get_work_order`, `search_kb`) surfaced from the Tools buffer.
- **Opens from any chat agent row** — the agent Badge + timestamp block becomes a `<button>` that calls `openForAgent(message.agent)`. `Esc` or the X button closes; closing unmounts the WS client cleanly, the backend run is unaffected.
- **Stream contract**: subscribes to `/api/v1/events` via the existing `createWsClient` + `EventBusMap` (cf. M4.1 table). Filters by `agent` on ingress, scopes buffers by `turn_id` so interleaved agent runs on the shared bus can't leak across turns.

Adheres to DESIGN_PLAN_v2: `design-system/icons.tsx` wrapper for all icons (Cpu/Wrench/FileText/Database/X), agent colors via `variant="agent"` Badge, 10px radius, 2px accent focus ring, no gradients/glass/neon. No new dep.

## Test plan

- [x] Click an agent badge in the chat → inspector drawer slides up, 4 tabs render.
- [x] Trigger an anomaly (or any Investigator turn) → Thinking tab streams tokens in real time with auto-scroll.
- [x] Tools used tab lists every `tool_call_started`, seals with `Check` + duration once `tool_call_completed` arrives.
- [ ] Inputs & outputs tab shows every raw event pretty-printed.
- [ ] Memory tab lists only read-style MCP tool calls (KB + failure history).
- [ ] Close the inspector (X or Esc) → WS closes, chat/control-room untouched, backend turn keeps running (check server logs).
- [ ] Control Room content stays fully reachable above the drawer — no content hidden behind the 40vh overlay.
- [ ] Chat drawer on the right is not obstructed.
- [ ] Cross-agent noise: if Sentinel and Investigator run concurrently, Investigator inspector only shows Investigator's buffers.

## Quality gates (run from `frontend/`)

- `npm run typecheck` ✓
- `npm run build` ✓
- `npm run check` (Biome) ✓
- `npm run test` (vitest) ✓ — 104/104 (7 new unit tests for `useAgentStream`)

Closes #49