### PR TITLE
docs: architecture documentation for ARIA backend

### DIFF
--- a/docs/architecture/01-data-layer.md
+++ b/docs/architecture/01-data-layer.md
@@ -1,0 +1,229 @@
+# M1 — Data Layer
+
+> [!NOTE]
+> The data layer is the foundation every other milestone depends on. M1 added migration 007, which extends `equipment_kb`, `work_order`, and `failure_history` with the JSONB columns the agents need, and ships the Pydantic schemas that mirror those columns. Migration 008 was added afterwards to enforce per-signal threshold-key integrity at write time.
+
+---
+
+## Why M1 exists
+
+ARIA's product promise is that the equipment knowledge base, the work order, and the failure history are *first-class structured data* — not free-text fields the agents have to parse out of markdown. M1's job was to give every downstream agent a typed, queryable home for the structured artifacts it produces.
+
+Three columns carry the bulk of the agent-produced state:
+
+- `equipment_kb.structured_data` — the full hybrid profile (manufacturer manual + operator-calibrated thresholds + failure patterns + maintenance procedures). Written by the KB Builder, read by every other agent.
+- `work_order.recommended_actions` and `work_order.required_parts` — the structured output of the Work Order Generator that drives the printable Work Order Card.
+- `failure_history.signal_patterns` — the per-signal signature of a past failure, used by the Investigator's "memory" scene to recognise recurring failure modes.
+
+Everything in the rest of the system flows through these three columns.
+
+---
+
+## Schema overview
+
+```mermaid
+erDiagram
+    enterprise ||--o{ site : has
+    site ||--o{ area : has
+    area ||--o{ line : has
+    line ||--o{ cell : has
+    cell ||--|| equipment_kb : "1:1"
+    cell ||--o{ work_order : opens
+    cell ||--o{ failure_history : records
+    cell ||--o{ process_signal_definition : exposes
+    process_signal_definition ||--o{ process_signal_data : streams
+    process_signal_definition }o--|| equipment_kb : "kb_threshold_key"
+
+    equipment_kb {
+        int cell_id PK
+        jsonb structured_data
+        text raw_markdown
+        bool onboarding_complete
+        float confidence_score
+        timestamptz last_enriched_at
+    }
+    work_order {
+        int id PK
+        int cell_id FK
+        text status
+        text rca_summary
+        jsonb recommended_actions
+        jsonb required_parts
+        timestamptz suggested_window_start
+        timestamptz suggested_window_end
+        text investigator_session_id
+    }
+    failure_history {
+        int id PK
+        int cell_id FK
+        text failure_mode
+        text root_cause
+        jsonb signal_patterns
+        int work_order_id FK
+    }
+```
+
+The hierarchy `enterprise → site → area → line → cell` is fixed and seeded. The cell is the unit of monitoring — all agent activity is keyed on `cell_id`.
+
+---
+
+## Migrations
+
+Migrations are SQL files versioned by the `migrate` service in [docker-compose.yaml](../../docker-compose.yaml). The relevant ones for the agent stack:
+
+| Migration                                       | What it adds                                                                                                                                   | Issue            |
+|-------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|------------------|
+| `001_initial_schema.up.sql`                     | Hierarchy tables, `equipment_kb` (column-only profile, no JSONB), `work_order`, `failure_history`.                                             | M1               |
+| `002_views.up.sql`                              | `current_process_signals` view used by `get_current_signals`.                                                                                  | M1               |
+| `003_kpi_system.up.sql`                         | `fn_oee`, `fn_mtbf`, `fn_mttr`, `fn_status_durations` — TimescaleDB functions wrapped by the KPI MCP tools.                                    | M1               |
+| `006_aria_seed_p02.up.sql`                      | Canonical P-02 (Grundfos centrifugal pump) seed used by every demo scenario.                                                                   | M1               |
+| `007_aria_kb_workorder_extension.up.sql`        | `equipment_kb.structured_data`, `work_order.recommended_actions` / `required_parts` / `suggested_window_*`, `failure_history.signal_patterns`. | M1.1, M1.2, M1.3 |
+| `008_kb_threshold_key.up.sql`                   | `process_signal_definition.kb_threshold_key` + the `_assert_thresholds_cover_signal_keys` integrity guard.                                     | #69              |
+| `009_work_order_investigator_session_id.up.sql` | `work_order.investigator_session_id` for the Managed Agents persistence story.                                                                 | M5.5             |
+
+> [!IMPORTANT]
+> Migration 008 is the most consequential addition after the original M1 plan. It enforces that every signal flagged for monitoring has a corresponding entry in `equipment_kb.structured_data.thresholds` — preventing silent monitoring gaps where a signal is wired to the database but no threshold ever causes a breach. The KB Builder pre-stubs missing entries during PDF extraction to satisfy this guard. See [03-kb-builder.md](./03-kb-builder.md#the-threshold-key-guard).
+
+---
+
+## Pydantic mirrors of the JSONB columns
+
+Each JSONB column has a Pydantic schema that owns its shape. The schemas are the contract LLMs see indirectly via tool descriptions and the contract Pydantic enforces on every write.
+
+### `EquipmentKB` — the structured KB profile
+
+[backend/modules/kb/kb_schema.py](../../backend/modules/kb/kb_schema.py)
+
+```mermaid
+classDiagram
+    class EquipmentKB {
+        kb_meta: KbMeta
+        equipment: Equipment
+        thresholds: dict[str, ThresholdValue]
+        failure_patterns: list[FailurePattern]
+        maintenance_procedures: list[MaintenanceProcedure]
+        calibration_log: list[CalibrationLogEntry]
+        compute_completeness() float
+    }
+    class ThresholdValue {
+        alert: float | None
+        trip: float | None
+        low_alert: float | None
+        high_alert: float | None
+        unit: str
+        source: str
+        confidence: float
+    }
+    class FailurePattern {
+        mode: str
+        signal_signature: dict
+        recommended_actions: list[str]
+        parts: list[str]
+    }
+    EquipmentKB --> ThresholdValue
+    EquipmentKB --> FailurePattern
+```
+
+Two threshold shapes are supported: single-sided (`alert` / `trip`) for vibration and temperature, and double-sided (`low_alert` / `high_alert`) for flow and pressure. The single source of truth for evaluating either shape against a measurement is [`core.thresholds.evaluate_threshold`](../../backend/core/thresholds.py) — see [04-sentinel-investigator.md](./04-sentinel-investigator.md#threshold-evaluation).
+
+`compute_completeness()` produces the `confidence_score` shown in the UI. The weights (thresholds 0.50, failure_patterns 0.20, procedures 0.20, equipment 0.10) reward operator calibration over raw PDF extraction, which is what drives the demo's "0.40 to 0.85" confidence jump after onboarding.
+
+### `WorkOrderCreate` / `WorkOrderUpdate` — work order writes
+
+[backend/modules/work_order/schemas.py](../../backend/modules/work_order/schemas.py)
+
+```python
+Status = Literal["detected", "analyzed", "open", "in_progress", "completed", "cancelled"]
+```
+
+The status machine is intentionally short. The agent pipeline only ever writes:
+
+- Sentinel: `detected` (on opening a new work order).
+- Investigator: `analyzed` (after a successful `submit_rca`) or remains `detected` if the run timed out.
+- Work Order Generator: `open` (after a successful `submit_work_order`) or remains `analyzed` on failure.
+
+Operator transitions (`open → in_progress → completed` or `cancelled`) are out of agent scope and only happen through the REST router.
+
+`recommended_actions` and `required_parts` are typed lists of structured rows. They are never free text — the Work Order Generator emits them through `submit_work_order`, which Pydantic-validates before the row is written.
+
+### `FailureHistoryRow` — the memory store
+
+[backend/modules/logbook/](../../backend/modules/logbook/) and the `failure_history` table.
+
+`signal_patterns` carries the per-signal signature of a past failure (rms vibration trace, peak frequencies, pressure droop, etc.). The Investigator reads the recent rows for the affected cell at the start of every RCA so that recurring failure modes can be recognised quickly. This is what powers the "knowledge does not retire with the senior technician" pitch line.
+
+---
+
+## How M1 plugs into M2 and beyond
+
+```mermaid
+flowchart LR
+    subgraph M1["M1 — Pydantic + JSONB"]
+        EquipmentKB
+        WorkOrderUpdate
+        FailureHistoryRow
+    end
+    subgraph M2["M2 — MCP tools"]
+        update_kb["update_equipment_kb"]
+        get_kb["get_equipment_kb"]
+        get_wo["get_work_orders"]
+        get_fh["get_failure_history"]
+    end
+    subgraph Agents
+        Builder
+        Inv["Investigator"]
+        WOG["WO Generator"]
+    end
+    EquipmentKB -- "validates writes" --> update_kb
+    EquipmentKB -- "deserialises reads" --> get_kb
+    WorkOrderUpdate -- "validates writes" --> Builder
+    FailureHistoryRow -- "deserialises reads" --> get_fh
+    update_kb --> Builder
+    get_kb --> Inv
+    get_kb --> WOG
+    get_wo --> WOG
+    get_fh --> Inv
+```
+
+Every agent tool that touches one of the three JSONB columns goes through the corresponding Pydantic mirror. There is no path from an agent to the JSONB blob that bypasses the schema — that is what protects the system from LLM-generated data that "almost" matches the contract.
+
+---
+
+## Repository pattern
+
+[backend/modules/kb/repository.py](../../backend/modules/kb/repository.py) — `KbRepository.upsert(payload)` is the canonical write path.
+
+Two non-obvious behaviours are encoded inside the repository (not the MCP tool):
+
+1. **Dynamic SQL.** The `upsert` builds its `UPDATE` clause from whatever fields the payload carries. This keeps the M2 `update_equipment_kb` tool small (it just forwards a dict) and lets the schema add new columns without touching the tool.
+2. **The threshold-key guard.** Every `upsert` call invokes `_assert_thresholds_cover_signal_keys` before the SQL executes. A write that would orphan a `kb_threshold_key` is rejected with a `ValidationFailedError`.
+
+This repository owns the integrity of the KB column set; the MCP tool is just an LLM-facing facade.
+
+---
+
+## P-02 canonical seed
+
+The hackathon demo is built around a single canonical cell — `cell_id = 1`, P-02, a Grundfos CR 32-2 centrifugal pump. The seed in [006_aria_seed_p02.up.sql](../../backend/infrastructure/database/migrations/versions/006_aria_seed_p02.up.sql) and the supplemental KB seed in [backend/infrastructure/database/seeds/p02_kb.sql](../../backend/infrastructure/database/seeds/p02_kb.sql) populate:
+
+- The hierarchy chain (enterprise → site → area → line → cell).
+- Four signal definitions: `vibration_mm_s`, `bearing_temp_c`, `flow_l_min`, `pressure_bar`. Each has a `kb_threshold_key` that points back to `equipment_kb.structured_data.thresholds`.
+- A complete `equipment_kb` row with all four thresholds and a couple of failure patterns.
+
+`make db.seed.p02` re-applies the supplemental KB row idempotently, which is what to run after KB drift during local debugging.
+
+---
+
+## Audits and references
+
+- [docs/audits/M2-mcp-server-audit.md §1](../audits/M2-mcp-server-audit.md) — pre-implementation review of the M2.5 KB tool against the M1 schema. Every "merge semantics" decision recorded there is now encoded in `KbRepository.upsert`.
+- [docs/audits/M3-kb-builder-audit.md §7.2](../audits/M3-kb-builder-audit.md) — post-implementation cross-check confirming that `EquipmentKbUpsert` and `KbRepository.upsert` already supported `raw_markdown` and `onboarding_complete` so M3 did not need a schema migration.
+- [docs/planning/M1-data-layer/issues.md](../planning/M1-data-layer/issues.md) — original issue plan.
+
+---
+
+## Where to next
+
+- The MCP tools that make this data accessible to agents: [02-mcp-server.md](./02-mcp-server.md).
+- The KB Builder agent that fills the structured columns: [03-kb-builder.md](./03-kb-builder.md).
+- The Investigator agent that reads `failure_history` to recognise patterns: [04-sentinel-investigator.md](./04-sentinel-investigator.md).

--- a/docs/architecture/02-mcp-server.md
+++ b/docs/architecture/02-mcp-server.md
@@ -1,0 +1,186 @@
+# M2 — MCP Server
+
+> [!NOTE]
+> M2 turns the data layer into an LLM-callable tool surface. A FastMCP instance mounted in-process exposes 14 read tools across KPI, signals, human context, KB, and hierarchy domains, plus one write tool (`update_equipment_kb`). The `MCPClient` singleton is the only path agents use to reach data — agents never touch `asyncpg` directly. A second tool family, the local `render_*` schemas, lets agents emit generative-UI artifacts without round-tripping through the database.
+
+---
+
+## Why M2 exists
+
+The product needs five different agents (KB Builder, Sentinel, Investigator, Work Order Generator, Q&A) to read the same data through the same API. Hand-rolling a service layer for each agent would duplicate query logic and split error handling. Instead, M2 declares one tool catalogue, exposed both to the local `MCPClient` (in-process loopback for our own agents) and to external MCP clients such as Claude Desktop or hosted MCP through the public path-secret URL.
+
+The same FastMCP instance also doubles as the integration surface for the hosted Managed Agents path — see [decisions.md](./decisions.md#two-paths-messages-api-vs-managed-agents).
+
+---
+
+## Tool catalogue
+
+```mermaid
+flowchart TB
+    subgraph FastMCP["FastMCP aria-tools 3.2.4"]
+        subgraph KPI["kpi.py — 4 tools"]
+            get_oee
+            get_mtbf
+            get_mttr
+            get_downtime["get_downtime_events"]
+        end
+        subgraph Signals["signals.py — 3 tools"]
+            get_trends["get_signal_trends"]
+            get_anom["get_signal_anomalies"]
+            get_curr["get_current_signals"]
+        end
+        subgraph Context["context.py — 4 tools"]
+            get_log["get_logbook_entries"]
+            get_shift["get_shift_assignments"]
+            get_wos["get_work_orders"]
+            get_wo["get_work_order"]
+        end
+        subgraph KB["kb.py — 3 tools"]
+            get_kb["get_equipment_kb"]
+            upd_kb["update_equipment_kb"]
+            get_fh["get_failure_history"]
+        end
+        subgraph Hier["hierarchy.py — 1 tool"]
+            list_cells
+        end
+    end
+    Repos[("Repositories<br/>asyncpg pool")]
+    KPI --> Repos
+    Signals --> Repos
+    Context --> Repos
+    KB --> Repos
+    Hier --> Repos
+```
+
+The full per-tool contract lives next to each tool decorator in [backend/aria_mcp/tools/](../../backend/aria_mcp/tools/). The most important contracts to know:
+
+- `get_signal_anomalies` — the breach-detection tool. Aggregates consecutive breach samples into structured *breach windows* (one row per contiguous interval) instead of one row per sample. This matters because a single 3-hour query on four signals previously returned 38 000 rows; the windowing fix in [M5.5](../audits/M5.5-end-to-end-test-report.md#4-token-overflow-resolved--context-window-overflow) brought that down to ~28 windows. It is what made hosted MCP economically viable.
+- `get_signal_trends` — bucketed time-series with a hard 500-row cap. When the cap fires the response includes `{"_truncated": true, "hint": "..."}` so the LLM knows it needs to narrow its window.
+- `update_equipment_kb` — the only write tool. Forwards a JSON Merge Patch (RFC 7396 semantics) plus optional `raw_markdown` and `onboarding_complete` fields to `KbRepository.upsert`. All housekeeping (`calibration_log` append, `kb_meta.version` bump, `confidence_score` recompute, `last_enriched_at` touch) happens inside the repository, not in the tool.
+
+> [!IMPORTANT]
+> All read tools take `cell_id: int` (or accept it as a filter). Time windows are ISO 8601 strings with offsets — never naive datetimes. The contract is enforced at the tool boundary so naive timestamps cannot silently produce empty results against TimescaleDB's `timestamptz` columns.
+
+---
+
+## In-process mounting
+
+[backend/main.py](../../backend/main.py) mounts the FastMCP ASGI sub-app at `/mcp/<path-secret>`:
+
+```python
+app.mount(f"/mcp/{settings.aria_mcp_path_secret}", mcp_http_app)
+```
+
+Two transports use the same mount:
+
+1. **Local loopback** — the `MCPClient` singleton calls `http://localhost:8000/mcp/<secret>/` on every tool call. Round-trip is 5-15 ms. This is the path used by Sentinel, Investigator (Messages API), Work Order Generator, Q&A, and KB Builder.
+2. **Public hosted MCP** — Anthropic's hosted Managed Agents harness calls the same mount through the Cloudflare tunnel at `https://aria-backend.vgtray.fr/mcp/<secret>/`. The path secret is the only auth — see [decisions.md](./decisions.md#path-secret-url-as-the-mcp-auth-mechanism).
+
+The lifespan composition in [backend/main.py](../../backend/main.py) wraps `mcp_http_app.lifespan(...)` so FastMCP's startup hooks run before the Sentinel task is created. This ordering is load-bearing — Sentinel's first tick calls `get_signal_anomalies` and would 500 if the FastMCP sub-app were not yet hot.
+
+---
+
+## `MCPClient` — the agent-facing facade
+
+[backend/aria_mcp/client.py](../../backend/aria_mcp/client.py)
+
+```mermaid
+sequenceDiagram
+    participant Agent
+    participant Client as MCPClient
+    participant FastMCP
+    participant Repo as Repository
+    participant DB
+
+    Agent->>Client: call_tool("get_signal_anomalies", {cell_id: 1, ...})
+    Client->>FastMCP: HTTP POST /mcp/<secret>/ (JSON-RPC)
+    FastMCP->>Repo: signals.get_signal_anomalies(...)
+    Repo->>DB: SELECT
+    DB-->>Repo: rows
+    Repo-->>FastMCP: bucketed list[dict]
+    FastMCP-->>Client: {"result": [...]}
+    Client->>Client: unwrap structured_content envelope
+    Client-->>Agent: ToolCallResult(content=..., is_error=False)
+```
+
+Three properties of the client are non-obvious and intentional:
+
+1. **Connection per call.** A persistent FastMCP session would hit a closure bug under asyncio. The client opens, calls, closes on every tool invocation. The 5-15 ms overhead is acceptable.
+2. **Schema caching.** `get_tools_schema()` caches the MCP tool list in memory and converts it to Anthropic's `input_schema` format on first call. The conversion strips `additionalProperties` (which the Messages API tolerates but Managed Agents rejects).
+3. **Envelope unwrapping.** FastMCP wraps `list[dict]` returns as `{"result": [...]}` in `structured_content`. The client recursively unwraps so callers get the native shape and can subscript `breach["signal_def_id"]` directly.
+
+The client returns a `ToolCallResult(content, is_error)`. Agents always check `is_error` rather than relying on exceptions — this matches the Anthropic Messages API tool contract, where tool failures must be surfaced as `tool_result` blocks with `is_error=True` so the model can recover within the same turn.
+
+---
+
+## Generative-UI tools (`render_*`)
+
+[backend/agents/ui_tools.py](../../backend/agents/ui_tools.py)
+
+The `render_*` tools are *not* MCP tools. They are local tool schemas declared on each agent's `tools` array. They never hit a database. Their semantics are:
+
+- The LLM emits a `tool_use` with `name="render_signal_chart"` and structured props.
+- The agent's tool dispatcher matches on the `render_` prefix and broadcasts a `ui_render` frame on both the events bus and the chat WebSocket (when applicable).
+- A literal string `"rendered"` is returned as the `tool_result` so the LLM's loop stays healthy.
+
+The shipped bundle:
+
+| Tool                       | Purpose                                                                                        |
+|----------------------------|------------------------------------------------------------------------------------------------|
+| `render_signal_chart`      | Multi-signal time-series overlay with anomaly markers.                                         |
+| `render_diagnostic_card`   | Investigator's RCA summary card.                                                               |
+| `render_pattern_match`     | "Recurring failure recognised" callout.                                                        |
+| `render_work_order_card`   | Printable Work Order Card.                                                                     |
+| `render_kb_progress`       | Onboarding progress indicator (5 phases).                                                      |
+| `render_equipment_kb_card` | Inline-editable KB card after onboarding.                                                      |
+| `render_alert_banner`      | Sentinel anomaly banner. Emitted directly via `ws_manager.broadcast` — not exposed to any LLM. |
+| `render_bar_chart`         | Generic chart for KPI views.                                                                   |
+
+`render_correlation_matrix` was intentionally dropped during the M2 audit because no MCP tool computes correlations — the LLM would synthesise plausible-looking but made-up numbers, which is fatal in a predictive-maintenance pitch. See [decisions.md](./decisions.md#dropping-render_correlation_matrix).
+
+> [!NOTE]
+> Each agent declares only the `render_*` subset it actually uses. The Investigator gets chart + diagnostic + pattern_match; the WO Generator gets work_order_card; Q&A gets chart + bar_chart. The schemas live in `agents/ui_tools.py` and are concatenated into the agent's `tools` array at startup.
+
+---
+
+## Threshold evaluation as a shared concern
+
+`get_signal_anomalies` does not compute breaches itself. It loads the cell's KB, iterates the recent samples, and delegates each evaluation to [`core.thresholds.evaluate_threshold`](../../backend/core/thresholds.py). The same helper is used by Sentinel.
+
+Two consequences matter:
+
+1. The single-sided / double-sided distinction is invisible to callers. `vibration_mm_s` and `flow_l_min` use different threshold shapes; both report identically through `BreachResult`.
+2. A null bound (no `alert`, no `trip`, no `low_alert`, no `high_alert`) returns `breached=False` automatically. This is what makes the KB Builder's "pre-stub missing entries with `alert: null`" pattern work without any special-case code in Sentinel.
+
+See [04-sentinel-investigator.md](./04-sentinel-investigator.md#threshold-evaluation) for the full breach contract.
+
+---
+
+## Adding a new tool
+
+To add a new MCP tool the standard path is:
+
+1. Add a method to the appropriate repository in `backend/modules/<domain>/repository.py`. SQL lives here.
+2. Add a `@mcp.tool()` function in the matching `backend/aria_mcp/tools/<domain>.py`. The function signature is the LLM contract — its parameters become the tool's `input_schema`, its return type becomes the response shape.
+3. The docstring is shipped to the LLM as the tool description. Write it for an LLM, not a human: be precise about units, time formats, and the difference between "no data" and "error".
+4. Register no enable flag — `from aria_mcp import tools as _tools` in `server.py` triggers all `@mcp.tool()` decorators on import.
+
+For `render_*` tools the path is:
+
+1. Add a schema dict to `backend/agents/ui_tools.py`.
+2. Add it to the relevant `*_RENDER_TOOLS` list (`INVESTIGATOR_RENDER_TOOLS`, `QA_RENDER_TOOLS`, `WORK_ORDER_GEN_RENDER_TOOLS`).
+3. Add a corresponding React component in `frontend/src/artifacts/` registered in the artifact registry.
+
+---
+
+## Audits and references
+
+- [docs/audits/M2-mcp-server-audit.md](../audits/M2-mcp-server-audit.md) — full pre-implementation review with per-tool contracts and the seven gap fixes that landed before coding.
+- [docs/planning/M2-mcp-server/issues.md](../planning/M2-mcp-server/issues.md) — original issue inventory (#8 to #16).
+
+---
+
+## Where to next
+
+- The agents that consume these tools: [03-kb-builder.md](./03-kb-builder.md), [04-sentinel-investigator.md](./04-sentinel-investigator.md), [05-workorder-qa.md](./05-workorder-qa.md).
+- The WebSocket fan-out used by the `render_*` dispatch: [cross-cutting.md](./cross-cutting.md#websocket-contracts).

--- a/docs/architecture/03-kb-builder.md
+++ b/docs/architecture/03-kb-builder.md
@@ -1,0 +1,145 @@
+# M3 — KB Builder Agent
+
+> [!NOTE]
+> The KB Builder is the agent that gets a cell from "no profile" to "Sentinel can watch it". Two entry points: a PDF upload that uses Opus 4.7 vision to extract a structured KB JSON from the manufacturer manual, and a four-question onboarding session that lets the operator calibrate thresholds with their tacit knowledge. A third entry point — `answer_kb_question` — exposes the agent as a callable tool for the Investigator and the Q&A agent to consult during their own runs.
+
+---
+
+## Why M3 exists
+
+ARIA's pitch is "from PDF manual to first prediction in minutes, with no data-science team". The KB Builder is the proof. Without it, every cell would need a human to author a JSON profile by hand — exactly the "months of configuration" pain the product replaces.
+
+The agent is structured around three flows that share the same write path (`update_equipment_kb` MCP tool) and the same Pydantic schema (`EquipmentKB` from M1):
+
+```mermaid
+flowchart LR
+    subgraph Inputs
+        PDF["Manufacturer PDF"]
+        Op["Operator answers<br/>4 calibration questions"]
+        Ask["Investigator / Q&A<br/>diagnostic question"]
+    end
+    subgraph KBBuilder["agents/kb_builder/"]
+        Vision["pdf_extraction.py<br/>Opus 4.7 vision"]
+        Onb["onboarding/<br/>multi-turn Sonnet session"]
+        Q["qa.py<br/>answer_kb_question"]
+    end
+    subgraph Sink
+        UPD["update_equipment_kb<br/>(MCP tool)"]
+        DB[("equipment_kb")]
+    end
+    PDF --> Vision --> UPD --> DB
+    Op --> Onb --> UPD
+    Ask --> Q --> DB
+    Q -- read-only --> DB
+```
+
+---
+
+## Three flows, one write path
+
+### 1. PDF extraction
+
+[backend/agents/kb_builder/pdf_extraction.py](../../backend/agents/kb_builder/pdf_extraction.py)
+
+The endpoint `POST /api/v1/kb/equipment/{cell_id}/upload` accepts a multipart PDF. The flow:
+
+1. Read the PDF, base64-encode the bytes, send a single `messages.create` call to Opus with a `document` content block. Opus processes the PDF natively — no separate text extraction step.
+2. Parse the response with `EquipmentKB.model_validate_json`. On Pydantic failure, retry once with the validation error appended as a system note.
+3. **Pre-stub missing threshold keys.** Before calling `update_equipment_kb`, walk the cell's `process_signal_definition` rows for any `kb_threshold_key` not present in the extracted thresholds, and inject `{alert: null, source: "pending_calibration", confidence: 0.0}`. This satisfies migration 008's integrity guard without forcing Opus to invent thresholds it has no evidence for.
+4. Call `update_equipment_kb` with the merged blob plus `raw_markdown` so the source markdown is persisted for later debugging or operator review.
+5. Stream five `render_kb_progress` frames bracketing the LLM call so the UI shows visible progress through what is otherwise a single 15-40 second `await`.
+
+> [!IMPORTANT]
+> The pre-stub step is what unblocks the demo. Without it, any partial PDF (and Opus routinely misses one of the four P-02 thresholds, especially `flow_l_min` if only the maintenance section is uploaded) crashes the upload with a 500 from the threshold-key guard. With it, a missing threshold simply enters the system as "pending calibration" and Sentinel's evaluator returns `breached=False` for that signal until the operator fills it in. See [02-mcp-server.md](./02-mcp-server.md#threshold-evaluation-as-a-shared-concern).
+
+### 2. Onboarding session
+
+[backend/agents/kb_builder/onboarding/](../../backend/agents/kb_builder/onboarding/)
+
+A four-question multi-turn session calibrated to the demo's most failure-prone signal (vibration). Implemented as an in-memory session store keyed by `session_id` plus a secondary index by `cell_id` (rejects concurrent sessions on the same cell with HTTP 409).
+
+```mermaid
+sequenceDiagram
+    participant UI
+    participant Router as POST /onboarding/start | /message
+    participant Session as in-memory store
+    participant LLM as Sonnet
+    participant Tool as update_equipment_kb
+
+    UI->>Router: POST /onboarding/start (cell_id)
+    Router->>Session: create session
+    Session-->>Router: session_id, Q1
+    Router-->>UI: {session_id, question}
+    loop 4 questions
+        UI->>Router: POST /onboarding/message (answer)
+        Router->>LLM: extract patch from answer
+        LLM-->>Router: JSON patch
+        Router->>Tool: update_equipment_kb(patch)
+        Router-->>UI: next question
+    end
+    Router->>Tool: update_equipment_kb(onboarding_complete=True)
+    Tool-->>Router: full KB after merge
+    Router-->>UI: {done: true, kb}
+```
+
+Each operator answer is converted to a JSON Merge Patch by Sonnet, validated against a narrow `OnboardingPatch` Pydantic model, then forwarded to `update_equipment_kb`. The final question's response also flips `onboarding_complete=True` atomically, so Sentinel starts watching the cell on its next 30-second tick.
+
+> [!IMPORTANT]
+> `onboarding_complete` is the gate Sentinel checks on every tick. Without the atomic flip, a freshly onboarded cell would never enter the watch list. The dual-source pattern (column on `equipment_kb` plus shadow inside `structured_data.kb_meta`) is intentional: the column is authoritative for backend queries, the shadow is for the LLM's convenience when it reads the KB blob.
+
+### 3. `answer_kb_question` — the agent-as-tool path
+
+[backend/agents/kb_builder/qa.py](../../backend/agents/kb_builder/qa.py)
+
+A side-effect-free async function: takes `cell_id` and `question`, reads the KB, asks Sonnet to answer in a structured `{answer, source, confidence}` shape, returns the dict. No DB writes. No WebSocket broadcasts.
+
+The `agent_handoff` / `agent_start` / `agent_end` frames are emitted by the *caller's* tool dispatcher (Investigator's `handoff.handle_ask_kb_builder`), not by this function. This separation means the same handler is reused unchanged whether the caller is the Messages-API Investigator, the Managed-Agents Investigator, or any future agent that needs to consult the KB.
+
+The contract is: never raises. On any failure (KB missing, LLM parse error) the function returns `{"answer": "<degraded message>", "source": null, "confidence": 0.0}` so the calling agent's loop sees a normal `tool_result` and continues.
+
+---
+
+## The threshold-key guard
+
+Migration 008 added `process_signal_definition.kb_threshold_key` and an integrity check enforced at every `KbRepository.upsert`:
+
+```sql
+-- Every signal flagged for monitoring must have a corresponding entry
+-- in equipment_kb.structured_data.thresholds
+SELECT psd.kb_threshold_key
+FROM process_signal_definition psd
+WHERE psd.cell_id = $1 AND psd.kb_threshold_key IS NOT NULL
+```
+
+The check fires inside the repository, not in the MCP tool — so any write path (REST PUT, MCP `update_equipment_kb`, direct repo call) is protected.
+
+The guard is what forces the pre-stub step in PDF extraction (above). Without the pre-stub, the first upload of any cell with a partial extraction crashes. With it, missing thresholds become explicit pending entries.
+
+The same pattern protects the cold-start onboarding case: if an operator runs onboarding on a cell with no PDF first, `/onboarding/start` either rejects with HTTP 409 (preferred for the demo) or applies the same pre-stub helper.
+
+---
+
+## Where the agent files live
+
+| File                                                                                             | Purpose                                                                                        |
+|--------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
+| [backend/agents/kb_builder/__init__.py](../../backend/agents/kb_builder/__init__.py)             | Public surface — exports `extract_from_pdf`, `answer_kb_question`, onboarding service helpers. |
+| [backend/agents/kb_builder/pdf_extraction.py](../../backend/agents/kb_builder/pdf_extraction.py) | Opus 4.7 vision call, response parsing, pre-stub helper, `update_equipment_kb` invocation.     |
+| [backend/agents/kb_builder/qa.py](../../backend/agents/kb_builder/qa.py)                         | `answer_kb_question` — side-effect-free Sonnet Q&A over the KB.                                |
+| [backend/agents/kb_builder/onboarding/](../../backend/agents/kb_builder/onboarding/)             | Session store, four-question script, patch-validation Pydantic model.                          |
+| [backend/modules/kb/router.py](../../backend/modules/kb/router.py)                               | The HTTP surface: `POST /upload`, `POST /onboarding/start`, `POST /onboarding/message`.        |
+
+---
+
+## Audits and references
+
+- [docs/audits/M3-kb-builder-audit.md](../audits/M3-kb-builder-audit.md) — pre- and post-implementation review. Section 7 ("Codebase cross-reference") is the post-implementation diff against the audit's recommendations and is the single best document for understanding why each KB Builder design choice exists.
+- [docs/planning/M3-kb-builder/issues.md](../planning/M3-kb-builder/issues.md) — original issue inventory (#17 to #22).
+
+---
+
+## Where to next
+
+- The Investigator that calls `answer_kb_question` via `ask_kb_builder`: [04-sentinel-investigator.md](./04-sentinel-investigator.md#agent-as-tool-handoffs).
+- The MCP write tool that the KB Builder uses: [02-mcp-server.md](./02-mcp-server.md#tool-catalogue).
+- The Pydantic schema that validates every write: [01-data-layer.md](./01-data-layer.md#equipmentkb--the-structured-kb-profile).

--- a/docs/architecture/04-sentinel-investigator.md
+++ b/docs/architecture/04-sentinel-investigator.md
@@ -1,0 +1,281 @@
+# M4 — Sentinel and Investigator
+
+> [!NOTE]
+> M4 is the critical path of the product. Sentinel is a 30-second loop that opens a work order on threshold breach. Investigator is a free agent loop with extended thinking enabled — it correlates signals, KPIs, logbook entries, shift assignments, and past failures to produce a structured root-cause analysis. Together they take the system from "a knowledge base with charts" to "an agentic predictive-maintenance platform". M4 also ships the WSManager broadcast singleton that every later milestone relies on.
+
+---
+
+## Topology
+
+```mermaid
+flowchart LR
+    subgraph Trigger
+        Tick["30s tick"]
+    end
+    subgraph M4["M4 components"]
+        WSManager["core.ws_manager<br/>WS /api/v1/events<br/>fan-out singleton"]
+        Sentinel["agents.sentinel<br/>detect → open WO → spawn"]
+        Investigator["agents.investigator.service<br/>RCA loop + extended thinking"]
+        Handoff["agents.investigator.handoff<br/>ask_kb_builder dispatch"]
+    end
+    subgraph Side["Side effects"]
+        WO[("work_order")]
+        FH[("failure_history")]
+        WOG["Work Order Generator (M5)"]
+    end
+    subgraph Builder
+        KB["KB Builder<br/>answer_kb_question"]
+    end
+    subgraph UI
+        Front["Frontend<br/>Control Room + Inspector"]
+    end
+
+    Tick --> Sentinel
+    Sentinel --> WSManager
+    Sentinel --> WO
+    Sentinel -- "asyncio.create_task" --> Investigator
+    Investigator --> WSManager
+    Investigator --> WO
+    Investigator --> FH
+    Investigator -- "submit_rca → spawn" --> WOG
+    Investigator -- "ask_kb_builder" --> Handoff
+    Handoff --> KB
+    WSManager --> Front
+```
+
+---
+
+## Sentinel — the detection loop
+
+[backend/agents/sentinel.py](../../backend/agents/sentinel.py)
+
+### Loop structure
+
+- Tick interval: 30 seconds (`_TICK_SECONDS`).
+- Lookback per tick: 5 minutes (`_WINDOW_MINUTES`).
+- Per-cell debounce: 30 minutes (`_DEBOUNCE_MINUTES`) — prevents repeated work orders for the same continuous breach.
+- Outer loop wraps every tick body in `try/except`. A single bad cell or transient DB error logs and returns; the loop keeps going.
+- Started by the FastAPI lifespan in [backend/main.py](../../backend/main.py) **inside** the FastMCP sub-app's lifespan wrapper. This ordering matters because Sentinel's first tick calls `get_signal_anomalies` through the in-process loopback — FastMCP must already be hot.
+
+### Detection contract
+
+Sentinel does *not* read raw thresholds. It calls `get_signal_anomalies` (M2.3) which delegates to `core.thresholds.evaluate_threshold` for every sample. This means:
+
+- Single-sided (`alert`/`trip`) and double-sided (`low_alert`/`high_alert`) shapes are treated identically.
+- `null` bounds (the "pending_calibration" pre-stubs from KB Builder) return `breached=False` automatically — no special case in Sentinel.
+- The `ToolCallResult.is_error` flag is checked. On error the cell is logged and skipped for that tick rather than crashing the loop.
+
+### Cell selection
+
+Only cells where `equipment_kb.onboarding_complete = TRUE` are watched. This is what couples M3 onboarding completion to M4 monitoring start — flipping `onboarding_complete=True` at the end of the four-question session is what brings a freshly onboarded cell into the watch list on the next tick.
+
+A one-time startup log emits the watched / ignored split so the docker logs carry a stable fingerprint without spamming every 30 seconds.
+
+### On breach
+
+1. Insert a new `work_order` row with `status='detected'`, `cell_id`, the breached `signal_def_id`, and a one-line `detection_summary`.
+2. Broadcast `anomaly_detected` on the events bus with `severity` and `direction` (both come from `BreachResult` — no recomputation in Sentinel).
+3. Broadcast `ui_render` for the alert banner (the only consumer of `render_alert_banner`, which is never exposed to an LLM).
+4. Spawn the Investigator: `asyncio.create_task(run_investigator(work_order_id))`. Sentinel does not await — the next tick fires in 30 seconds regardless of how long the Investigator takes.
+
+---
+
+## Investigator — the RCA agent
+
+[backend/agents/investigator/service.py](../../backend/agents/investigator/service.py)
+
+### Anatomy
+
+```mermaid
+flowchart TB
+    Entry["run_investigator(wo_id)"]
+    Wrap["asyncio.wait_for(_run_body, 120s)<br/>+ outer try/except"]
+    Body["_run_investigator_body"]
+    Loop["for _turn in range(MAX_TURNS=12):"]
+    Stream["_llm_call(messages, tools)<br/>thinking={enabled, budget=10000}"]
+    Disp["_dispatch_tool_uses(tool_uses)"]
+    Submit["submit_rca → handoff.spawn_work_order_generator"]
+    End["UPDATE work_order SET status='analyzed'"]
+    Fail["UPDATE work_order SET rca_summary='Investigation timed out' (status stays 'detected')"]
+    Entry --> Wrap --> Body --> Loop
+    Loop --> Stream --> Disp --> Loop
+    Disp --> Submit --> End
+    Wrap -. "timeout/exception" .-> Fail
+```
+
+### Safety nets
+
+The audit flagged "no `max_turns`, no wall-clock timeout, no outer `try/except`" as the single biggest M4 risk. The shipped implementation closes all three:
+
+- `MAX_TURNS = 12`. Empirically enough for a complete RCA loop on the P-02 scenario.
+- `_TIMEOUT_SECONDS = 120.0` — an `asyncio.wait_for` wraps the body. Timeouts are recorded as `rca_summary = "Investigation timed out"` so the operator sees a visible degradation rather than a stuck `status='detected'`.
+- Outer `try/except Exception` catches any agent-loop crash (LLM rate limit, DB glitch, JSON parse error). The work order is updated with a degraded RCA so the pipeline unsticks.
+
+These three nets are the contract every long-running agent in ARIA follows. See [decisions.md](./decisions.md#safety-nets-on-every-agent-loop).
+
+### Extended thinking
+
+`_llm_call` wraps `anthropic.messages.stream(...)` with `thinking={"type": "enabled", "budget_tokens": 10000}` and `max_tokens=16384` (Anthropic requires `max_tokens > thinking.budget_tokens` with at least one block of headroom).
+
+The streamed `thinking_delta` events are re-broadcast as `thinking_delta` frames on the events bus with `{agent: "investigator", content, turn_id}`. The frontend Agent Inspector renders the live reasoning trace.
+
+> [!IMPORTANT]
+> The signed `thinking` block must be preserved verbatim in the next turn's `messages.append({"role": "assistant", "content": ...})`. Dropping or reordering it returns `400 thinking block signature invalid`. The Investigator's loop reconstructs the assistant turn from `final_message.content` (which keeps the signed block intact) — this is the most important single line of code in the file. See [decisions.md](./decisions.md#extended-thinking--signed-block-preservation).
+
+### Tool surface
+
+The Investigator's `tools` array is concatenated at the start of every turn from three sources:
+
+1. The full MCP tool catalogue from `MCPClient.get_tools_schema()` — all 14 read tools.
+2. Local agent-only tools: `SUBMIT_RCA_TOOL`, `ASK_KB_BUILDER_TOOL`.
+3. `INVESTIGATOR_RENDER_TOOLS` — `render_signal_chart`, `render_diagnostic_card`, `render_pattern_match`.
+
+The dispatcher in `_dispatch_tool_uses` routes on the tool name:
+
+- `submit_rca` → write the RCA to the work order, broadcast `rca_ready`, spawn the Work Order Generator.
+- `render_*` → broadcast a `ui_render` frame.
+- `ask_kb_builder` → call `handoff.handle_ask_kb_builder` (see below).
+- Everything else → `mcp_client.call_tool(name, args)`.
+
+### Memory — `failure_history` injection
+
+At the start of every Investigator run, the recent `failure_history` rows for the affected cell are loaded via `get_failure_history` and injected into the system prompt as a "previously seen failure modes for this cell" block. This is what makes the recurring-failure recognition demo work: when the same vibration pattern that caused a bearing failure three months ago shows up again, the Investigator can call it out by name and propose the same fix.
+
+The decision to put memory in the system prompt rather than as a tool call was deliberate — it costs zero turns and zero tool dispatch overhead, and the operator-visible trace ("I noticed this matches failure mode #4 from January") is a strong demo moment.
+
+---
+
+## Agent-as-tool handoffs
+
+[backend/agents/investigator/handoff.py](../../backend/agents/investigator/handoff.py)
+
+When the Investigator emits a `tool_use` for `ask_kb_builder`, the handler:
+
+1. Generates a child `turn_id` (UUID hex).
+2. Broadcasts `agent_handoff` on the events bus with `{from_agent, to_agent, reason, turn_id}` (underscored field names).
+3. Broadcasts `agent_start` for the child agent on the events bus.
+4. Calls `kb_builder.answer_kb_question(cell_id, question)` (synchronous async — the Investigator awaits the result).
+5. Broadcasts `agent_end` on the events bus with the finish reason.
+6. Returns the answer as the `tool_result` for the Investigator's loop.
+
+> [!NOTE]
+> The Q&A agent uses an analogous pattern with `ask_investigator` — see [05-workorder-qa.md](./05-workorder-qa.md#chat-side-handoff-mirroring). The two patterns are intentionally symmetric: parent agent owns the handoff broadcast, child agent's handler is side-effect free.
+
+---
+
+## Threshold evaluation
+
+[backend/core/thresholds.py](../../backend/core/thresholds.py) — `evaluate_threshold(threshold, value) -> BreachResult`
+
+The function unifies the two threshold shapes the KB supports. Precedence (highest severity first):
+
+1. `trip` (single-sided high) — `severity="trip"`, `direction="high"`
+2. `high_alert` (double-sided high) — `severity="alert"`, `direction="high"`
+3. `alert` (single-sided high) — `severity="alert"`, `direction="high"`
+4. `low_alert` (double-sided low) — `severity="alert"`, `direction="low"`
+
+A non-breach returns all-null fields. A null bound is skipped, which is what makes "pending calibration" thresholds invisible to detection until the operator fills them in.
+
+Both Sentinel and the MCP `get_signal_anomalies` tool route through this helper. Anything else that needs to evaluate a threshold (future agents, future REST endpoints) must use the same helper — direct `.alert` reads are forbidden because they silently miss double-sided shapes.
+
+---
+
+## WSManager — the broadcast singleton
+
+[backend/core/ws_manager.py](../../backend/core/ws_manager.py)
+
+A module-level singleton fan-out for `WS /api/v1/events`. Every agent imports `ws_manager` from here.
+
+### Frame shape
+
+```python
+await ws_manager.broadcast("anomaly_detected", {"cell_id": 1, "signal_def_id": 4, ...})
+```
+
+Becomes `{"type": "anomaly_detected", "cell_id": 1, "signal_def_id": 4, "turn_id": "..."}` on every connected socket.
+
+### `current_turn_id` ContextVar
+
+```python
+from core.ws_manager import current_turn_id
+token = current_turn_id.set(uuid.uuid4().hex)
+try:
+    # ... agent loop ...
+finally:
+    current_turn_id.reset(token)
+```
+
+The orchestrator sets a `turn_id` once per agent run. Every `ws_manager.broadcast(...)` call inside that scope automatically picks it up — no agent has to thread the id through every helper. The ContextVar is propagated across `await` boundaries by asyncio.
+
+### Failure semantics
+
+- Sockets that fail (closed, network error) are silently dropped from the registry. The broadcast never raises to the caller.
+- Payloads that fail to JSON-serialise are logged and the broadcast is skipped (the broadcast contract is best-effort, not transactional).
+- The single `broadcast` is fanned out sequentially. With one operator on the demo this is fine; multi-tenant production would need Redis pub/sub.
+
+The full event vocabulary lives in [cross-cutting.md](./cross-cutting.md#websocket-contracts).
+
+---
+
+## The full anomaly-to-RCA sequence
+
+```mermaid
+sequenceDiagram
+    participant Loop as Sentinel loop
+    participant MCP as get_signal_anomalies
+    participant WS as ws_manager
+    participant DB as work_order
+    participant Inv as run_investigator
+    participant LLM as Opus + thinking
+    participant KB as ask_kb_builder
+    participant WOG as Work Order Generator
+
+    Loop->>MCP: get_signal_anomalies(cell_id, last 5 min)
+    MCP-->>Loop: [BreachResult]
+    Loop->>DB: INSERT work_order (status=detected)
+    Loop->>WS: broadcast(anomaly_detected, {severity, direction, ...})
+    Loop->>WS: broadcast(ui_render, alert_banner)
+    Loop->>Inv: asyncio.create_task(run_investigator(wo_id))
+    Loop-->>Loop: continue (does not await)
+
+    Inv->>WS: broadcast(agent_start, {agent: investigator, turn_id})
+    loop up to 12 turns
+        Inv->>LLM: messages.stream(thinking enabled)
+        LLM-->>Inv: thinking_delta * N + tool_use blocks
+        loop per tool_use
+            Inv->>WS: broadcast(thinking_delta, {chunk})
+            Inv->>MCP: call_tool(name, args)
+            MCP-->>Inv: tool_result
+        end
+        opt ask_kb_builder
+            Inv->>WS: broadcast(agent_handoff)
+            Inv->>WS: broadcast(agent_start, {agent: kb_builder, turn_id})
+            Inv->>KB: answer_kb_question(cell_id, question)
+            KB-->>Inv: {answer, source, confidence}
+            Inv->>WS: broadcast(agent_end, {agent: kb_builder})
+        end
+        opt submit_rca
+            Inv->>DB: UPDATE work_order SET status=analyzed, rca_summary
+            Inv->>WS: broadcast(rca_ready, {wo_id, summary, confidence})
+            Inv->>WOG: asyncio.create_task(run_work_order_generator(wo_id))
+        end
+    end
+    Inv->>WS: broadcast(agent_end, {agent: investigator, finish_reason})
+```
+
+---
+
+## Audits and references
+
+- [docs/audits/M4-M5-sentinel-investigator-workorder-qa-audit.md](../audits/M4-M5-sentinel-investigator-workorder-qa-audit.md) — full pre-implementation review. Section 4 ("Missing guard-rails") is the source of the safety-net contract that every long-running agent now follows.
+- [docs/audits/M4-M5-issue-context-pass.md](../audits/M4-M5-issue-context-pass.md) — issue-context cross-pass, including the `ask_kb_builder` handler shape.
+- [docs/planning/M4-sentinel-investigator/issues.md](../planning/M4-sentinel-investigator/issues.md) — original issue inventory (#23 to #29).
+
+---
+
+## Where to next
+
+- The Work Order Generator that the Investigator spawns: [05-workorder-qa.md](./05-workorder-qa.md#work-order-generator).
+- The Q&A agent that calls back into the Investigator via `ask_investigator`: [05-workorder-qa.md](./05-workorder-qa.md#qa-operator-chat).
+- The Managed Agents migration of the Investigator: [05-workorder-qa.md](./05-workorder-qa.md#managed-agents-migration-m55) and [decisions.md](./decisions.md#two-paths-messages-api-vs-managed-agents).
+- The full WebSocket frame catalogue: [cross-cutting.md](./cross-cutting.md#websocket-contracts).

--- a/docs/architecture/05-workorder-qa.md
+++ b/docs/architecture/05-workorder-qa.md
@@ -1,0 +1,281 @@
+# M5 — Work Order Generator and Q&A
+
+> [!NOTE]
+> M5 closes the loop. The Work Order Generator turns the Investigator's RCA into a printable, structured work order with recommended actions and parts. The Q&A agent gives the operator a natural-language interface to the entire system through a streaming WebSocket. M5 also contains the Managed Agents migration of the Investigator (M5.5), which moves the long-running RCA loop onto Anthropic's hosted infrastructure while keeping interactive Q&A on the Messages API where token-granular streaming is native.
+
+---
+
+## Two agents, one transport pattern
+
+```mermaid
+flowchart LR
+    subgraph Trigger
+        Inv["Investigator submit_rca"]
+        UI["Operator chat input"]
+    end
+    subgraph M5
+        WOG["agents.work_order_generator<br/>RCA → structured WO"]
+        QA["agents.qa<br/>WS chat agent"]
+    end
+    subgraph Sinks
+        WO[("work_order<br/>recommended_actions, required_parts")]
+        Chat["WS /api/v1/agent/chat<br/>frame-by-frame to client"]
+        Bus["WS /api/v1/events<br/>broadcast to Control Room"]
+    end
+    Inv --> WOG --> WO
+    WOG --> Bus
+    UI --> QA --> Chat
+    QA --> Bus
+    QA -- "ask_investigator" --> Inv
+```
+
+---
+
+## Work Order Generator
+
+[backend/agents/work_order_generator/service.py](../../backend/agents/work_order_generator/service.py)
+
+A short agent loop spawned by the Investigator immediately after `submit_rca` succeeds. The contract is "RCA in, structured work order out, in 1-2 turns".
+
+### Loop bounds
+
+- `MAX_TURNS = 6` — the loop typically terminates in 2 turns (`get_equipment_kb` then `submit_work_order`).
+- `_TIMEOUT_SECONDS = 60.0` — half the Investigator's budget, because the loop is much shorter.
+- Same outer `try/except` + `asyncio.wait_for` pattern as the Investigator. On timeout or crash, the work order stays at `status='analyzed'` with its existing `rca_summary` intact, and `work_order_ready` is *not* broadcast — the frontend keeps showing the RCA-only state and the operator can hit "Regenerate" to retry.
+
+### Tool surface
+
+- All 14 MCP read tools (the generator may need to look up KPIs or signal context).
+- One local tool: `SUBMIT_WORK_ORDER_TOOL` — the only tool that writes.
+- `WORK_ORDER_GEN_RENDER_TOOLS` — `render_work_order_card` for the printable card.
+
+### `submit_work_order` shape
+
+The tool input mirrors the `WorkOrderUpdate` Pydantic schema verbatim:
+
+```
+{
+  work_order_id: int,
+  recommended_actions: [{action, priority, est_duration_min}],
+  required_parts: [{ref, qty, description?}],
+  suggested_window_start: ISO8601,
+  suggested_window_end: ISO8601,
+  printable_summary: str
+}
+```
+
+> [!IMPORTANT]
+> The field name is `required_parts`, not `parts_required`. The audit caught this drift in the original issue body before any code shipped — the database column, the Pydantic field, and the tool schema all match. See [decisions.md](./decisions.md#contract-discipline-frontend-types-are-the-source-of-truth).
+
+Extended thinking is *not* enabled here. The generator's job is structured output, not multi-step reasoning — Sonnet at standard mode is the right tool.
+
+### Broadcast contract
+
+On successful `submit_work_order`:
+
+1. `UPDATE work_order SET status='open', recommended_actions=..., required_parts=..., ...`
+2. Broadcast `work_order_ready` on the events bus with `{work_order_id}`.
+3. Broadcast `ui_render` for `render_work_order_card` with the printable summary as props.
+4. The frontend's artifact registry maps `render_work_order_card` to the printable React component, which is what closes the demo's "Scene 4: print this work order".
+
+---
+
+## Q&A — operator chat
+
+The Q&A agent powers `WS /api/v1/agent/chat`. The router and the agent are deliberately split:
+
+| File                                                                               | Concern                                                                                                                                                       |
+|------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| [backend/modules/chat/router.py](../../backend/modules/chat/router.py)             | Authenticate the WebSocket handshake (cookie JWT). Hold per-connection `messages: list` state. Forward each `{type: "user", content}` frame to `run_qa_turn`. |
+| [backend/agents/qa/messages_api.py](../../backend/agents/qa/messages_api.py)       | The Messages-API agent loop. Streams `text_delta`, `tool_call`, `tool_result`, `ui_render`, `agent_handoff`, `done` frames per turn.                          |
+| [backend/agents/qa/tool_dispatch.py](../../backend/agents/qa/tool_dispatch.py)     | Shared tool handlers: `handle_render`, `handle_ask_investigator`, `summarise_tool_result`, `safe_send`.                                                       |
+| [backend/agents/qa/investigator_qa.py](../../backend/agents/qa/investigator_qa.py) | `answer_investigator_question` — the deterministic fast-path used by `ask_investigator`.                                                                      |
+| [backend/agents/qa/prompts.py](../../backend/agents/qa/prompts.py)                 | `QA_SYSTEM` and `INVESTIGATOR_QA_SYSTEM` system prompts.                                                                                                      |
+| [backend/agents/qa/schemas.py](../../backend/agents/qa/schemas.py)                 | `ASK_INVESTIGATOR_TOOL` local tool schema.                                                                                                                    |
+
+### The chat WebSocket contract
+
+The `ChatMap` in [frontend/src/lib/ws.types.ts](../../frontend/src/lib/ws.types.ts) is the source of truth. Frames the backend emits:
+
+- `text_delta` — token-by-token streamed text (the value Q&A on Messages API delivers that Managed Agents cannot).
+- `tool_call` — the agent invoked a tool. Frontend renders an inline collapsable card.
+- `tool_result` — short summary string (raw JSON is forbidden on the chat channel; it lives in per-turn server state for debugging).
+- `ui_render` — a generative-UI artifact dispatched into the chat stream.
+- `agent_start` — the speaker for this turn (or sub-turn). Frontend uses this to flip the badge.
+- `agent_handoff` — `{from, to, reason}` (unprefixed names; the events-bus mirror uses `from_agent`/`to_agent`).
+- `done` — the turn is complete. Optional `error` field on degraded paths.
+
+### One turn end-to-end
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Router as chat/router.py
+    participant Loop as run_qa_turn
+    participant Stream as anthropic.messages.stream
+    participant Disp as _dispatch_tool_uses
+    participant MCP
+
+    Client->>Router: {type: user, content}
+    Router->>Router: append to messages[]
+    Router->>Bus: broadcast(agent_start, agent=qa)
+    Router->>Client: send_json(agent_start, agent=qa)
+    Router->>Loop: run_qa_turn(ws, messages, content)
+    loop up to 8 turns
+        Loop->>Stream: messages.stream(tools, system)
+        loop streamed events
+            Stream-->>Loop: text_delta
+            Loop->>Client: send_json(text_delta, content)
+        end
+        Stream-->>Loop: final_message (tool_use blocks)
+        opt tool_uses present
+            Loop->>Disp: dispatch each
+            Disp->>Bus: broadcast(tool_call_started)
+            Disp->>Client: send_json(tool_call)
+            alt render_*
+                Disp->>Bus: broadcast(ui_render)
+                Disp->>Client: send_json(ui_render)
+            else ask_investigator
+                Disp->>Disp: handle_ask_investigator
+            else mcp tool
+                Disp->>MCP: call_tool
+                MCP-->>Disp: result
+            end
+            Disp->>Client: send_json(tool_result, summary)
+        end
+    end
+    Loop->>Bus: broadcast(agent_end, finish_reason)
+    Loop->>Client: send_json(done)
+```
+
+### Chat-side handoff mirroring
+
+The `ask_investigator` handler is the chat-equivalent of the Investigator's `ask_kb_builder` handler:
+
+1. Broadcast `agent_handoff` on the events bus with underscored field names.
+2. Send `agent_handoff` on the chat socket with unprefixed field names.
+3. Generate a child `turn_id`, broadcast `agent_start` for `"investigator"` on **both** channels (events bus and chat socket — the chat-side mirror was added in issue #125 to unblock the M8.5 Agent Inspector's `turn_id` correlation).
+4. Call `answer_investigator_question(cell_id, question)` — a deterministic single Sonnet call against recent work orders and past failures for the cell.
+5. Broadcast `agent_end` on both channels with the matching `turn_id`.
+6. Return the JSON answer as the `tool_result` for the Q&A loop.
+
+> [!NOTE]
+> The Q&A's `ask_investigator` does not run the full Managed-Agents Investigator loop. It uses the lightweight `answer_investigator_question` fast-path so chat latency stays sub-second. A future "Continue investigation" feature would re-open the Investigator's persisted Anthropic session — see [decisions.md](./decisions.md#two-paths-messages-api-vs-managed-agents).
+
+### Per-connection state
+
+The chat router holds `messages: list[dict]` per WebSocket. The list is appended by `run_qa_turn` on every user message and tool result, so multi-turn context is preserved for the lifetime of the socket. When the operator closes the tab, the state is discarded. There is no server-side persistence — this is an interactive chat, not a long-running session.
+
+This is the architectural reason Q&A stayed on the Messages API and did not migrate to Managed Agents — see the next section.
+
+---
+
+## Managed Agents migration (M5.5)
+
+> [!IMPORTANT]
+> M5.4 originally migrated Q&A to Managed Agents to qualify for the "Best Use of Managed Agents" prize. The M5 audit (`docs/audits/M5-managed-agents-refactor-audit.md`) concluded that Q&A is the wrong target — interactive sub-second turns fight the platform's `agent.message`-block grain. The Investigator is the right target: long-running, tool-heavy, asynchronous. M5.5 implements that pivot.
+
+### What changed
+
+| Layer                       | Before (M5.4 / M4.5)                                            | After (M5.5)                                                                          |
+|-----------------------------|-----------------------------------------------------------------|---------------------------------------------------------------------------------------|
+| Q&A backend                 | Managed Agents path (414 LOC) gated behind feature flag         | Removed. Q&A is Messages-API only.                                                    |
+| Investigator backend        | Messages-API loop only (`agents.investigator.service`)          | Dual path: Messages API kept as fallback, Managed Agents primary.                     |
+| MCP tool execution          | All 14 tools dispatched in our backend per call                 | Hosted MCP — Anthropic calls our `/mcp/<secret>/` URL directly via Cloudflare tunnel. |
+| Custom tools in our backend | Every MCP tool wrapped + render_* + submit_rca + ask_kb_builder | Only render_* + submit_rca + ask_kb_builder.                                          |
+| Session persistence         | Dies with the WebSocket                                         | `work_order.investigator_session_id` (migration 009) persists Anthropic session id.   |
+| Streaming `thinking_delta`  | Per-chunk via `_llm_call`                                       | Block-level via `agent.thinking` events (one frame per reasoning block).              |
+
+### Module layout
+
+[backend/agents/investigator/managed/](../../backend/agents/investigator/managed/)
+
+```
+managed/
+├── __init__.py        # Public surface: run_investigator_managed
+├── bootstrap.py       # environments.create + agents.create + sessions.create
+├── events.py          # SSE consumer for sessions.events.stream
+├── tool_dispatch.py   # custom-tool result dispatcher
+└── service.py         # Public entry: run_investigator_managed(work_order_id)
+```
+
+The split mirrors the four concerns of a Managed-Agents integration:
+
+1. **bootstrap** — declarative agent + environment + session lifecycle.
+2. **events** — consume the SSE stream, route each event type to its handler.
+3. **tool_dispatch** — when the platform emits `requires_action`, send back `user.custom_tool_result` for our 3 custom tools (skip MCP-tool ids — those are Anthropic-side).
+4. **service** — public async function with the same signature as the Messages-API entry point.
+
+The legacy `agents.investigator.service.run_investigator` remains, gated behind `INVESTIGATOR_USE_MANAGED=False` in the config. Flipping the flag is a 5-minute rollback if the hosted path misbehaves on demo day.
+
+### Hosted MCP wiring
+
+Two pieces of infrastructure make hosted MCP work:
+
+1. **Cloudflare tunnel.** `aria-cloudflared` (compose profile `tunnel`) exposes `aria-backend.vgtray.fr` → `backend:8000`. The MCP mount is reachable as `https://aria-backend.vgtray.fr/mcp/<secret>/`.
+2. **Path-secret URL.** The `/mcp` mount lives at `/mcp/<settings.aria_mcp_path_secret>` rather than `/mcp`. The URL is the secret. The Managed Agents `mcp_servers` config does not support custom HTTP headers, and the OAuth+vaults path is too heavy for a hackathon — the path secret is the pragmatic compromise. See [decisions.md](./decisions.md#path-secret-url-as-the-mcp-auth-mechanism).
+
+The agent definition references the public URL via `mcp_servers=[{"type": "url", "name": "aria", "url": ARIA_MCP_PUBLIC_URL}]`, plus a `{"type": "mcp_toolset", "mcp_server_name": "aria"}` entry in the `tools` array (without it the platform returns `400 mcp_servers declared but no mcp_toolset references them`).
+
+### Token-budget fixes
+
+The first end-to-end run of the Managed Investigator overflowed the 200k context window in a single tool call: `get_signal_trends` on a 3-hour, 4-signal, 1-minute query returned 2.3 MB / ~575k tokens. Two fixes shipped in [backend/aria_mcp/tools/signals.py](../../backend/aria_mcp/tools/signals.py):
+
+- `get_signal_anomalies` now aggregates consecutive breach samples into structured *breach windows*. The same query now returns 28 windows / ~2 400 tokens — a 240x reduction.
+- `get_signal_trends` enforces a hard 500-row cap and appends `{"_truncated": true, "hint": "use 5m/15m aggregation or shorter window"}` when hit.
+
+These changes apply to both the Messages-API path and the hosted-MCP path, but they were forced by the hosted path because Managed Agents' built-in compaction works on conversation history, not on individual oversized tool responses.
+
+### Custom tool quirks
+
+- The Managed Agents API rejects `additionalProperties` in custom tool input schemas (the Messages API tolerates it). `bootstrap.py::_strip_additional_properties` walks the schema recursively and removes the field.
+- Hosted MCP tool ids appear in `requires_action.event_ids` but are *not* custom-tool events. Sending a `user.custom_tool_result` for them returns `400 tool_use_id sevt_... does not match any custom_tool_use event in this session`. The dispatcher silently skips them.
+- The default `mcp_toolset.permission_policy` is `always_ask`, which pauses the agent waiting for a human approval that never arrives. The bootstrap sets `default_config.permission_policy = always_allow` so the agent runs autonomously.
+
+### What was kept on the Messages API
+
+- The Q&A agent. Token-granular streaming is what `text_delta` requires; Managed Agents emits `agent.message` blocks that would have to be re-chunked artificially.
+- The Investigator fallback path. Set `INVESTIGATOR_USE_MANAGED=False` to revert in <5 min.
+
+### Verification
+
+The full M5.5 end-to-end test report lives at [docs/audits/M5.5-end-to-end-test-report.md](../audits/M5.5-end-to-end-test-report.md). Key result: a Sentinel-triggered investigation against P-02 with the dead-head pressure scenario produces:
+
+- `work_order.status = 'analyzed'`
+- `work_order.investigator_session_id = 'sesn_011CaMUPAWcCBfc1oMyMFZG3'`
+- `failure_history` row with `failure_mode = 'discharge_blockage'` and a populated `root_cause`
+
+All three of which are persisted across the migration without contract change.
+
+---
+
+## File map
+
+| File                                                                                                   | Purpose                                                                             |
+|--------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|
+| [backend/agents/work_order_generator/service.py](../../backend/agents/work_order_generator/service.py) | RCA → structured work order. 336 lines.                                             |
+| [backend/agents/work_order_generator/prompts.py](../../backend/agents/work_order_generator/prompts.py) | `WO_GEN_SYSTEM` system prompt.                                                      |
+| [backend/agents/work_order_generator/schemas.py](../../backend/agents/work_order_generator/schemas.py) | `SUBMIT_WORK_ORDER_TOOL` schema mirroring `WorkOrderUpdate`.                        |
+| [backend/agents/qa/messages_api.py](../../backend/agents/qa/messages_api.py)                           | `run_qa_turn` — the streaming agent loop. 198 lines.                                |
+| [backend/agents/qa/tool_dispatch.py](../../backend/agents/qa/tool_dispatch.py)                         | Tool routing (`handle_render`, `handle_ask_investigator`, `summarise_tool_result`). |
+| [backend/agents/qa/investigator_qa.py](../../backend/agents/qa/investigator_qa.py)                     | `answer_investigator_question` — deterministic fast-path for `ask_investigator`.    |
+| [backend/agents/investigator/managed/](../../backend/agents/investigator/managed/)                     | Managed Agents migration. 575 lines across 5 files.                                 |
+| [backend/modules/chat/router.py](../../backend/modules/chat/router.py)                                 | `WS /api/v1/agent/chat` — auth, per-connection state, hand-off to `run_qa_turn`.    |
+
+---
+
+## Audits and references
+
+- [docs/audits/M4-M5-sentinel-investigator-workorder-qa-audit.md](../audits/M4-M5-sentinel-investigator-workorder-qa-audit.md) — pre-implementation review of M5.1 (WO Generator) and M5.2 (Q&A WebSocket).
+- [docs/audits/M5-managed-agents-refactor-audit.md](../audits/M5-managed-agents-refactor-audit.md) — the audit that drove the M5.5 pivot from Q&A-on-Managed-Agents to Investigator-on-Managed-Agents. Section 6.5 sketches the two differentiation add-ons (Continue Investigation, in-sandbox Python diagnostics) that the platform uniquely enables.
+- [docs/audits/M5.5-end-to-end-test-report.md](../audits/M5.5-end-to-end-test-report.md) — full live-test report with the seven cascade fixes that landed during the migration.
+- [docs/planning/M5-workorder-qa/issues.md](../planning/M5-workorder-qa/issues.md) — original issue inventory (#30 to #33).
+- [docs/planning/M5-workorder-qa/managed-agents-refactor-issues.md](../planning/M5-workorder-qa/managed-agents-refactor-issues.md) — M5.5 refactor issue plan.
+
+---
+
+## Where to next
+
+- The Investigator that the Work Order Generator chains from and that Q&A consults: [04-sentinel-investigator.md](./04-sentinel-investigator.md).
+- The full WebSocket frame catalogue (chat and bus): [cross-cutting.md](./cross-cutting.md#websocket-contracts).
+- The decision log for "why Managed Agents on Investigator only": [decisions.md](./decisions.md#two-paths-messages-api-vs-managed-agents).

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,164 @@
+# ARIA Backend Architecture
+
+> [!NOTE]
+> Technical architecture documentation for the ARIA backend, covering Milestones M1 through M5 (data layer, MCP server, agents). The frontend is documented separately under [frontend/docs/](../../frontend/docs/).
+
+This documentation is structured to serve two audiences in a single pass:
+
+- **Overview readers** — the executive summary and the top diagram of each milestone document explain *what* ARIA does and *how* the pieces fit together. Reading this `README.md` plus the executive summary of each milestone doc is enough to understand the system end to end.
+- **Deep-dive readers** — every section links down to concrete file paths, line ranges, and contracts. Engineers extending an agent, debugging a tool, or porting the architecture will find file references, schemas, and sequence diagrams sufficient to work without re-reading the source from scratch.
+
+---
+
+## Reading paths
+
+| If you want to                                         | Read                                                         |
+|--------------------------------------------------------|--------------------------------------------------------------|
+| Understand the product end to end                      | This file, then [decisions.md](./decisions.md)               |
+| Understand the data model                              | [01-data-layer.md](./01-data-layer.md)                       |
+| Understand how agents access data                      | [02-mcp-server.md](./02-mcp-server.md)                       |
+| Understand the onboarding flow (PDF → calibrated KB)   | [03-kb-builder.md](./03-kb-builder.md)                       |
+| Understand anomaly detection and root-cause analysis   | [04-sentinel-investigator.md](./04-sentinel-investigator.md) |
+| Understand the work order pipeline and operator chat   | [05-workorder-qa.md](./05-workorder-qa.md)                   |
+| Understand the WebSocket bus, auth, and shared helpers | [cross-cutting.md](./cross-cutting.md)                       |
+| Understand why a non-obvious choice was made           | [decisions.md](./decisions.md)                               |
+
+---
+
+## What ARIA is
+
+ARIA is an agentic predictive-maintenance platform for industrial operators. A multi-agent backend consumes time-series signals plus a structured equipment knowledge base (KB), detects anomalies in real time, runs root-cause analysis with extended thinking on Opus 4.7, generates printable work orders, and answers operator questions in natural language. Generative-UI artifacts (charts, diagnostic cards, work orders) are streamed directly into the operator's chat as the agents work.
+
+The product premise is that 95 percent of industrial sites cannot afford the months of data-science work that traditional predictive maintenance configuration requires. ARIA collapses that into minutes by reading the manufacturer's PDF manual with Opus 4.7 vision, calibrating thresholds with the floor operator through a short dialogue, and then watching the equipment continuously.
+
+The full product framing lives in [docs/ARIA_PRD.md](../ARIA_PRD.md). The backend documented here implements the agent topology, the data layer, and the MCP tool surface that makes that promise possible.
+
+---
+
+## System overview
+
+```mermaid
+flowchart LR
+    subgraph M1["M1 — Data Layer"]
+        DB[("TimescaleDB<br/>equipment_kb / work_order /<br/>failure_history / process_signal_data")]
+    end
+    subgraph M2["M2 — MCP Server"]
+        FastMCP["FastMCP aria-tools<br/>14 read tools + 1 write tool"]
+        MCPClient["MCPClient singleton<br/>(in-process loopback)"]
+    end
+    subgraph Agents["M3-M5 — Agents"]
+        Builder["KB Builder<br/>PDF → KB + onboarding"]
+        Sentinel["Sentinel<br/>30 s detection loop"]
+        Investigator["Investigator<br/>RCA + extended thinking"]
+        WOGen["Work Order Generator"]
+        QA["Q&A<br/>operator chat"]
+    end
+    subgraph Bus["Cross-cutting"]
+        WSManager["WSManager<br/>WS /api/v1/events"]
+        Chat["WS /api/v1/agent/chat"]
+    end
+    Frontend[("Operator browser")]
+
+    DB --> FastMCP
+    FastMCP --> MCPClient
+    MCPClient --> Sentinel
+    MCPClient --> Investigator
+    MCPClient --> WOGen
+    MCPClient --> QA
+    MCPClient --> Builder
+
+    Sentinel -- "anomaly_detected" --> Investigator
+    Investigator -- "submit_rca" --> WOGen
+    Investigator -- "ask_kb_builder" --> Builder
+    QA -- "ask_investigator" --> Investigator
+
+    Sentinel --> WSManager
+    Investigator --> WSManager
+    WOGen --> WSManager
+    QA --> Chat
+    WSManager --> Frontend
+    Chat --> Frontend
+```
+
+---
+
+## Component map
+
+| Layer          | Module                                                                                           | Owner milestone | Purpose                                                                                                                  |
+|----------------|--------------------------------------------------------------------------------------------------|-----------------|--------------------------------------------------------------------------------------------------------------------------|
+| Data           | [backend/modules/](../../backend/modules/)                                                       | M1              | Domain repositories, Pydantic schemas, FastAPI routers per bounded context (kb, work_order, signal, kpi, logbook, etc.). |
+| Data           | [backend/infrastructure/database/migrations/](../../backend/infrastructure/database/migrations/) | M1              | SQL migrations 001-009. The `equipment_kb` / `work_order` / `failure_history` extensions live in 007-009.                |
+| Tools          | [backend/aria_mcp/server.py](../../backend/aria_mcp/server.py)                                   | M2              | `FastMCP("aria-tools")` instance, mounted at `/mcp/<path-secret>` from `main.py`.                                        |
+| Tools          | [backend/aria_mcp/tools/](../../backend/aria_mcp/tools/)                                         | M2              | The 14 data tools split by surface: `kpi`, `signals`, `context`, `kb`, `hierarchy`.                                      |
+| Tools          | [backend/aria_mcp/client.py](../../backend/aria_mcp/client.py)                                   | M2              | `MCPClient` singleton — every agent's only path to data tools.                                                           |
+| Agents         | [backend/agents/anthropic_client.py](../../backend/agents/anthropic_client.py)                   | M3              | Shared `AsyncAnthropic` wrapper, model selection, JSON-response helper.                                                  |
+| Agents         | [backend/agents/kb_builder/](../../backend/agents/kb_builder/)                                   | M3              | PDF vision extraction, onboarding session, `answer_kb_question` handler.                                                 |
+| Agents         | [backend/agents/sentinel.py](../../backend/agents/sentinel.py)                                   | M4              | 30-second detection loop, work-order opening, anomaly broadcast.                                                         |
+| Agents         | [backend/agents/investigator/](../../backend/agents/investigator/)                               | M4              | RCA agent loop with extended thinking; Messages-API path and Managed-Agents path.                                        |
+| Agents         | [backend/agents/work_order_generator/](../../backend/agents/work_order_generator/)               | M5              | RCA → structured work order + recommended actions + parts list.                                                          |
+| Agents         | [backend/agents/qa/](../../backend/agents/qa/)                                                   | M5              | Operator chat agent. WebSocket-driven, with `ask_investigator` agent-as-tool handoff.                                    |
+| Agents         | [backend/agents/ui_tools.py](../../backend/agents/ui_tools.py)                                   | M2/M4           | Generative-UI tool schemas (`render_*`) shared across agents.                                                            |
+| Cross-cutting  | [backend/core/ws_manager.py](../../backend/core/ws_manager.py)                                   | M4              | WebSocket fan-out singleton; `current_turn_id` ContextVar.                                                               |
+| Cross-cutting  | [backend/core/thresholds.py](../../backend/core/thresholds.py)                                   | M2/M4           | Single source of truth for breach evaluation (single-sided vs double-sided).                                             |
+| Cross-cutting  | [backend/core/security/](../../backend/core/security/)                                           | M5              | Cookie-based JWT auth shared by REST routers and WebSockets.                                                             |
+| Chat transport | [backend/modules/chat/router.py](../../backend/modules/chat/router.py)                           | M5              | `WS /api/v1/agent/chat` — operator chat WebSocket.                                                                       |
+| Bus transport  | [backend/modules/events/router.py](../../backend/modules/events/router.py)                       | M4              | `WS /api/v1/events` — global telemetry bus.                                                                              |
+
+---
+
+## Two transports, one event vocabulary
+
+The backend exposes two WebSockets to the frontend, with overlapping but distinct semantics:
+
+| WebSocket               | Source                                                         | Audience                       | Frame contract                                  |
+|-------------------------|----------------------------------------------------------------|--------------------------------|-------------------------------------------------|
+| `WS /api/v1/events`     | `ws_manager.broadcast(...)` from any agent or router           | Control Room and Inspector UIs | `EventBusMap` in `frontend/src/lib/ws.types.ts` |
+| `WS /api/v1/agent/chat` | `ws.send_json(...)` from the chat router and Q&A tool dispatch | Chat panel only                | `ChatMap` in `frontend/src/lib/ws.types.ts`     |
+
+The two contracts are deliberately distinct. The bus is broadcast and uses underscored field names (`from_agent`, `to_agent`); the chat socket is per-connection and uses unprefixed names (`from`, `to`). When an agent action concerns both audiences (for example `agent_handoff`), the source emits both frames with the per-channel field naming. The `tool_dispatch` modules of each agent encapsulate this dual emission.
+
+See [cross-cutting.md](./cross-cutting.md#websocket-contracts) for the full frame catalogue.
+
+---
+
+## Milestone delivery in one diagram
+
+```mermaid
+flowchart LR
+    M1["M1<br/>Data Layer<br/>migrations 007-008<br/>+ Pydantic schemas"]
+    M2["M2<br/>FastMCP + MCPClient<br/>14 tools + render_* schemas"]
+    M3["M3<br/>KB Builder agent<br/>PDF vision + onboarding"]
+    M4["M4<br/>Sentinel + Investigator<br/>WSManager + thinking + handoffs"]
+    M5["M5<br/>WO Generator + Q&A<br/>Managed Agents migration"]
+
+    M1 --> M2
+    M2 --> M3
+    M2 --> M4
+    M3 --> M4
+    M4 --> M5
+
+    classDef done fill:#0d3a1a,stroke:#2ea043,color:#fff
+    class M1,M2,M3,M4,M5 done
+```
+
+Each milestone is fully shipped on `main`. The roadmap and the original issue inventory live in [docs/planning/ROADMAP.md](../planning/ROADMAP.md). Per-issue audits performed before and after implementation live in [docs/audits/](../audits/) — they are excellent secondary reading for anyone investigating *why* a particular contract has the shape it does.
+
+---
+
+## Conventions
+
+> [!IMPORTANT]
+> The backend follows three non-negotiable conventions that cut across every milestone document. New code that violates them will be rejected at review.
+
+1. **Repositories own SQL. Routers own HTTP. Tools own LLM-facing contracts.** The agent layer never touches `asyncpg` directly — it goes through `MCPClient`, which goes through FastMCP, which goes through repositories.
+2. **The frontend `EventBusMap` and `ChatMap` are the WebSocket contracts.** Backend payloads conform to those types verbatim. Field-name drift between the two is intentional and documented in [cross-cutting.md](./cross-cutting.md#websocket-contracts).
+3. **Every long-running agent body is wrapped in `asyncio.wait_for(..., timeout=...)` and an outer `try/except`.** A hung tool call must not leave a work order stuck in `status='detected'` or a chat turn stuck without a `done` frame. See [decisions.md](./decisions.md#safety-nets-on-every-agent-loop).
+
+---
+
+## Where to go next
+
+- New to the project: read [01-data-layer.md](./01-data-layer.md) → [02-mcp-server.md](./02-mcp-server.md) → [04-sentinel-investigator.md](./04-sentinel-investigator.md). That is the minimal trace of "anomaly to RCA".
+- Frontend integrator: read [cross-cutting.md](./cross-cutting.md#websocket-contracts) and the per-agent doc for any agent you render.
+- Adding a new MCP tool: read [02-mcp-server.md](./02-mcp-server.md#adding-a-new-tool).
+- Adding a new agent: read [04-sentinel-investigator.md](./04-sentinel-investigator.md#agent-loop-template) for the canonical loop pattern, then [decisions.md](./decisions.md#two-paths-messages-api-vs-managed-agents) for which execution path to pick.

--- a/docs/architecture/cross-cutting.md
+++ b/docs/architecture/cross-cutting.md
@@ -1,0 +1,241 @@
+# Cross-cutting Concerns
+
+> [!NOTE]
+> This document covers the shared subsystems that no single milestone owns: the WebSocket transport contracts, the Anthropic client wrapper, authentication, configuration, and the conventions every agent follows. Read this when integrating with the backend from the frontend, or when adding a new agent that needs to plug into the existing telemetry and auth surfaces.
+
+---
+
+## WebSocket contracts
+
+The backend exposes two WebSockets with deliberately distinct semantics. The frontend type definitions in [frontend/src/lib/ws.types.ts](../../frontend/src/lib/ws.types.ts) are the source of truth — backend payloads conform to those types verbatim.
+
+### `WS /api/v1/events` — global telemetry bus (`EventBusMap`)
+
+Source: `core.ws_manager.broadcast(event_type, payload)` from any agent or router.
+Audience: Control Room, Agent Inspector, Activity Feed, Anomaly Banner.
+
+```mermaid
+flowchart LR
+    subgraph Producers
+        Sentinel
+        Investigator
+        WOG["WO Generator"]
+        QA["Q&A handoff"]
+        Builder["KB Builder"]
+    end
+    Singleton["ws_manager<br/>(singleton)"]
+    subgraph Frame
+        Auto["+turn_id from<br/>current_turn_id ContextVar"]
+        JSON["JSON serialise"]
+    end
+    subgraph Consumers
+        Front1["Control Room"]
+        Front2["Inspector"]
+        Front3["Activity Feed"]
+    end
+    Sentinel --> Singleton
+    Investigator --> Singleton
+    WOG --> Singleton
+    QA --> Singleton
+    Builder --> Singleton
+    Singleton --> Auto --> JSON --> Consumers
+```
+
+Frame catalogue (the full list — backend-emitted):
+
+| Type                  | Payload                                                                                         | Emitter                                                           |
+|-----------------------|-------------------------------------------------------------------------------------------------|-------------------------------------------------------------------|
+| `anomaly_detected`    | `{cell_id, signal_def_id, value, threshold, severity, direction, work_order_id, time, turn_id}` | Sentinel                                                          |
+| `agent_start`         | `{agent, turn_id}`                                                                              | Every agent at run start                                          |
+| `agent_end`           | `{agent, turn_id, finish_reason}`                                                               | Every agent at run end                                            |
+| `agent_handoff`       | `{from_agent, to_agent, reason, turn_id}`                                                       | Investigator (`ask_kb_builder`), Q&A (`ask_investigator`)         |
+| `thinking_delta`      | `{agent, content, turn_id}`                                                                     | Investigator (Messages API: per-chunk; Managed Agents: per-block) |
+| `tool_call_started`   | `{agent, tool_name, args, turn_id}`                                                             | Every agent's tool dispatcher                                     |
+| `tool_call_completed` | `{agent, tool_name, duration_ms, turn_id}`                                                      | Every agent's tool dispatcher                                     |
+| `ui_render`           | `{agent, component, props, turn_id}`                                                            | Every `render_*` dispatch                                         |
+| `rca_ready`           | `{work_order_id, rca_summary, confidence, turn_id}`                                             | Investigator on `submit_rca`                                      |
+| `work_order_ready`    | `{work_order_id}`                                                                               | WO Generator on `submit_work_order`                               |
+| `kb_updated`          | `{cell_id}`                                                                                     | KB Builder writes (planned)                                       |
+
+### `WS /api/v1/agent/chat` — per-operator chat (`ChatMap`)
+
+Source: `ws.send_json(...)` from `modules/chat/router.py` and `agents/qa/`.
+Audience: chat panel only. Per-connection.
+
+| Type             | Payload              | Notes                                                                                |
+|------------------|----------------------|--------------------------------------------------------------------------------------|
+| `text_delta`     | `{content}`          | Token-by-token streamed assistant text.                                              |
+| `thinking_delta` | `{content}`          | Reserved for future use (Q&A is not extended-thinking-enabled today).                |
+| `tool_call`      | `{name, args}`       | One per tool invocation. Frontend renders an inline collapsable card.                |
+| `tool_result`    | `{name, summary}`    | Short string only — raw JSON forbidden on this channel.                              |
+| `ui_render`      | `{component, props}` | Mirror of the bus `ui_render` (no `agent` field — chat already implies the speaker). |
+| `agent_start`    | `{agent}`            | Speaker for this turn or sub-turn. Frontend flips the badge.                         |
+| `agent_handoff`  | `{from, to, reason}` | Unprefixed names (vs `from_agent`/`to_agent` on the bus).                            |
+| `done`           | `{error?: string}`   | Turn complete. `error` populated on degraded paths.                                  |
+
+> [!IMPORTANT]
+> The field-name divergence between the two channels is intentional. `from`/`to` on the chat socket reads more naturally for the per-conversation chatStore reducer; `from_agent`/`to_agent` on the bus avoids any chance of conflict with JS reserved words and disambiguates against generic event payloads. When an agent action concerns both audiences (handoffs, ui_render), the source emits both frames with the per-channel naming — this is encapsulated in each agent's `tool_dispatch` module.
+
+### `current_turn_id` ContextVar
+
+[backend/core/ws_manager.py](../../backend/core/ws_manager.py)
+
+```python
+from core.ws_manager import current_turn_id, ws_manager
+import uuid
+
+token = current_turn_id.set(uuid.uuid4().hex)
+try:
+    await ws_manager.broadcast("anomaly_detected", {...})  # turn_id auto-injected
+finally:
+    current_turn_id.reset(token)
+```
+
+The orchestrator sets the turn id once; every nested `ws_manager.broadcast` picks it up automatically. asyncio propagates ContextVars across `await` boundaries, so the same id flows into every tool call and every nested handler within the run.
+
+---
+
+## Anthropic client wrapper
+
+[backend/agents/anthropic_client.py](../../backend/agents/anthropic_client.py)
+
+A thin wrapper around `AsyncAnthropic` that owns:
+
+- **Singleton instance.** One `anthropic` client per process.
+- **Model selection.** `model_for("reasoning")` returns Opus 4.7, `model_for("chat")` returns Sonnet, `model_for("extraction")` returns the model used for PDF vision. Toggling `ARIA_MODEL=opus` for Investigator-only runs is the cost lever; the wrapper isolates this from agent code.
+- **Timeout and retry.** `httpx.AsyncClient(timeout=60.0)` and `max_retries=2` to keep stuck calls from hanging the demo.
+- **`parse_json_response` helper.** Strips ```json fences, falls back to regex extraction if `json.loads` fails — the Sonnet quirk that breaks every agent the first time it ships.
+
+Every agent imports `anthropic` and `model_for` from this module. No agent constructs its own SDK client.
+
+---
+
+## Authentication
+
+[backend/core/security/](../../backend/core/security/)
+
+| File          | Purpose                                                                                     |
+|---------------|---------------------------------------------------------------------------------------------|
+| `jwt.py`      | Issue / decode access tokens. HS256, short TTL, signed with `ARIA_JWT_SECRET`.              |
+| `cookies.py`  | Set / clear the access cookie (HTTP-only, `Secure` in production).                          |
+| `password.py` | bcrypt hashing helpers — used by the auth module's user creation flow.                      |
+| `role.py`     | `Role` enum (`ADMIN`, `OPERATOR`, `VIEWER`) and the `require_role(...)` FastAPI dependency. |
+| `deps.py`     | Standard FastAPI dependencies: `get_current_user`, `require_role(...)`.                     |
+| `ws_auth.py`  | `require_access_cookie(ws)` — the WebSocket-side decoder. Returns `User` or closes 4401.    |
+
+Both WebSockets (`/api/v1/events` and `/api/v1/agent/chat`) authenticate via the same `require_access_cookie` helper. The cookie is set by the REST login flow and is automatically attached to the WebSocket handshake by the browser. There is no separate WebSocket token.
+
+The `/mcp/<secret>/` mount has *no* per-request auth — the path secret is the auth. See [decisions.md](./decisions.md#path-secret-url-as-the-mcp-auth-mechanism).
+
+---
+
+## Configuration
+
+[backend/core/config.py](../../backend/core/config.py)
+
+A single `Settings` class loaded from environment variables via `pydantic-settings`. Notable fields:
+
+| Setting                    | Purpose                                                                                   |
+|----------------------------|-------------------------------------------------------------------------------------------|
+| `database_url`             | TimescaleDB DSN.                                                                          |
+| `anthropic_api_key`        | Required for all agents.                                                                  |
+| `aria_model`               | `sonnet` (default) or `opus`. Drives `model_for("reasoning")`.                            |
+| `aria_jwt_secret`          | HS256 signing key for access tokens.                                                      |
+| `aria_mcp_path_secret`     | The path segment for the MCP mount. Generate with `openssl rand -hex 32`.                 |
+| `aria_mcp_url`             | Internal MCP URL used by the loopback `MCPClient`.                                        |
+| `aria_mcp_public_url`      | Public MCP URL (Cloudflare tunnel) used by hosted Managed Agents.                         |
+| `investigator_use_managed` | `True` to route Investigator through Managed Agents, `False` to fallback to Messages API. |
+
+`.env` is gitignored. `.env.example` documents the full set with placeholder values.
+
+---
+
+## Database access pattern
+
+[backend/core/database.py](../../backend/core/database.py)
+
+`db: Database` is a module-level singleton holding an `asyncpg.pool` (`min_size=2`, `max_size=20`). Every repository acquires a connection from this pool.
+
+The `_with_conn(...)` pattern ensures pool acquisition is scoped to the call:
+
+```python
+async def get_oee(cell_id: int, window_start: str) -> dict:
+    async with db.pool.acquire() as conn:
+        return await KpiRepository.oee(conn, cell_id, window_start)
+```
+
+This pattern is mandatory inside MCP tools because FastMCP tool functions cannot use FastAPI's `Depends()`. It is also the only sanctioned path for any module that runs outside the request lifecycle (Sentinel, the Investigator background task, the Work Order Generator background task).
+
+---
+
+## Repository pattern
+
+Every domain module in `backend/modules/` follows the same shape:
+
+```
+modules/<domain>/
+├── __init__.py
+├── router.py        # FastAPI router (HTTP)
+├── schemas.py       # Pydantic input/output models
+├── repository.py    # async classmethods, takes a connection
+└── (optional)
+    ├── service.py   # cross-repo orchestration
+    └── helpers.py
+```
+
+Repositories are stateless classes with classmethods that take an `asyncpg.Connection` as the first argument. This makes them trivially testable and consistent across the codebase. SQL never lives outside `repository.py`.
+
+---
+
+## Conventions
+
+### Safety nets on every long-running agent
+
+Every agent body that runs outside the request lifecycle (Sentinel tick, Investigator run, WO Generator run, Q&A turn) is wrapped in:
+
+1. `asyncio.wait_for(body, timeout=N)` — wall-clock budget.
+2. Outer `try/except Exception` — never let an agent crash propagate into the asyncio task supervisor.
+3. A graceful-degradation update to the relevant DB row (work order, session) so the operator-visible state always reflects the outcome.
+
+A hung tool call must never leave a work order stuck in `status='detected'`. The contract is encoded in [decisions.md](./decisions.md#safety-nets-on-every-agent-loop) and enforced at code review.
+
+### `tool_use` dispatch is per-agent
+
+Each agent has its own `tool_dispatch` module that owns:
+
+- The branch logic on tool name.
+- The dual-channel emission (events bus + chat socket where applicable).
+- The `safe_send` wrapper that swallows closed-socket errors so a dropped client never tears down the agent loop mid-turn.
+- The `tool_result` summarisation for the chat channel (the chat contract forbids raw tool JSON).
+
+Sharing one global dispatcher would couple every agent's tool surface — the per-agent split is what lets each agent declare its own `tools` array without affecting the others.
+
+### Pydantic at boundaries, not internally
+
+Repositories return `asyncpg.Record` or plain `dict`. Pydantic validates only at the HTTP/MCP/tool-input boundary. Agents pass dicts to each other internally — no schema boilerplate inside the agent loop. The two reasons:
+
+1. Pydantic instantiation is hot-path-expensive on a tool call that runs every 30 seconds.
+2. The schema is the LLM contract. Re-validating mid-loop adds no safety the LLM has not already implicitly satisfied by emitting a `tool_use` that the SDK accepted.
+
+### Logger names are stable
+
+Every module uses `log = logging.getLogger("aria.<domain>")`. The full set:
+
+- `aria.sentinel`
+- `aria.investigator`
+- `aria.work_order_generator`
+- `aria.qa_agent`
+- `aria.kb_builder`
+- `aria.ws_manager`
+- `aria.chat.ws`
+- `aria.mcp.client`
+
+Filtering docker logs by logger name is the standard debugging path.
+
+---
+
+## Where to next
+
+- The data layer that everything reads and writes: [01-data-layer.md](./01-data-layer.md).
+- The MCP tool catalogue: [02-mcp-server.md](./02-mcp-server.md).
+- Why a particular non-obvious choice was made: [decisions.md](./decisions.md).

--- a/docs/architecture/decisions.md
+++ b/docs/architecture/decisions.md
@@ -1,0 +1,212 @@
+# Architecture Decisions
+
+> [!NOTE]
+> This document captures the non-obvious choices made during the hackathon — the ones where the "obvious" alternative was considered, tried, or initially shipped before being replaced. Each entry records the decision, the alternatives weighed, the trigger that forced the choice, and the consequences. Read this to understand *why* the codebase looks the way it does.
+
+---
+
+## Two paths: Messages API vs Managed Agents
+
+**Decision.** The Investigator runs on Anthropic Managed Agents (M5.5). The Q&A agent runs on the Messages API. Sentinel, Work Order Generator, and KB Builder run on the Messages API. The Investigator's Messages-API implementation is kept behind `INVESTIGATOR_USE_MANAGED=False` as a 5-minute rollback path.
+
+**Alternatives considered.**
+
+- *Q&A on Managed Agents (originally shipped in M5.4).* Removed. Interactive sub-second turns fight the platform's `agent.message`-block grain — there is no token-level streaming, only block-level, which would have required artificial chunking on the backend to satisfy the chat `text_delta` contract.
+- *Investigator on Messages API only (the M4 baseline).* Works, but loses three differentiation features the platform uniquely enables: built-in conversation compaction, persistent session ids that survive across requests, and the in-sandbox bash + Python environment for quantitative diagnostics.
+- *Both on Managed Agents.* Rejected for the same reason as Q&A above.
+
+**Trigger.** [docs/audits/M5-managed-agents-refactor-audit.md](../audits/M5-managed-agents-refactor-audit.md) explicitly framed the question: which agent is the right Managed-Agents target? The audit's answer — the long-running, tool-heavy, asynchronous one — drove the M5.5 pivot.
+
+**Consequences.**
+
+- The 414-line Q&A Managed-Agents implementation was deleted in M5.5.
+- The Investigator gained `agents/investigator/managed/` (575 LOC across 5 files) and migration 009 added `work_order.investigator_session_id`.
+- Hosted MCP became part of the production deployment surface, requiring the Cloudflare tunnel and the path-secret URL.
+- Two Investigator entry points (Messages API and Managed Agents) co-exist with the same external contract, which lets us compare cost and latency in real time.
+
+---
+
+## Path-secret URL as the MCP auth mechanism
+
+**Decision.** The MCP HTTP mount is at `/mcp/<aria_mcp_path_secret>` rather than `/mcp`. There is no per-request auth on the mount.
+
+**Alternatives considered.**
+
+- *Custom HTTP header (e.g. `X-MCP-Token`).* Rejected — the Anthropic Managed Agents `mcp_servers` config does not support custom headers.
+- *OAuth + Anthropic vault integration.* Rejected for hackathon scope. The full OAuth flow plus vault provisioning is several days of work and adds zero demo value.
+- *No auth (mount at `/mcp`).* Rejected — anyone with the public Cloudflare URL would have unauthenticated read+write access to the database via the MCP write tool.
+
+**Trigger.** Plugging hosted MCP into Managed Agents during M5.5 made the auth question urgent.
+
+**Consequences.**
+
+- The path secret is generated with `openssl rand -hex 32` and stored in `.env` only. It is shared between `aria_mcp_url` (loopback) and `aria_mcp_public_url` (Cloudflare tunnel).
+- All MCP traffic, internal and external, goes through the same secret-bearing URL. Rotating the secret rotates both transports atomically.
+- The mount lives in [backend/main.py](../../backend/main.py) — `app.mount(f"/mcp/{settings.aria_mcp_path_secret}", mcp_http_app)`.
+
+---
+
+## Safety nets on every agent loop
+
+**Decision.** Every long-running agent body (Sentinel tick, Investigator run, Work Order Generator run, Q&A turn) is wrapped in `asyncio.wait_for(body, timeout=N)` plus an outer `try/except Exception`, with a graceful-degradation DB update on failure.
+
+**Alternatives considered.**
+
+- *No timeout, no outer try.* The M4 audit flagged this as the highest-risk gap before any agent code shipped. A hung tool call would have left work orders stuck in `status='detected'` and the Sentinel loop unable to make progress.
+- *Per-tool-call timeout instead of per-run timeout.* Insufficient — the failure mode is the agent loop accumulating turns, not a single tool call hanging.
+
+**Trigger.** [docs/audits/M4-M5-sentinel-investigator-workorder-qa-audit.md §4](../audits/M4-M5-sentinel-investigator-workorder-qa-audit.md) "Missing guard-rails".
+
+**Consequences.**
+
+- Investigator: `MAX_TURNS=12`, `_TIMEOUT_SECONDS=120`, on timeout sets `rca_summary='Investigation timed out'` (status stays at `detected`).
+- Work Order Generator: `MAX_TURNS=6`, `_TIMEOUT_SECONDS=60`, on timeout leaves the WO at `status='analyzed'` so the operator can hit Regenerate.
+- Q&A: per-turn safe-send on every WS write so a dropped client cannot tear down the agent loop mid-turn.
+- Sentinel: per-cell try/except inside the tick body so one bad cell never breaks the rest.
+
+---
+
+## Extended thinking — signed block preservation
+
+**Decision.** The Investigator's `_llm_call` reconstructs the next turn's assistant message from `final_message.content` rather than from `text_delta` accumulation. This preserves Anthropic's signed `thinking` block verbatim across turns.
+
+**Alternatives considered.**
+
+- *Reconstruct the assistant turn from streamed `text_delta` chunks.* Returns `400 thinking block signature invalid` on the next turn. The signed block is not part of the streamed text — it is a separate content block in `final_message.content`.
+- *Disable extended thinking.* Loses the operator-visible reasoning trace that is one of the demo's strongest moments.
+
+**Trigger.** First end-to-end test of the Investigator after enabling `thinking={enabled, 10000}`.
+
+**Consequences.**
+
+- The `_llm_call` helper returns the full `final_message` and the agent-loop appends `{"role": "assistant", "content": final_message.content}` directly. No reconstruction, no chunking.
+- `thinking_delta` events are still streamed live to the events bus for UI rendering — the live stream and the message-history block are two separate concerns.
+- This is the most important single line of code in [backend/agents/investigator/service.py](../../backend/agents/investigator/service.py).
+
+---
+
+## Dropping `render_correlation_matrix`
+
+**Decision.** The originally planned `render_correlation_matrix` generative-UI tool was removed from `INVESTIGATOR_RENDER_TOOLS` before M4 shipped.
+
+**Alternatives considered.**
+
+- *Ship the tool, let the LLM compute correlation matrices.* Rejected. No MCP tool computes correlations — the LLM would synthesise plausible-looking but fabricated numbers, which is fatal in a predictive-maintenance pitch.
+- *Add an MCP `compute_correlation_matrix` tool.* Out of scope for M4. The signal-correlation use case did not earn its own backend route within the milestone budget.
+
+**Trigger.** [docs/audits/M2-mcp-server-audit.md](../audits/M2-mcp-server-audit.md) flagged the data-source mismatch during the pre-implementation review of the render tool family.
+
+**Consequences.**
+
+- Investigator's render tool surface is the three trustworthy ones: `render_signal_chart`, `render_diagnostic_card`, `render_pattern_match`.
+- Future addition of correlation requires the round trip: add an MCP tool that computes from real samples first, then expose the render tool.
+
+---
+
+## Token-budget hardening: breach windows and trend caps
+
+**Decision.** `get_signal_anomalies` returns aggregated breach windows, not per-sample rows. `get_signal_trends` enforces a hard 500-row cap.
+
+**Alternatives considered.**
+
+- *Per-sample rows with an LLM-side instruction to summarise.* Returned 575k tokens in a single tool result during the first hosted-MCP run, overflowing the 200k context window mid-call.
+- *Lower per-tool token cap configured on Managed Agents.* The platform's own compaction works at conversation grain, not tool-result grain. The fix had to be on our side.
+
+**Trigger.** [docs/audits/M5.5-end-to-end-test-report.md §4](../audits/M5.5-end-to-end-test-report.md) "Token overflow resolved".
+
+**Consequences.**
+
+- The same query on the same data now returns ~28 windows / ~2 400 tokens — a 240x reduction.
+- `get_signal_trends` truncated responses include `{"_truncated": true, "hint": "..."}` so the LLM can self-correct by narrowing its window.
+- Both fixes apply to the Messages-API path too — the change improved Investigator latency and cost on the existing path even though the trigger was the hosted path.
+
+---
+
+## Hosted-MCP wiring quirks: `permission_policy` and `mcp_toolset`
+
+**Decision.** The bootstrap of every Managed Agents session sets `default_config.permission_policy = "always_allow"` and includes `{"type": "mcp_toolset", "mcp_server_name": "aria"}` in the `tools` array.
+
+**Trigger.** First end-to-end run of the Managed Investigator hung indefinitely. Second run returned `400 mcp_servers declared but no mcp_toolset references them`.
+
+**Consequences.**
+
+- `permission_policy` defaults to `always_ask`, which pauses the agent waiting for a human approval that never arrives. `always_allow` is the only autonomous mode.
+- The `mcp_toolset` entry is the explicit link between the declared MCP server and the agent's tool surface. Without it the platform refuses to start.
+- The hosted-MCP tool ids (`sevt_*`) appear in `requires_action.event_ids` but must *not* be dispatched as custom tools — the dispatcher in [backend/agents/investigator/managed/tool_dispatch.py](../../backend/agents/investigator/managed/tool_dispatch.py) silently skips them.
+
+---
+
+## `additionalProperties` stripping for Managed Agents
+
+**Decision.** [backend/agents/investigator/managed/bootstrap.py](../../backend/agents/investigator/managed/bootstrap.py) walks every custom tool input schema and removes any `additionalProperties` field before submitting the agent definition.
+
+**Trigger.** Managed Agents rejects schemas containing `additionalProperties` even at false. The Messages API tolerates the same field.
+
+**Consequences.**
+
+- The schema strip is recursive — it covers nested objects.
+- The same Pydantic-generated schemas are used unchanged on the Messages-API path.
+- A future Anthropic SDK update that supports `additionalProperties` is a simple flip — remove the strip call.
+
+---
+
+## FastMCP envelope unwrapping
+
+**Decision.** [backend/aria_mcp/client.py](../../backend/aria_mcp/client.py) recursively unwraps the `structured_content` envelope FastMCP wraps around `list[dict]` returns.
+
+**Trigger.** Sentinel's first tick treated `[{"result": [{"signal_def_id": ...}]}]` as a list of breaches with one entry, then tried to subscript `breach["signal_def_id"]` on the wrapper dict and crashed.
+
+**Consequences.**
+
+- Callers see the native shape — `list[dict]` is `list[dict]`, not `{"result": list[dict]}`.
+- The unwrap is recursive so deeply-nested return shapes are normalised.
+- The MCP SDK update that removes the wrapping entirely is a single-line removal of the unwrap helper.
+
+---
+
+## Contract discipline: frontend types are the source of truth
+
+**Decision.** Backend WebSocket payloads conform verbatim to `EventBusMap` and `ChatMap` in [frontend/src/lib/ws.types.ts](../../frontend/src/lib/ws.types.ts). When a contract changes, the frontend types are updated first and the backend is checked against them.
+
+**Alternatives considered.**
+
+- *Generate frontend types from backend Pydantic.* Tooling overhead too high for hackathon timeline; would have required Pydantic-to-TypeScript codegen plumbing.
+- *Backend defines the contract, frontend follows.* Rejected because the consumer (frontend) has stricter requirements (exhaustive switch on type unions) than the producer.
+
+**Trigger.** Repeated minor drifts during M4 (`from` vs `from_agent`, `parts_required` vs `required_parts`) caught at integration rather than at code review.
+
+**Consequences.**
+
+- Field naming on the chat socket (`from`/`to`) deliberately differs from the events bus (`from_agent`/`to_agent`). The asymmetry is documented and intentional.
+- Issue #125 (sub-agent `agent_start`/`agent_end` mirroring on the chat socket) was a pure backend fix because the frontend `ChatMap` already supported the frame.
+
+---
+
+## Memory injection in the Investigator system prompt
+
+**Decision.** Recent `failure_history` rows for the affected cell are loaded once at the start of every Investigator run and pasted into the system prompt as a "previously seen failure modes" block. They are *not* exposed as a tool call.
+
+**Alternatives considered.**
+
+- *`get_failure_history` MCP tool exposed to the LLM.* The tool exists (and is exposed), but the system-prompt injection guarantees the memory is *seen* on every run regardless of whether the LLM thinks to query it.
+- *Vector search over historical failures.* Out of scope — the demo cell has at most a handful of failures, exact-match by `cell_id` is sufficient.
+
+**Trigger.** The "knowledge does not retire with the senior technician" demo moment requires the Investigator to *spontaneously* recognise a recurring pattern, not be asked to look it up.
+
+**Consequences.**
+
+- Zero extra turns and zero tool dispatch overhead.
+- The reasoning trace ("I noticed this matches failure mode #4 from January") is a strong demo moment.
+- The system prompt grows with cell history. For the demo's 1-2 historical failures this is a non-issue; a production deployment would cap the injected window.
+
+---
+
+## Where to next
+
+- The README index: [README.md](./README.md).
+- The data layer: [01-data-layer.md](./01-data-layer.md).
+- The MCP server: [02-mcp-server.md](./02-mcp-server.md).
+- The KB Builder: [03-kb-builder.md](./03-kb-builder.md).
+- Sentinel and Investigator: [04-sentinel-investigator.md](./04-sentinel-investigator.md).
+- Work Order Generator and Q&A: [05-workorder-qa.md](./05-workorder-qa.md).
+- Cross-cutting concerns: [cross-cutting.md](./cross-cutting.md).


### PR DESCRIPTION
- Introduced README.md for ARIA backend architecture covering milestones M1 to M5, providing an overview and deep-dive paths for readers.
- Created cross-cutting.md to document shared subsystems, including WebSocket contracts, authentication, and conventions for agent integration.
- Added decisions.md to capture architectural choices made during development, detailing alternatives considered and consequences of each decision.