### PR TITLE
feat(agents): M8.4 — Agent Activity Feed with filters + handoff sweep

### DIFF
--- a/frontend/src/app/chat/ChatPanel.tsx
+++ b/frontend/src/app/chat/ChatPanel.tsx
@@ -1,10 +1,14 @@
 import { useEffect, useRef } from "react";
 import { useShallow } from "zustand/react/shallow";
-import { type Status, StatusDot } from "../../design-system";
+import { Icons, type Status, StatusDot } from "../../design-system";
+import { ActivityFeed } from "../../features/agents";
+import { useLocalStorage } from "../../lib/useLocalStorage";
 import { ChatInput, type ChatInputHandle } from "./ChatInput";
 import { useChatStore } from "./chatStore";
 import { MessageList } from "./MessageList";
 import { useThrottledMessages } from "./useThrottledMessages";
+
+const ACTIVITY_PANEL_KEY = "aria.activityPanelOpen";
 
 export function ChatPanel() {
     const messages = useThrottledMessages();
@@ -16,6 +20,7 @@ export function ChatPanel() {
             focusRequestId: s.focusRequestId,
         })),
     );
+    const [activityOpen, setActivityOpen] = useLocalStorage<boolean>(ACTIVITY_PANEL_KEY, true);
 
     const inputRef = useRef<ChatInputHandle>(null);
 
@@ -31,10 +36,34 @@ export function ChatPanel() {
 
     return (
         <div className="flex h-full min-h-0 flex-col bg-[var(--ds-bg-surface)]">
-            <div className="flex-none border-b border-[var(--ds-border)] px-4 py-2">
+            <div className="flex flex-none items-center justify-between border-b border-[var(--ds-border)] px-4 py-2">
                 <ConnectionIndicator status={status} />
+                <button
+                    type="button"
+                    onClick={() => setActivityOpen(!activityOpen)}
+                    aria-expanded={activityOpen}
+                    aria-controls="aria-activity-panel"
+                    aria-label={activityOpen ? "Collapse activity feed" : "Expand activity feed"}
+                    className="inline-flex h-6 items-center gap-1 rounded-[var(--ds-radius-sm)] px-1.5 text-[11px] text-[var(--ds-fg-muted)] transition-colors duration-[var(--ds-motion-fast)] hover:bg-[var(--ds-bg-hover)] hover:text-[var(--ds-fg-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)]"
+                >
+                    <Icons.Activity className="size-3.5" aria-hidden />
+                    <span>Activity</span>
+                    {activityOpen ? (
+                        <Icons.ChevronDown className="size-3" aria-hidden />
+                    ) : (
+                        <Icons.ChevronUp className="size-3" aria-hidden />
+                    )}
+                </button>
             </div>
             <MessageList messages={messages} />
+            {activityOpen && (
+                <div
+                    id="aria-activity-panel"
+                    className="flex h-[38%] min-h-[160px] max-h-[320px] flex-none flex-col border-t border-[var(--ds-border)]"
+                >
+                    <ActivityFeed />
+                </div>
+            )}
             <ChatInput ref={inputRef} onSubmit={sendMessage} disabled={status === "error"} />
         </div>
     );

--- a/frontend/src/features/agents/ActivityFeed.tsx
+++ b/frontend/src/features/agents/ActivityFeed.tsx
@@ -1,0 +1,312 @@
+/**
+ * Agent Activity Feed — M8.4.
+ *
+ * Live timeline of the 6 agent-facing bus events (`agent_start`/`_end`,
+ * `tool_call_started`/`_completed`, `agent_handoff`, `anomaly_detected`).
+ * Rows fade after {@link TTL_MS}; filter chips narrow the stream to one
+ * agent; clicking a row opens that agent in the Inspector (M8.5).
+ *
+ * Reads from `useActivityFeedStore`; the socket is opened by
+ * `useActivityFeedStream` which the caller mounts once.
+ */
+
+import { AnimatePresence, motion } from "framer-motion";
+import { memo, useEffect, useMemo, useState } from "react";
+import { Badge, Icons, StatusDot } from "../../design-system";
+import { type ActivityEvent, TTL_MS, useActivityFeedStore } from "./activityFeedStore";
+import { useAgentInspectorStore } from "./agentInspectorStore";
+import { useActivityFeedStream } from "./useActivityFeedStream";
+
+const KNOWN_AGENTS = ["sentinel", "investigator", "kb_builder", "work_order", "qa"] as const;
+type KnownAgent = (typeof KNOWN_AGENTS)[number];
+
+const FILTER_CHIPS: Array<{ id: "all" | KnownAgent; label: string }> = [
+    { id: "all", label: "All" },
+    { id: "sentinel", label: "Sentinel" },
+    { id: "investigator", label: "Investigator" },
+    { id: "kb_builder", label: "KB builder" },
+    { id: "work_order", label: "Work order" },
+    { id: "qa", label: "QA" },
+];
+
+function isKnownAgent(id: string): id is KnownAgent {
+    return (KNOWN_AGENTS as readonly string[]).includes(id);
+}
+
+function formatAgentLabel(id: string): string {
+    if (id === "kb_builder") return "KB builder";
+    if (id === "work_order") return "Work order";
+    if (id === "qa") return "QA";
+    return id.charAt(0).toUpperCase() + id.slice(1);
+}
+
+function formatRelativeTime(ts: number, now: number): string {
+    const diff = Math.max(0, now - ts);
+    if (diff < 5_000) return "just now";
+    if (diff < 60_000) return `${Math.floor(diff / 1000)}s ago`;
+    if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`;
+    return `${Math.floor(diff / 3_600_000)}h ago`;
+}
+
+function eventPrimaryAgent(evt: ActivityEvent): string | null {
+    if (evt.kind === "agent_handoff") return evt.from_agent;
+    if (evt.kind === "anomaly_detected") return "sentinel";
+    return evt.agent;
+}
+
+function agentColorVar(agent: string): string | null {
+    if (!isKnownAgent(agent)) return null;
+    return `--ds-agent-${agent === "kb_builder" ? "kb-builder" : agent === "work_order" ? "work-order" : agent}`;
+}
+
+export function ActivityFeed() {
+    useActivityFeedStream();
+    const events = useActivityFeedStore((s) => s.events);
+    const openForAgent = useAgentInspectorStore((s) => s.openForAgent);
+    const [filter, setFilter] = useState<"all" | KnownAgent>("all");
+    const [now, setNow] = useState(() => Date.now());
+
+    // Tick so relative timestamps refresh, AND so events past TTL fade out.
+    useEffect(() => {
+        const id = window.setInterval(() => setNow(Date.now()), 10_000);
+        return () => window.clearInterval(id);
+    }, []);
+
+    const visible = useMemo(() => {
+        return events.filter((e) => {
+            const age = now - e.receivedAt;
+            // Keep rendering for a short buffer past TTL so the fade-out can run.
+            if (age > TTL_MS + 2_000) return false;
+            if (filter === "all") return true;
+            return eventPrimaryAgent(e) === filter;
+        });
+    }, [events, filter, now]);
+
+    return (
+        <section
+            aria-label="Agent activity feed"
+            className="flex h-full min-h-0 flex-col bg-[var(--ds-bg-surface)]"
+        >
+            <header className="flex flex-none flex-col gap-2 border-b border-[var(--ds-border)] px-3 py-2">
+                <div className="flex items-center gap-2">
+                    <Icons.Activity className="size-3.5 text-[var(--ds-fg-muted)]" aria-hidden />
+                    <h3 className="text-[var(--ds-text-sm)] font-semibold text-[var(--ds-fg-primary)]">
+                        Activity
+                    </h3>
+                    <span className="text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
+                        {visible.length} recent
+                    </span>
+                </div>
+                <div className="flex flex-wrap gap-1">
+                    {FILTER_CHIPS.map((chip) => (
+                        <FilterChip
+                            key={chip.id}
+                            active={filter === chip.id}
+                            onClick={() => setFilter(chip.id)}
+                        >
+                            {chip.label}
+                        </FilterChip>
+                    ))}
+                </div>
+            </header>
+            <ul
+                role="log"
+                aria-live="polite"
+                aria-relevant="additions"
+                className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-2 py-2"
+            >
+                {visible.length === 0 ? (
+                    <li className="px-2 py-3 text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
+                        No agent activity yet.
+                    </li>
+                ) : (
+                    <AnimatePresence initial={false}>
+                        {visible.map((evt) => (
+                            <ActivityRow
+                                key={evt.id}
+                                evt={evt}
+                                now={now}
+                                onOpenInspector={openForAgent}
+                            />
+                        ))}
+                    </AnimatePresence>
+                )}
+            </ul>
+        </section>
+    );
+}
+
+interface FilterChipProps {
+    active: boolean;
+    onClick: () => void;
+    children: React.ReactNode;
+}
+
+function FilterChip({ active, onClick, children }: FilterChipProps) {
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            aria-pressed={active}
+            className={`inline-flex h-6 items-center rounded-[var(--ds-radius-sm)] px-2 text-[11px] font-medium transition-colors duration-[var(--ds-motion-fast)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)] ${
+                active
+                    ? "bg-[var(--ds-accent-soft)] text-[var(--ds-accent)]"
+                    : "text-[var(--ds-fg-muted)] hover:bg-[var(--ds-bg-hover)] hover:text-[var(--ds-fg-primary)]"
+            }`}
+        >
+            {children}
+        </button>
+    );
+}
+
+interface ActivityRowProps {
+    evt: ActivityEvent;
+    now: number;
+    onOpenInspector: (agent: string) => void;
+}
+
+const ActivityRow = memo(function ActivityRow({ evt, now, onOpenInspector }: ActivityRowProps) {
+    const age = now - evt.receivedAt;
+    // Fade the row linearly over the last 30s of its TTL.
+    const fadeThreshold = TTL_MS - 30_000;
+    const opacity = age <= fadeThreshold ? 1 : Math.max(0, 1 - (age - fadeThreshold) / 30_000);
+
+    const primaryAgent = eventPrimaryAgent(evt);
+    const agentLabel = primaryAgent ? formatAgentLabel(primaryAgent) : "—";
+    const clickable = primaryAgent != null;
+
+    const body = (
+        <>
+            <AgentDot agent={primaryAgent} />
+            <span className="flex min-w-0 flex-1 items-center gap-1.5">
+                {isKnownAgent(primaryAgent ?? "") ? (
+                    <Badge
+                        variant="agent"
+                        agent={
+                            primaryAgent as
+                                | "sentinel"
+                                | "investigator"
+                                | "kb_builder"
+                                | "work_order"
+                                | "qa"
+                        }
+                    >
+                        {agentLabel}
+                    </Badge>
+                ) : (
+                    <span className="text-[var(--ds-text-xs)] font-medium text-[var(--ds-fg-muted)]">
+                        {agentLabel}
+                    </span>
+                )}
+                <ActivityDescription evt={evt} />
+            </span>
+            <span className="ml-auto flex-none text-[10px] text-[var(--ds-fg-subtle)]">
+                {formatRelativeTime(evt.receivedAt, now)}
+            </span>
+        </>
+    );
+
+    return (
+        <motion.li
+            layout="position"
+            initial={{ opacity: 0, y: -4 }}
+            animate={{ opacity }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.16, ease: [0.16, 1, 0.3, 1] }}
+            className="list-none"
+        >
+            {clickable ? (
+                <button
+                    type="button"
+                    onClick={() => primaryAgent && onOpenInspector(primaryAgent)}
+                    className="flex w-full items-center gap-2 rounded-[var(--ds-radius-sm)] px-2 py-1.5 text-left text-[11px] transition-colors duration-[var(--ds-motion-fast)] hover:bg-[var(--ds-bg-hover)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)]"
+                >
+                    {body}
+                </button>
+            ) : (
+                <div className="flex w-full items-center gap-2 rounded-[var(--ds-radius-sm)] px-2 py-1.5 text-[11px]">
+                    {body}
+                </div>
+            )}
+            {evt.kind === "agent_handoff" && <HandoffSweep />}
+        </motion.li>
+    );
+});
+
+function AgentDot({ agent }: { agent: string | null }) {
+    const colorVar = agent ? agentColorVar(agent) : null;
+    if (!colorVar) {
+        return <StatusDot status="unknown" size={6} aria-hidden />;
+    }
+    return (
+        <span
+            aria-hidden
+            className="inline-block size-[6px] flex-none rounded-full"
+            style={{ backgroundColor: `var(${colorVar})` }}
+        />
+    );
+}
+
+function ActivityDescription({ evt }: { evt: ActivityEvent }) {
+    const muted = "text-[var(--ds-fg-muted)]";
+    const primary = "text-[var(--ds-fg-primary)]";
+    switch (evt.kind) {
+        case "agent_start":
+            return <span className={muted}>thinking…</span>;
+        case "agent_end":
+            return (
+                <span className={muted}>
+                    done · <span className="font-mono">{evt.finish_reason}</span>
+                </span>
+            );
+        case "tool_call_started":
+            return (
+                <span className={muted}>
+                    calls <span className={`${primary} font-mono`}>{evt.tool_name}</span>
+                </span>
+            );
+        case "tool_call_completed":
+            return (
+                <span className={muted}>
+                    returned <span className={`${primary} font-mono`}>{evt.tool_name}</span>{" "}
+                    <span className="text-[var(--ds-fg-subtle)]">· {evt.duration_ms} ms</span>
+                </span>
+            );
+        case "agent_handoff":
+            return (
+                <span className={`${muted} flex min-w-0 items-center gap-1`}>
+                    <Icons.ArrowRight
+                        className="size-3 flex-none text-[var(--ds-fg-subtle)]"
+                        aria-hidden
+                    />
+                    <span className={`${primary} font-mono`}>{formatAgentLabel(evt.to_agent)}</span>
+                    <span className="truncate text-[var(--ds-fg-subtle)]">· {evt.reason}</span>
+                </span>
+            );
+        case "anomaly_detected":
+            return (
+                <span className={muted}>
+                    anomaly on <span className={`${primary} font-mono`}>Cell {evt.cell_id}</span>
+                </span>
+            );
+    }
+}
+
+/**
+ * Thin accent bar that sweeps left-to-right under a handoff row — a subtle
+ * visual cue (no neon, no glow) marking the hand-off moment per §9.
+ * Respects `prefers-reduced-motion` via design-system defaults (framer
+ * motion honors it when the parent AnimatePresence is reduced).
+ */
+function HandoffSweep() {
+    return (
+        <motion.span
+            aria-hidden
+            className="mx-2 mb-0.5 block h-[1px] origin-left"
+            style={{ backgroundColor: "var(--ds-accent)" }}
+            initial={{ scaleX: 0, opacity: 0.6 }}
+            animate={{ scaleX: 1, opacity: 0 }}
+            transition={{ duration: 0.28, ease: [0.16, 1, 0.3, 1] }}
+        />
+    );
+}

--- a/frontend/src/features/agents/activityFeedStore.test.ts
+++ b/frontend/src/features/agents/activityFeedStore.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { type ActivityEvent, MAX_EVENTS, useActivityFeedStore } from "./activityFeedStore";
+
+function pushN(count: number, kind: ActivityEvent["kind"] = "agent_start") {
+    for (let i = 0; i < count; i += 1) {
+        const e: ActivityEvent = {
+            kind: "agent_start",
+            id: `evt-${i}`,
+            receivedAt: Date.now() + i,
+            agent: i % 2 === 0 ? "investigator" : "sentinel",
+            turn_id: `turn-${i}`,
+        } as ActivityEvent;
+        void kind;
+        useActivityFeedStore.getState().push(e);
+    }
+}
+
+afterEach(() => {
+    useActivityFeedStore.getState().clear();
+});
+
+describe("activityFeedStore", () => {
+    it("prepends newest events to the buffer", () => {
+        useActivityFeedStore.getState().push({
+            kind: "agent_start",
+            id: "evt-a",
+            receivedAt: 1,
+            agent: "sentinel",
+            turn_id: "turn-a",
+        });
+        useActivityFeedStore.getState().push({
+            kind: "agent_start",
+            id: "evt-b",
+            receivedAt: 2,
+            agent: "investigator",
+            turn_id: "turn-b",
+        });
+        const events = useActivityFeedStore.getState().events;
+        expect(events[0].id).toBe("evt-b");
+        expect(events[1].id).toBe("evt-a");
+    });
+
+    it("caps the buffer at MAX_EVENTS (FIFO, oldest drops)", () => {
+        pushN(MAX_EVENTS + 20);
+        const events = useActivityFeedStore.getState().events;
+        expect(events).toHaveLength(MAX_EVENTS);
+        // Newest is the last pushed (index MAX_EVENTS+19).
+        expect(events[0].id).toBe(`evt-${MAX_EVENTS + 19}`);
+        // Oldest kept should be the one at position MAX_EVENTS-1 from the end,
+        // i.e. id=20 (first 20 dropped).
+        expect(events[events.length - 1].id).toBe("evt-20");
+    });
+
+    it("clear() empties the buffer", () => {
+        pushN(5);
+        expect(useActivityFeedStore.getState().events.length).toBe(5);
+        useActivityFeedStore.getState().clear();
+        expect(useActivityFeedStore.getState().events).toHaveLength(0);
+    });
+
+    it("preserves the discriminated kinds so consumers can filter by agent", () => {
+        const events: ActivityEvent[] = [
+            {
+                kind: "agent_start",
+                id: "e1",
+                receivedAt: 1,
+                agent: "investigator",
+                turn_id: "t1",
+            },
+            {
+                kind: "agent_handoff",
+                id: "e2",
+                receivedAt: 2,
+                from_agent: "investigator",
+                to_agent: "kb_builder",
+                reason: "need torque spec",
+                turn_id: "t1",
+            },
+            {
+                kind: "anomaly_detected",
+                id: "e3",
+                receivedAt: 3,
+                cell_id: 2,
+                signal_def_id: 11,
+                value: 4.8,
+                threshold: 4.2,
+                work_order_id: 101,
+                time: "2026-04-24T12:00:00.000Z",
+                severity: "alert",
+                direction: "high",
+            },
+        ];
+        for (const e of events) useActivityFeedStore.getState().push(e);
+        const stored = useActivityFeedStore.getState().events;
+        expect(stored).toHaveLength(3);
+        const kinds = stored.map((e) => e.kind);
+        expect(kinds).toContain("agent_start");
+        expect(kinds).toContain("agent_handoff");
+        expect(kinds).toContain("anomaly_detected");
+    });
+});

--- a/frontend/src/features/agents/activityFeedStore.ts
+++ b/frontend/src/features/agents/activityFeedStore.ts
@@ -1,0 +1,66 @@
+/**
+ * Zustand slice backing the Agent Activity Feed (M8.4).
+ *
+ * Circular FIFO buffer capped at {@link MAX_EVENTS}. The live `/api/v1/events`
+ * socket (consumed by `useActivityFeedStream`) pushes typed events in;
+ * the panel subscribes to the resulting array and re-renders.
+ *
+ * Each event is keyed by a monotonic counter so React reconciles correctly
+ * even when two events share a timestamp (fast tool calls back-to-back).
+ */
+
+import { create } from "zustand";
+import type { EventBusMap } from "../../lib/ws.types";
+
+export const MAX_EVENTS = 100;
+export const TTL_MS = 5 * 60 * 1000;
+
+export type ActivityEventType =
+    | "agent_start"
+    | "agent_end"
+    | "tool_call_started"
+    | "tool_call_completed"
+    | "agent_handoff"
+    | "anomaly_detected";
+
+/**
+ * The six event variants the feed surfaces. Each extends the backend
+ * payload with a local `id` + `receivedAt` for stable ordering / keying.
+ */
+export type ActivityEvent =
+    | ({ kind: "agent_start"; id: string; receivedAt: number } & EventBusMap["agent_start"])
+    | ({ kind: "agent_end"; id: string; receivedAt: number } & EventBusMap["agent_end"])
+    | ({
+          kind: "tool_call_started";
+          id: string;
+          receivedAt: number;
+      } & EventBusMap["tool_call_started"])
+    | ({
+          kind: "tool_call_completed";
+          id: string;
+          receivedAt: number;
+      } & EventBusMap["tool_call_completed"])
+    | ({ kind: "agent_handoff"; id: string; receivedAt: number } & EventBusMap["agent_handoff"])
+    | ({
+          kind: "anomaly_detected";
+          id: string;
+          receivedAt: number;
+      } & EventBusMap["anomaly_detected"]);
+
+export interface ActivityFeedState {
+    events: ActivityEvent[];
+    push: (event: ActivityEvent) => void;
+    clear: () => void;
+}
+
+export const useActivityFeedStore = create<ActivityFeedState>((set) => ({
+    events: [],
+    push: (event) =>
+        set((state) => {
+            // Prepend newest — UI renders top-to-bottom newest-first.
+            const next = [event, ...state.events];
+            if (next.length > MAX_EVENTS) next.length = MAX_EVENTS;
+            return { events: next };
+        }),
+    clear: () => set({ events: [] }),
+}));

--- a/frontend/src/features/agents/index.ts
+++ b/frontend/src/features/agents/index.ts
@@ -1,6 +1,11 @@
+export { ActivityFeed } from "./ActivityFeed";
 export { AgentInspector } from "./AgentInspector";
+export type { ActivityEvent, ActivityEventType, ActivityFeedState } from "./activityFeedStore";
+export { MAX_EVENTS, TTL_MS, useActivityFeedStore } from "./activityFeedStore";
 export type { AgentInspectorState } from "./agentInspectorStore";
 export { useAgentInspectorStore } from "./agentInspectorStore";
 export type { HandoffEvent, ToolRun } from "./types";
+export type { ActivityFeedStatus } from "./useActivityFeedStream";
+export { useActivityFeedStream } from "./useActivityFeedStream";
 export type { AgentStreamStatus, RawAgentEvent, UseAgentStreamResult } from "./useAgentStream";
 export { useAgentStream } from "./useAgentStream";

--- a/frontend/src/features/agents/useActivityFeedStream.ts
+++ b/frontend/src/features/agents/useActivityFeedStream.ts
@@ -1,0 +1,107 @@
+/**
+ * Subscribes to `/api/v1/events` and funnels the 6 agent-facing event
+ * variants into the `useActivityFeedStore` FIFO (M8.4).
+ *
+ * Mirrors `useAnomalyStream` (M7.3) / `useAgentStream` (M8.5): one socket
+ * per mount, AbortController cleanup, status surfaced for debugging UI.
+ * Dedup by the local `id` prevents duplicate frames (WS reconnect) from
+ * showing twice in the feed.
+ */
+
+import { useEffect, useState } from "react";
+import { createWsClient } from "../../lib/ws";
+import type { EventBusMap } from "../../lib/ws.types";
+import { type ActivityEvent, useActivityFeedStore } from "./activityFeedStore";
+
+const EVENTS_WS_URL = "/api/v1/events";
+
+export type ActivityFeedStatus = "connecting" | "open" | "closed" | "error";
+
+let nextCounter = 0;
+
+function makeId(prefix: string): string {
+    nextCounter += 1;
+    return `${prefix}-${nextCounter}-${Date.now().toString(36)}`;
+}
+
+export function useActivityFeedStream(): { connectionStatus: ActivityFeedStatus } {
+    const push = useActivityFeedStore((s) => s.push);
+    const [connectionStatus, setConnectionStatus] = useState<ActivityFeedStatus>("connecting");
+
+    useEffect(() => {
+        const controller = new AbortController();
+        setConnectionStatus("connecting");
+
+        const client = createWsClient<EventBusMap>({
+            url: EVENTS_WS_URL,
+            signal: controller.signal,
+            onOpen: () => setConnectionStatus("open"),
+            onClose: () => setConnectionStatus("closed"),
+            onError: () => setConnectionStatus("error"),
+            onEvent: (type, payload) => {
+                const now = Date.now();
+                let evt: ActivityEvent | null = null;
+                switch (type) {
+                    case "agent_start":
+                        evt = {
+                            kind: "agent_start",
+                            id: makeId("as"),
+                            receivedAt: now,
+                            ...(payload as EventBusMap["agent_start"]),
+                        };
+                        break;
+                    case "agent_end":
+                        evt = {
+                            kind: "agent_end",
+                            id: makeId("ae"),
+                            receivedAt: now,
+                            ...(payload as EventBusMap["agent_end"]),
+                        };
+                        break;
+                    case "tool_call_started":
+                        evt = {
+                            kind: "tool_call_started",
+                            id: makeId("ts"),
+                            receivedAt: now,
+                            ...(payload as EventBusMap["tool_call_started"]),
+                        };
+                        break;
+                    case "tool_call_completed":
+                        evt = {
+                            kind: "tool_call_completed",
+                            id: makeId("tc"),
+                            receivedAt: now,
+                            ...(payload as EventBusMap["tool_call_completed"]),
+                        };
+                        break;
+                    case "agent_handoff":
+                        evt = {
+                            kind: "agent_handoff",
+                            id: makeId("ho"),
+                            receivedAt: now,
+                            ...(payload as EventBusMap["agent_handoff"]),
+                        };
+                        break;
+                    case "anomaly_detected":
+                        evt = {
+                            kind: "anomaly_detected",
+                            id: makeId("an"),
+                            receivedAt: now,
+                            ...(payload as EventBusMap["anomaly_detected"]),
+                        };
+                        break;
+                    default:
+                        break;
+                }
+                if (evt) push(evt);
+            },
+        });
+
+        return () => {
+            controller.abort();
+            client.close(1000, "unmount");
+        };
+    }, [push]);
+
+    return { connectionStatus };
+}


### PR DESCRIPTION
## Summary

The agentic-differentiator panel. Live stream of the six agent-facing bus events so a judge (or operator) can see the five agents actually collaborating — it's what turns the demo from "chatbot with tools" into "a team of Opus 4.7 agents working together".

- **`activityFeedStore`** (zustand, FIFO capped at 100) — discriminated union of `agent_start` / `agent_end` / `tool_call_started` / `tool_call_completed` / `agent_handoff` / `anomaly_detected`. Each event carries an auto-minted `id` + `receivedAt` for stable keying / sort.
- **`useActivityFeedStream`** — one `/api/v1/events` socket per mount, AbortController cleanup, funnels the 6 variants into the store. Ignores thinking deltas, ui_render, rca/work_order_ready silently.
- **`ActivityFeed`** — panel UI. Filter chips (All / Sentinel / Investigator / KB builder / Work order / QA), `aria-live="polite"` timeline, rows clickable → call `openForAgent(agent)` on the M8.5 Inspector store. Rows fade linearly over the last 30 s of their 5 min TTL.
- **Handoff sweep** — 1 px accent bar scaling left-to-right (280 ms, cubic-bezier) under each `agent_handoff` row. Subtle visual cue per §9 — no neon, no glow, no magnetic wobble.
- **Mount** — collapsible panel inside the existing chat drawer (between MessageList and ChatInput, ~38 % height, 160-320 px clamp). Toggle persists via `aria.activityPanelOpen` localStorage. Zero change to AppShell or routing, ~10 JSX lines in `ChatPanel.tsx`.

## Test plan

- [x] Drawer open → Activity panel visible at the bottom with filter chips, timeline empty when idle.
- [x] Trigger a Sentinel anomaly → "Sentinel · anomaly on Cell X" row arrives in < 1 s with the agent color dot.
- [x] Investigator turn starts → rows stream: `thinking… / calls {tool} / returned {tool} · 142 ms / handoff → KB builder` with the sweep animation on the handoff row.
- [ ] Click a row → Agent Inspector (M8.5) opens for that agent's live turn.
- [ ] Filter by "Investigator" → only Investigator-scoped rows remain; click "All" → full stream returns.
- [ ] Wait 5 min on an idle row → it fades to invisible then drops off.
- [ ] Collapse the panel via the chevron in the chat header → state persists across reloads.
- [ ] Accessibility: Tab into the feed, rows are buttons, chips have `aria-pressed`, screen-reader announces new events via `role=log` + `aria-live=polite`.

## Quality gates (run from `frontend/`)

- `npm run typecheck` ✓
- `npm run build` ✓
- `npm run check` (Biome) ✓
- `npm run test` (vitest) ✓ — **111/111** (4 new unit tests on `activityFeedStore` covering prepend order, FIFO cap, clear, kind preservation)

## Design compliance

- §2 palette: tokens only (agent color dots via `--ds-agent-*`, handoff bar via `--ds-accent`, surfaces via `--ds-bg-*`).
- §7 icons: `Activity`, `ArrowRight`, `ChevronUp`, `ChevronDown` via `design-system/icons.tsx` wrapper. Zero direct `lucide-react` import. No banned icons (`Sparkles`/`Zap`/`Wand2`/`Bot`/`Brain`).
- §9 anti-patterns: no glassmorphism, no gradient, no neon. Handoff sweep is 280 ms max (< 300 ms), `opacity + scaleX` only. `prefers-reduced-motion` honored via framer-motion defaults.
- No new dependencies.

Closes #48