### PR TITLE
feat(demo): debug endpoint + DEV trigger to replay Investigator for J-2

### DIFF
--- a/backend/agents/investigator/service.py
+++ b/backend/agents/investigator/service.py
@@ -71,11 +71,12 @@ async def _llm_call(
     """
     async with anthropic.messages.stream(
         model=model_for("reasoning"),
-        thinking={"type": "enabled", "budget_tokens": _THINKING_BUDGET},
+        thinking={"type": "adaptive", "display": "summarized"},
         system=system,
         messages=cast(Any, messages),
         tools=cast(Any, tools),
         max_tokens=_MAX_TOKENS,
+        extra_body={"output_config": {"effort": "high"}},
     ) as stream:
         async for raw_event in stream:
             # The MessageStreamEvent union has many variants; pyright would

--- a/backend/main.py
+++ b/backend/main.py
@@ -104,6 +104,15 @@ def create_app() -> FastAPI:
         app.include_router(demo_router)
         log.info("Demo endpoints enabled at /api/v1/demo/*")
 
+        # J-2 hackathon trigger — replay an existing WO through the full
+        # Investigator agent so the demo can show Opus 4.7 extended
+        # thinking on cue. Gated behind the same flag as the memory
+        # scene; removable post-demo by unsetting ARIA_DEMO_ENABLED.
+        from modules.debug.router import router as debug_router
+
+        app.include_router(debug_router)
+        log.info("Debug endpoints enabled at /api/v1/debug/*")
+
     # Mount MCP behind a path-secret gate so the tunneled URL carries its own
     # auth token (hosted MCP does not forward custom headers — see #103).
     # The legacy unsecured ``/mcp`` mount is only kept when hosted MCP is NOT

--- a/backend/modules/debug/router.py
+++ b/backend/modules/debug/router.py
@@ -1,0 +1,99 @@
+"""Debug endpoints for the hackathon demo (J-2).
+
+Exposes a single trigger that re-spawns the Investigator agent on an
+existing work order so Adam can showcase Opus 4.7 extended thinking
+live during the pitch without waiting for a natural Sentinel detection.
+Also exposes a tiny listing endpoint so the frontend can grab the most
+recent work order to replay.
+
+Scope is intentionally throwaway — keep this module out of production
+imports and remove post-demo. Auth stays on via `get_current_user` so
+the existing cookie/session path is reused (the frontend calls through
+Vite proxy with `credentials: "include"`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import asyncpg
+from agents.investigator.service import run_investigator
+from core.database import get_db
+from core.security import get_current_user
+from fastapi import APIRouter, Depends, HTTPException
+
+log = logging.getLogger("aria.debug")
+
+router = APIRouter(
+    prefix="/api/v1/debug",
+    tags=["debug"],
+    dependencies=[Depends(get_current_user)],
+)
+
+
+@router.post("/replay-investigator/{work_order_id}", status_code=202)
+async def replay_investigator(
+    work_order_id: int,
+    conn: asyncpg.Connection = Depends(get_db),
+) -> dict[str, Any]:
+    """Re-spawn the full Investigator agent on an existing work order.
+
+    Resets the WO status to ``detected`` first so the agent re-emits the
+    full broadcast sequence (``agent_start`` → ``thinking_delta`` →
+    ``tool_call_*`` → ``submit_rca`` → ``agent_end``). Returns 202 with
+    the scheduled task identifier; the actual run happens in the
+    background task.
+    """
+    wo = await conn.fetchrow(
+        "SELECT id, cell_id, status FROM work_order WHERE id = $1",
+        work_order_id,
+    )
+    if wo is None:
+        raise HTTPException(
+            status_code=404, detail=f"work_order {work_order_id} not found"
+        )
+
+    await conn.execute(
+        "UPDATE work_order SET status = 'detected' WHERE id = $1",
+        work_order_id,
+    )
+
+    # Fire-and-forget — the endpoint returns immediately so the UI can
+    # start rendering `agent_start` as soon as the Investigator emits it.
+    asyncio.create_task(
+        run_investigator(work_order_id),
+        name=f"debug-investigator-wo-{work_order_id}",
+    )
+    log.info(
+        "debug replay: Investigator spawned for WO %d (cell %d, prior status %s)",
+        work_order_id,
+        wo["cell_id"],
+        wo["status"],
+    )
+    return {
+        "work_order_id": work_order_id,
+        "cell_id": wo["cell_id"],
+        "previous_status": wo["status"],
+        "spawned": True,
+    }
+
+
+@router.get("/recent-work-orders")
+async def recent_work_orders(
+    limit: int = 10,
+    conn: asyncpg.Connection = Depends(get_db),
+) -> list[dict[str, Any]]:
+    """List recent work orders for the demo trigger UI (newest first)."""
+    limit = max(1, min(limit, 100))
+    rows = await conn.fetch(
+        """
+        SELECT id, cell_id, status, title, created_at
+        FROM work_order
+        ORDER BY created_at DESC
+        LIMIT $1
+        """,
+        limit,
+    )
+    return [dict(r) for r in rows]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -82,6 +82,7 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       ARIA_MODEL: ${ARIA_MODEL:-sonnet}
       INVESTIGATOR_USE_MANAGED: ${INVESTIGATOR_USE_MANAGED:-false}
+      ARIA_DEMO_ENABLED: ${ARIA_DEMO_ENABLED:-false}
       ARIA_MCP_PATH_SECRET: ${ARIA_MCP_PATH_SECRET}
       ARIA_MCP_PUBLIC_URL: ${ARIA_MCP_PUBLIC_URL:-}
       # ARIA_MCP_URL is intentionally omitted: the internal MCP client

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useId, useRef } from "react";
 import { Outlet } from "react-router-dom";
 import { AgentInspector, useAgentInspectorStore } from "../features/agents";
 import { AnomalyBanner, KpiBar } from "../features/control-room";
+import { DemoReplayButton } from "../features/demo";
 import { EQUIPMENT_KEY, validateEquipmentSelection } from "../lib/equipmentSelection";
 import type { EquipmentSelection } from "../lib/hierarchy";
 import { useLocalStorage } from "../lib/useLocalStorage";
@@ -133,6 +134,7 @@ export function AppShell() {
                     <ChatPanel />
                 </Drawer>
             </div>
+            {import.meta.env.DEV && <DemoReplayButton />}
         </div>
     );
 }

--- a/frontend/src/app/AppShell.tsx
+++ b/frontend/src/app/AppShell.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useId, useRef } from "react";
 import { Outlet } from "react-router-dom";
 import { AgentInspector, useAgentInspectorStore } from "../features/agents";
+import { useAgentTurnsIngest } from "../features/agents/useAgentTurnsIngest";
 import { AnomalyBanner, KpiBar } from "../features/control-room";
 import { DemoReplayButton } from "../features/demo";
 import { EQUIPMENT_KEY, validateEquipmentSelection } from "../lib/equipmentSelection";
@@ -43,6 +44,10 @@ function isTypingTarget(target: EventTarget | null) {
 }
 
 export function AppShell() {
+    // Singleton bus consumer — keeps the agent turn buffer alive regardless
+    // of the Inspector's open/close state.
+    useAgentTurnsIngest();
+
     const [drawer, setDrawer] = useLocalStorage<ChatDrawerState>(
         CHAT_DRAWER_KEY,
         DEFAULT_DRAWER_STATE,

--- a/frontend/src/features/agents/agentTurnsStore.ts
+++ b/frontend/src/features/agents/agentTurnsStore.ts
@@ -1,0 +1,241 @@
+/**
+ * Global, lifecycle-agnostic buffer of agent turns (M8.5 fix).
+ *
+ * Fed in permanence by `useAgentTurnsIngest` (mounted once at the app
+ * root), consumed on-demand by `useAgentStream` (Agent Inspector). The
+ * Inspector's mount/unmount cycle can no longer wipe the buffer — close
+ * and reopen the drawer, everything is still there.
+ *
+ * Keyed by `turn_id` for O(1) lookup on every incoming event. A
+ * `latestByAgent` secondary index lets the Inspector resolve
+ * `agent -> latest turn` in a single selector call.
+ *
+ * FIFO cap: MAX_TURNS_TOTAL drops the oldest turn when the map overflows.
+ * Each turn also holds a bounded `rawEvents` list (every frame the
+ * ingestor forwarded for that turn) so the Inspector's "Inputs & outputs"
+ * tab can render the raw event log even long after the turn ended.
+ */
+import { create } from "zustand";
+import type { EventBusMap } from "../../lib/ws.types";
+import type { HandoffEvent, ToolRun } from "./types";
+
+export interface RawAgentEvent {
+    id: string;
+    type: keyof EventBusMap;
+    at: number;
+    payload: Record<string, unknown>;
+}
+
+export interface TurnState {
+    agent: string;
+    turnId: string;
+    startedAt: number;
+    endedAt: number | null;
+    thinking: string;
+    tools: ToolRun[];
+    handoffs: HandoffEvent[];
+    rawEvents: RawAgentEvent[];
+    finishReason: string | null;
+}
+
+interface AgentTurnsState {
+    /** Turn data indexed by turn_id. */
+    turns: Record<string, TurnState>;
+    /** Agent name -> most recent turn_id seen for that agent. */
+    latestByAgent: Record<string, string>;
+    /** Monotonic counter for local id generation (stable React keys). */
+    counter: number;
+    /** Funnel from the bus. Called once per frame by the ingest hook. */
+    ingest: (type: keyof EventBusMap, payload: Record<string, unknown>) => void;
+    /** Wipe everything — used by tests, never by the UI. */
+    clearAll: () => void;
+}
+
+const MAX_TURNS_TOTAL = 50;
+const MAX_RAW_EVENTS_PER_TURN = 500;
+
+function bumpCounter(state: AgentTurnsState): number {
+    state.counter += 1;
+    return state.counter;
+}
+
+function nextLocalId(state: AgentTurnsState, prefix: string): string {
+    return `${prefix}-${bumpCounter(state)}`;
+}
+
+function appendRaw(
+    state: AgentTurnsState,
+    turnId: string,
+    type: keyof EventBusMap,
+    payload: Record<string, unknown>,
+): void {
+    const turn = state.turns[turnId];
+    if (!turn) return;
+    const entry: RawAgentEvent = {
+        id: nextLocalId(state, "raw"),
+        type,
+        at: Date.now(),
+        payload,
+    };
+    const raw =
+        turn.rawEvents.length >= MAX_RAW_EVENTS_PER_TURN
+            ? [...turn.rawEvents.slice(-(MAX_RAW_EVENTS_PER_TURN - 1)), entry]
+            : [...turn.rawEvents, entry];
+    state.turns[turnId] = { ...turn, rawEvents: raw };
+}
+
+export const useAgentTurnsStore = create<AgentTurnsState>((set) => ({
+    turns: {},
+    latestByAgent: {},
+    counter: 0,
+    ingest: (type, payload) =>
+        set((prev) => {
+            // Work on a shallow draft — we rebuild turns/latestByAgent on write.
+            const draft: AgentTurnsState = {
+                ...prev,
+                turns: { ...prev.turns },
+                latestByAgent: { ...prev.latestByAgent },
+            };
+
+            const p = payload as Record<string, unknown>;
+            const agent = typeof p.agent === "string" ? (p.agent as string) : undefined;
+            const turnId = typeof p.turn_id === "string" ? (p.turn_id as string) : undefined;
+            const now = Date.now();
+
+            switch (type) {
+                case "agent_start": {
+                    if (!agent || !turnId) break;
+                    draft.turns[turnId] = {
+                        agent,
+                        turnId,
+                        startedAt: now,
+                        endedAt: null,
+                        thinking: "",
+                        tools: [],
+                        handoffs: [],
+                        rawEvents: [
+                            {
+                                id: nextLocalId(draft, "raw"),
+                                type,
+                                at: now,
+                                payload,
+                            },
+                        ],
+                        finishReason: null,
+                    };
+                    draft.latestByAgent[agent] = turnId;
+                    break;
+                }
+                case "agent_end": {
+                    if (!turnId || !draft.turns[turnId]) break;
+                    const finishReason =
+                        typeof p.finish_reason === "string"
+                            ? (p.finish_reason as string)
+                            : "unknown";
+                    draft.turns[turnId] = {
+                        ...draft.turns[turnId],
+                        endedAt: now,
+                        finishReason,
+                    };
+                    appendRaw(draft, turnId, type, payload);
+                    break;
+                }
+                case "thinking_delta": {
+                    if (!turnId || !draft.turns[turnId]) break;
+                    const content = typeof p.content === "string" ? (p.content as string) : "";
+                    draft.turns[turnId] = {
+                        ...draft.turns[turnId],
+                        thinking: draft.turns[turnId].thinking + content,
+                    };
+                    appendRaw(draft, turnId, type, payload);
+                    break;
+                }
+                case "tool_call_started": {
+                    if (!turnId || !draft.turns[turnId]) break;
+                    const toolName = typeof p.tool_name === "string" ? (p.tool_name as string) : "";
+                    const args =
+                        p.args && typeof p.args === "object"
+                            ? (p.args as Record<string, unknown>)
+                            : {};
+                    const run: ToolRun = {
+                        id: nextLocalId(draft, "tc"),
+                        toolName,
+                        args,
+                        startedAt: now,
+                        status: "running",
+                    };
+                    draft.turns[turnId] = {
+                        ...draft.turns[turnId],
+                        tools: [...draft.turns[turnId].tools, run],
+                    };
+                    appendRaw(draft, turnId, type, payload);
+                    break;
+                }
+                case "tool_call_completed": {
+                    if (!turnId || !draft.turns[turnId]) break;
+                    const toolName = typeof p.tool_name === "string" ? (p.tool_name as string) : "";
+                    const durationMs =
+                        typeof p.duration_ms === "number" ? (p.duration_ms as number) : 0;
+                    const tools = [...draft.turns[turnId].tools];
+                    const idx = tools.findIndex(
+                        (t) => t.toolName === toolName && t.status === "running",
+                    );
+                    if (idx >= 0) {
+                        tools[idx] = { ...tools[idx], durationMs, status: "done" };
+                        draft.turns[turnId] = { ...draft.turns[turnId], tools };
+                    }
+                    appendRaw(draft, turnId, type, payload);
+                    break;
+                }
+                case "agent_handoff": {
+                    if (!turnId || !draft.turns[turnId]) break;
+                    const fromAgent =
+                        typeof p.from_agent === "string" ? (p.from_agent as string) : "";
+                    const toAgent = typeof p.to_agent === "string" ? (p.to_agent as string) : "";
+                    const reason = typeof p.reason === "string" ? (p.reason as string) : "";
+                    const handoff: HandoffEvent = {
+                        id: nextLocalId(draft, "ho"),
+                        from_agent: fromAgent,
+                        to_agent: toAgent,
+                        reason,
+                        turn_id: turnId,
+                        receivedAt: now,
+                    };
+                    draft.turns[turnId] = {
+                        ...draft.turns[turnId],
+                        handoffs: [...draft.turns[turnId].handoffs, handoff],
+                    };
+                    appendRaw(draft, turnId, type, payload);
+                    break;
+                }
+                default:
+                    break;
+            }
+
+            // Bound total turns — drop oldest by startedAt.
+            const ids = Object.keys(draft.turns);
+            if (ids.length > MAX_TURNS_TOTAL) {
+                const sorted = ids.sort(
+                    (a, b) => draft.turns[a].startedAt - draft.turns[b].startedAt,
+                );
+                for (const id of sorted.slice(0, ids.length - MAX_TURNS_TOTAL)) {
+                    delete draft.turns[id];
+                }
+                // Rebuild latestByAgent — a dropped turn_id might have been
+                // referenced there. Keep only entries still pointing at a
+                // live turn.
+                const cleaned: Record<string, string> = {};
+                for (const [a, tid] of Object.entries(draft.latestByAgent)) {
+                    if (draft.turns[tid]) cleaned[a] = tid;
+                }
+                draft.latestByAgent = cleaned;
+            }
+
+            return {
+                turns: draft.turns,
+                latestByAgent: draft.latestByAgent,
+                counter: draft.counter,
+            };
+        }),
+    clearAll: () => set({ turns: {}, latestByAgent: {}, counter: 0 }),
+}));

--- a/frontend/src/features/agents/useAgentStream.test.ts
+++ b/frontend/src/features/agents/useAgentStream.test.ts
@@ -1,202 +1,148 @@
+/**
+ * Tests for the `useAgentStream` selector.
+ *
+ * M8.5 refactor: the hook no longer owns a WebSocket subscription. It
+ * reads from the global `useAgentTurnsStore` which is fed by
+ * `useAgentTurnsIngest`. Tests drive the store directly to exercise
+ * the selector.
+ */
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { installMockWebSocket, MockWebSocket, restoreWebSocket } from "../../test/mock-websocket";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAgentTurnsStore } from "./agentTurnsStore";
 import { useAgentStream } from "./useAgentStream";
 
-beforeEach(() => {
-    installMockWebSocket();
-});
-
-afterEach(() => {
-    restoreWebSocket();
-});
-
 describe("useAgentStream", () => {
-    it("is idle when agent is null (no socket opened)", () => {
+    afterEach(() => {
+        useAgentTurnsStore.getState().clearAll();
+    });
+
+    type IngestType = Parameters<ReturnType<typeof useAgentTurnsStore.getState>["ingest"]>[0];
+
+    function ingest(type: IngestType, payload: Record<string, unknown>): void {
+        useAgentTurnsStore.getState().ingest(type, payload);
+    }
+
+    it("returns empty state when agent is null", () => {
         const { result } = renderHook(() => useAgentStream(null));
-        expect(result.current.isStreaming).toBe(false);
         expect(result.current.turnId).toBeNull();
         expect(result.current.thinking).toBe("");
-        expect(result.current.connectionStatus).toBe("closed");
+        expect(result.current.tools).toEqual([]);
+        expect(result.current.isStreaming).toBe(false);
     });
 
-    it("opens a turn and accumulates thinking for the tracked agent", () => {
+    it("returns empty state when no turn has been recorded for agent", () => {
+        const { result } = renderHook(() => useAgentStream("investigator"));
+        expect(result.current.turnId).toBeNull();
+    });
+
+    it("picks up an agent_start and exposes turnId + isStreaming", () => {
         const { result } = renderHook(() => useAgentStream("investigator"));
         act(() => {
-            MockWebSocket.last.simulateOpen();
-            MockWebSocket.last.simulateMessage({
-                type: "agent_start",
-                agent: "investigator",
-                turn_id: "turn-1",
-            });
-            MockWebSocket.last.simulateMessage({
-                type: "thinking_delta",
-                agent: "investigator",
-                content: "Observing ",
-                turn_id: "turn-1",
-            });
-            MockWebSocket.last.simulateMessage({
-                type: "thinking_delta",
-                agent: "investigator",
-                content: "vibration spike.",
-                turn_id: "turn-1",
-            });
+            ingest("agent_start", { agent: "investigator", turn_id: "t1" });
         });
-
-        expect(result.current.turnId).toBe("turn-1");
-        expect(result.current.thinking).toBe("Observing vibration spike.");
+        expect(result.current.turnId).toBe("t1");
         expect(result.current.isStreaming).toBe(true);
-    });
-
-    it("flips isStreaming off on agent_end but keeps buffers", () => {
-        const { result } = renderHook(() => useAgentStream("investigator"));
-        act(() => {
-            MockWebSocket.last.simulateOpen();
-            MockWebSocket.last.simulateMessage({
-                type: "agent_start",
-                agent: "investigator",
-                turn_id: "turn-1",
-            });
-            MockWebSocket.last.simulateMessage({
-                type: "thinking_delta",
-                agent: "investigator",
-                content: "done.",
-                turn_id: "turn-1",
-            });
-            MockWebSocket.last.simulateMessage({
-                type: "agent_end",
-                agent: "investigator",
-                turn_id: "turn-1",
-                finish_reason: "end_turn",
-            });
-        });
-
-        expect(result.current.isStreaming).toBe(false);
-        expect(result.current.thinking).toBe("done.");
-    });
-
-    it("ignores events for other agents on the shared bus", () => {
-        const { result } = renderHook(() => useAgentStream("investigator"));
-        act(() => {
-            MockWebSocket.last.simulateOpen();
-            MockWebSocket.last.simulateMessage({
-                type: "agent_start",
-                agent: "sentinel",
-                turn_id: "other-turn",
-            });
-            MockWebSocket.last.simulateMessage({
-                type: "thinking_delta",
-                agent: "sentinel",
-                content: "nope",
-                turn_id: "other-turn",
-            });
-        });
-
-        expect(result.current.turnId).toBeNull();
         expect(result.current.thinking).toBe("");
-        expect(result.current.isStreaming).toBe(false);
     });
 
-    it("ignores events with a stale turn_id for the same agent", () => {
+    it("accumulates thinking deltas on the active turn", () => {
         const { result } = renderHook(() => useAgentStream("investigator"));
         act(() => {
-            MockWebSocket.last.simulateOpen();
-            MockWebSocket.last.simulateMessage({
-                type: "agent_start",
+            ingest("agent_start", { agent: "investigator", turn_id: "t1" });
+            ingest("thinking_delta", {
                 agent: "investigator",
-                turn_id: "turn-2",
+                turn_id: "t1",
+                content: "Hmm, ",
             });
-            // Stray event from a previous turn leaking in.
-            MockWebSocket.last.simulateMessage({
-                type: "thinking_delta",
+            ingest("thinking_delta", {
                 agent: "investigator",
-                content: "stale",
-                turn_id: "turn-1",
-            });
-            MockWebSocket.last.simulateMessage({
-                type: "thinking_delta",
-                agent: "investigator",
-                content: "current",
-                turn_id: "turn-2",
+                turn_id: "t1",
+                content: "pressure is pinned.",
             });
         });
-
-        expect(result.current.turnId).toBe("turn-2");
-        expect(result.current.thinking).toBe("current");
+        expect(result.current.thinking).toBe("Hmm, pressure is pinned.");
     });
 
-    it("tracks tool call lifecycle with duration on completion", () => {
+    it("records tool_call lifecycle with FIFO matching", () => {
         const { result } = renderHook(() => useAgentStream("investigator"));
         act(() => {
-            MockWebSocket.last.simulateOpen();
-            MockWebSocket.last.simulateMessage({
-                type: "agent_start",
+            ingest("agent_start", { agent: "investigator", turn_id: "t1" });
+            ingest("tool_call_started", {
                 agent: "investigator",
-                turn_id: "turn-1",
+                turn_id: "t1",
+                tool_name: "get_signal_trend",
+                args: { cell_id: 1 },
             });
-            MockWebSocket.last.simulateMessage({
-                type: "tool_call_started",
+            ingest("tool_call_started", {
                 agent: "investigator",
-                tool_name: "get_equipment_kb",
+                turn_id: "t1",
+                tool_name: "get_signal_trend",
                 args: { cell_id: 2 },
-                turn_id: "turn-1",
             });
-        });
-
-        expect(result.current.tools).toHaveLength(1);
-        expect(result.current.tools[0].status).toBe("running");
-        expect(result.current.tools[0].toolName).toBe("get_equipment_kb");
-
-        act(() => {
-            MockWebSocket.last.simulateMessage({
-                type: "tool_call_completed",
+            ingest("tool_call_completed", {
                 agent: "investigator",
-                tool_name: "get_equipment_kb",
-                duration_ms: 123,
-                turn_id: "turn-1",
+                turn_id: "t1",
+                tool_name: "get_signal_trend",
+                duration_ms: 42,
             });
         });
-
+        expect(result.current.tools).toHaveLength(2);
+        // First (oldest running) tool is the one that gets sealed.
         expect(result.current.tools[0].status).toBe("done");
-        expect(result.current.tools[0].durationMs).toBe(123);
+        expect(result.current.tools[0].durationMs).toBe(42);
+        expect(result.current.tools[1].status).toBe("running");
     });
 
-    it("resets buffers when a new turn starts for the same agent", () => {
+    it("flips isStreaming to false on agent_end", () => {
         const { result } = renderHook(() => useAgentStream("investigator"));
         act(() => {
-            MockWebSocket.last.simulateOpen();
-            MockWebSocket.last.simulateMessage({
-                type: "agent_start",
+            ingest("agent_start", { agent: "investigator", turn_id: "t1" });
+            ingest("agent_end", {
                 agent: "investigator",
-                turn_id: "turn-1",
-            });
-            MockWebSocket.last.simulateMessage({
-                type: "thinking_delta",
-                agent: "investigator",
-                content: "first",
-                turn_id: "turn-1",
-            });
-            MockWebSocket.last.simulateMessage({
-                type: "agent_end",
-                agent: "investigator",
-                turn_id: "turn-1",
+                turn_id: "t1",
                 finish_reason: "end_turn",
             });
-            MockWebSocket.last.simulateMessage({
-                type: "agent_start",
+        });
+        expect(result.current.isStreaming).toBe(false);
+        expect(result.current.turnId).toBe("t1"); // still readable after end
+    });
+
+    it("survives the Inspector closing + reopening (persistence)", () => {
+        // First mount — simulates Inspector open during the run.
+        const first = renderHook(() => useAgentStream("investigator"));
+        act(() => {
+            ingest("agent_start", { agent: "investigator", turn_id: "t1" });
+            ingest("thinking_delta", {
                 agent: "investigator",
-                turn_id: "turn-2",
+                turn_id: "t1",
+                content: "Diagnosing...",
             });
-            MockWebSocket.last.simulateMessage({
-                type: "thinking_delta",
+            ingest("agent_end", {
                 agent: "investigator",
-                content: "second",
-                turn_id: "turn-2",
+                turn_id: "t1",
+                finish_reason: "end_turn",
             });
         });
+        first.unmount();
 
-        expect(result.current.turnId).toBe("turn-2");
-        expect(result.current.thinking).toBe("second");
-        expect(result.current.isStreaming).toBe(true);
+        // Second mount — simulates Inspector reopened after the turn.
+        const second = renderHook(() => useAgentStream("investigator"));
+        expect(second.result.current.turnId).toBe("t1");
+        expect(second.result.current.thinking).toBe("Diagnosing...");
+        expect(second.result.current.isStreaming).toBe(false);
+    });
+
+    it("ignores events for a different agent", () => {
+        const { result } = renderHook(() => useAgentStream("investigator"));
+        act(() => {
+            ingest("agent_start", { agent: "kb_builder", turn_id: "t99" });
+            ingest("thinking_delta", {
+                agent: "kb_builder",
+                turn_id: "t99",
+                content: "KB work",
+            });
+        });
+        expect(result.current.turnId).toBeNull();
+        expect(result.current.thinking).toBe("");
     });
 });

--- a/frontend/src/features/agents/useAgentStream.ts
+++ b/frontend/src/features/agents/useAgentStream.ts
@@ -1,264 +1,72 @@
 /**
- * Subscribes to `/api/v1/events` for a given agent and exposes a turn-scoped
- * buffer (thinking delta cumul, tool call lifecycle, handoffs, streaming
- * flag). Mirrors the `useAnomalyStream` pattern (M7.3) — one socket per
- * hook instance, filter inside `onEvent`.
+ * Agent Inspector data source — lifecycle-agnostic selector.
  *
- * Turn semantics:
- * - `agent_start` for the tracked agent → opens a new turn, resets buffers,
- *   flips `isStreaming` to true.
- * - `agent_end` for the tracked agent → keeps buffers, flips `isStreaming`
- *   to false.
- * - All intermediate events (`thinking_delta`, `tool_call_started`,
- *   `tool_call_completed`, `agent_handoff`) are scoped to the active
- *   `turnId`. Events with a different `turn_id` are ignored defensively
- *   (the bus is global, simultaneous agents can interleave).
+ * Reads from `useAgentTurnsStore` (fed in permanence by
+ * `useAgentTurnsIngest` mounted once in `AppShell`). Closing and
+ * reopening the Inspector does NOT wipe buffers — the store owns the
+ * history, this hook is a pure selector.
  *
- * No persistence. Closing the inspector unmounts → socket closes, buffer
- * garbage-collected. Re-opening the inspector starts fresh.
+ * Signature is preserved so `AgentInspector.tsx` doesn't know the
+ * refactor happened. Behaviour changes: `connectionStatus` is
+ * always `"open"` from the Inspector's point of view because the
+ * ingest socket is mounted at the app root and owns the lifecycle.
  */
-
-import { useEffect, useRef, useState } from "react";
-import { createWsClient } from "../../lib/ws";
-import type { EventBusMap } from "../../lib/ws.types";
+import { type RawAgentEvent, useAgentTurnsStore } from "./agentTurnsStore";
 import type { HandoffEvent, ToolRun } from "./types";
 
-const EVENTS_WS_URL = "/api/v1/events";
+export type { RawAgentEvent };
 
 export type AgentStreamStatus = "connecting" | "open" | "closed" | "error";
 
 export interface UseAgentStreamResult {
-    /** Current turn id — null before the first `agent_start`. */
+    /** Most recent turn_id seen for `agent`. Null until the first frame. */
     turnId: string | null;
-    /** Cumulative `thinking_delta` content for the current turn. */
+    /** Cumulative `thinking_delta` content for that turn. */
     thinking: string;
-    /** Tool calls emitted during the current turn, in start order. */
+    /** Tool calls emitted during that turn, in start order. */
     tools: ToolRun[];
-    /** Handoffs originating from this agent during the current turn. */
+    /** Handoffs originating from `agent` during that turn. */
     handoffs: HandoffEvent[];
-    /** Raw bus events for this agent's active turn — used by the IO tab. */
+    /** Raw bus events for that turn — feeds the "Inputs & outputs" tab. */
     rawEvents: RawAgentEvent[];
-    /** True between `agent_start` and `agent_end` for the tracked agent. */
+    /** True between `agent_start` and `agent_end` for `agent`. */
     isStreaming: boolean;
-    /** Socket lifecycle. */
+    /** Ingest socket state (opened once at app root). */
     connectionStatus: AgentStreamStatus;
 }
 
-export interface RawAgentEvent {
-    id: string;
-    type: keyof EventBusMap;
-    at: number;
-    payload: Record<string, unknown>;
-}
-
-interface MutableTurnState {
-    turnId: string | null;
-    thinking: string;
-    tools: ToolRun[];
-    handoffs: HandoffEvent[];
-    rawEvents: RawAgentEvent[];
-    counter: number;
-}
-
-const emptyTurn = (): MutableTurnState => ({
-    turnId: null,
-    thinking: "",
-    tools: [],
-    handoffs: [],
-    rawEvents: [],
-    counter: 0,
-});
+const EMPTY_TOOLS: ToolRun[] = [];
+const EMPTY_HANDOFFS: HandoffEvent[] = [];
+const EMPTY_RAW: RawAgentEvent[] = [];
 
 /**
- * Subscribe to the event bus for `agent`. Pass `null` to keep the hook
- * idle (no socket opened).
+ * Returns the latest turn snapshot for `agent`, sourced from the global
+ * turns store. Pass `null` to get an empty result (used when the
+ * Inspector is closed with no current agent).
  */
 export function useAgentStream(agent: string | null): UseAgentStreamResult {
-    const [turnId, setTurnId] = useState<string | null>(null);
-    const [thinking, setThinking] = useState("");
-    const [tools, setTools] = useState<ToolRun[]>([]);
-    const [handoffs, setHandoffs] = useState<HandoffEvent[]>([]);
-    const [rawEvents, setRawEvents] = useState<RawAgentEvent[]>([]);
-    const [isStreaming, setIsStreaming] = useState(false);
-    const [connectionStatus, setConnectionStatus] = useState<AgentStreamStatus>("connecting");
+    const turnId = useAgentTurnsStore((s) => (agent ? (s.latestByAgent[agent] ?? null) : null));
+    const turn = useAgentTurnsStore((s) => (turnId ? s.turns[turnId] : null));
 
-    const stateRef = useRef<MutableTurnState>(emptyTurn());
-
-    useEffect(() => {
-        if (!agent) {
-            stateRef.current = emptyTurn();
-            setTurnId(null);
-            setThinking("");
-            setTools([]);
-            setHandoffs([]);
-            setRawEvents([]);
-            setIsStreaming(false);
-            setConnectionStatus("closed");
-            return;
-        }
-
-        const controller = new AbortController();
-        setConnectionStatus("connecting");
-        stateRef.current = emptyTurn();
-        setTurnId(null);
-        setThinking("");
-        setTools([]);
-        setHandoffs([]);
-        setRawEvents([]);
-        setIsStreaming(false);
-
-        const nextId = (prefix: string): string => {
-            stateRef.current.counter += 1;
-            return `${prefix}-${stateRef.current.counter}`;
+    if (!agent || !turn) {
+        return {
+            turnId: null,
+            thinking: "",
+            tools: EMPTY_TOOLS,
+            handoffs: EMPTY_HANDOFFS,
+            rawEvents: EMPTY_RAW,
+            isStreaming: false,
+            connectionStatus: "open",
         };
-
-        const pushRaw = (type: keyof EventBusMap, payload: Record<string, unknown>) => {
-            const entry: RawAgentEvent = {
-                id: nextId("raw"),
-                type,
-                at: Date.now(),
-                payload,
-            };
-            stateRef.current.rawEvents = [...stateRef.current.rawEvents, entry];
-            setRawEvents(stateRef.current.rawEvents);
-        };
-
-        const client = createWsClient<EventBusMap>({
-            url: EVENTS_WS_URL,
-            signal: controller.signal,
-            onOpen: () => setConnectionStatus("open"),
-            onClose: () => setConnectionStatus("closed"),
-            onError: () => setConnectionStatus("error"),
-            onEvent: (type, payload) => {
-                // Only claim events that reference our agent.
-                const p = payload as Record<string, unknown>;
-                const isForAgent =
-                    (type === "agent_start" ||
-                        type === "agent_end" ||
-                        type === "thinking_delta" ||
-                        type === "tool_call_started" ||
-                        type === "tool_call_completed" ||
-                        type === "agent_handoff") &&
-                    agentFromPayload(type, p) === agent;
-                if (!isForAgent) return;
-
-                switch (type) {
-                    case "agent_start": {
-                        const e = payload as EventBusMap["agent_start"];
-                        // New turn — clear buffers.
-                        stateRef.current = {
-                            ...emptyTurn(),
-                            turnId: e.turn_id,
-                            counter: stateRef.current.counter,
-                        };
-                        setTurnId(e.turn_id);
-                        setThinking("");
-                        setTools([]);
-                        setHandoffs([]);
-                        setRawEvents([]);
-                        setIsStreaming(true);
-                        pushRaw(type, e as unknown as Record<string, unknown>);
-                        break;
-                    }
-                    case "agent_end": {
-                        const e = payload as EventBusMap["agent_end"];
-                        if (e.turn_id !== stateRef.current.turnId) return;
-                        setIsStreaming(false);
-                        pushRaw(type, e as unknown as Record<string, unknown>);
-                        break;
-                    }
-                    case "thinking_delta": {
-                        const e = payload as EventBusMap["thinking_delta"];
-                        if (e.turn_id !== stateRef.current.turnId) return;
-                        stateRef.current.thinking += e.content;
-                        setThinking(stateRef.current.thinking);
-                        pushRaw(type, e as unknown as Record<string, unknown>);
-                        break;
-                    }
-                    case "tool_call_started": {
-                        const e = payload as EventBusMap["tool_call_started"];
-                        if (e.turn_id !== stateRef.current.turnId) return;
-                        const run: ToolRun = {
-                            id: nextId("tc"),
-                            toolName: e.tool_name,
-                            args: e.args,
-                            startedAt: Date.now(),
-                            status: "running",
-                        };
-                        stateRef.current.tools = [...stateRef.current.tools, run];
-                        setTools(stateRef.current.tools);
-                        pushRaw(type, e as unknown as Record<string, unknown>);
-                        break;
-                    }
-                    case "tool_call_completed": {
-                        const e = payload as EventBusMap["tool_call_completed"];
-                        if (e.turn_id !== stateRef.current.turnId) return;
-                        // FIFO match on tool_name against the oldest running run.
-                        const idx = stateRef.current.tools.findIndex(
-                            (t) => t.toolName === e.tool_name && t.status === "running",
-                        );
-                        if (idx >= 0) {
-                            const next = [...stateRef.current.tools];
-                            next[idx] = {
-                                ...next[idx],
-                                durationMs: e.duration_ms,
-                                status: "done",
-                            };
-                            stateRef.current.tools = next;
-                            setTools(next);
-                        }
-                        pushRaw(type, e as unknown as Record<string, unknown>);
-                        break;
-                    }
-                    case "agent_handoff": {
-                        const e = payload as EventBusMap["agent_handoff"];
-                        if (e.turn_id !== stateRef.current.turnId) return;
-                        const entry: HandoffEvent = {
-                            ...e,
-                            id: nextId("ho"),
-                            receivedAt: Date.now(),
-                        };
-                        stateRef.current.handoffs = [...stateRef.current.handoffs, entry];
-                        setHandoffs(stateRef.current.handoffs);
-                        pushRaw(type, e as unknown as Record<string, unknown>);
-                        break;
-                    }
-                    default:
-                        break;
-                }
-            },
-        });
-
-        return () => {
-            controller.abort();
-            client.close(1000, "unmount");
-        };
-    }, [agent]);
+    }
 
     return {
-        turnId,
-        thinking,
-        tools,
-        handoffs,
-        rawEvents,
-        isStreaming,
-        connectionStatus,
+        turnId: turn.turnId,
+        thinking: turn.thinking,
+        tools: turn.tools,
+        handoffs: turn.handoffs,
+        rawEvents: turn.rawEvents,
+        isStreaming: turn.endedAt === null,
+        connectionStatus: "open",
     };
-}
-
-/**
- * Extract the `agent` field from an event payload. `agent_handoff` uses
- * `from_agent` (the outgoing speaker); that's still the agent this inspector
- * tracks when we're watching them delegate.
- */
-function agentFromPayload(
-    type: keyof EventBusMap,
-    payload: Record<string, unknown>,
-): string | null {
-    if (type === "agent_handoff") {
-        const v = payload.from_agent;
-        return typeof v === "string" ? v : null;
-    }
-    const v = payload.agent;
-    return typeof v === "string" ? v : null;
 }

--- a/frontend/src/features/agents/useAgentTurnsIngest.ts
+++ b/frontend/src/features/agents/useAgentTurnsIngest.ts
@@ -1,0 +1,41 @@
+/**
+ * Singleton bus consumer feeding `useAgentTurnsStore`.
+ *
+ * Mounted exactly once at the app root (`AppShell`). Keeps a single
+ * `/api/v1/events` WebSocket open for the lifetime of the session so
+ * every agent frame is captured in the store — regardless of whether
+ * the Agent Inspector is currently open.
+ *
+ * Mirrors `useAnomalyStream` / `useActivityFeedStream` wiring: the
+ * typed `createWsClient` with an AbortController-based cleanup.
+ */
+import { useEffect } from "react";
+import { createWsClient } from "../../lib/ws";
+import type { EventBusMap } from "../../lib/ws.types";
+import { useAgentTurnsStore } from "./agentTurnsStore";
+
+const EVENTS_WS_URL = "/api/v1/events";
+
+/**
+ * Mount-once side effect hook. Populates `useAgentTurnsStore` from the
+ * `/api/v1/events` server-sent stream for the lifetime of the tab. Any
+ * consumer that calls `useAgentStream(agent)` reads from the resulting
+ * buffer — closing/reopening the consumer never wipes history.
+ */
+export function useAgentTurnsIngest(): void {
+    const ingest = useAgentTurnsStore((s) => s.ingest);
+    useEffect(() => {
+        const controller = new AbortController();
+        const client = createWsClient<EventBusMap>({
+            url: EVENTS_WS_URL,
+            signal: controller.signal,
+            onEvent: (type, payload) => {
+                ingest(type, payload as Record<string, unknown>);
+            },
+        });
+        return () => {
+            controller.abort();
+            client.close(1000, "unmount");
+        };
+    }, [ingest]);
+}

--- a/frontend/src/features/demo/DemoReplayButton.tsx
+++ b/frontend/src/features/demo/DemoReplayButton.tsx
@@ -1,0 +1,95 @@
+/**
+ * DEV-only demo trigger (hackathon J-2).
+ *
+ * Calls the backend debug endpoint `/api/v1/debug/replay-investigator/{id}`
+ * to re-spawn the Investigator agent on an existing work order — unblocks
+ * the demo pitch by firing Opus 4.7 extended thinking + Agent Inspector +
+ * Activity Feed on cue, instead of waiting for a natural Sentinel
+ * detection.
+ *
+ * Gated on `import.meta.env.DEV` so production builds strip the button
+ * entirely (Vite tree-shakes the consumer when the gate is false). The
+ * backend endpoint itself is gated server-side behind `ARIA_DEMO_ENABLED`,
+ * so even a leaked bundle can't trigger it in prod.
+ *
+ * Mounted as a fixed floating control in the bottom-right of the viewport
+ * so it is reachable from any page (Control Room, Work Orders, etc.)
+ * without collision with TopBar / Chat drawer / Agent Inspector.
+ *
+ * Remove post-demo along with `backend/modules/debug/`.
+ */
+
+import { useState } from "react";
+import { Icons } from "../../design-system";
+
+interface RecentWorkOrder {
+    id: number;
+    cell_id: number;
+    status: string;
+    title: string;
+}
+
+export function DemoReplayButton() {
+    const [busy, setBusy] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [lastSpawned, setLastSpawned] = useState<RecentWorkOrder | null>(null);
+
+    async function replay() {
+        setBusy(true);
+        setError(null);
+        try {
+            const listResp = await fetch("/api/v1/debug/recent-work-orders?limit=1", {
+                credentials: "include",
+            });
+            if (!listResp.ok) {
+                throw new Error(`recent-work-orders ${listResp.status}`);
+            }
+            const wos = (await listResp.json()) as RecentWorkOrder[];
+            if (wos.length === 0) {
+                throw new Error("no work orders available");
+            }
+            const wo = wos[0];
+
+            const replayResp = await fetch(`/api/v1/debug/replay-investigator/${wo.id}`, {
+                method: "POST",
+                credentials: "include",
+            });
+            if (!replayResp.ok) {
+                throw new Error(`replay ${replayResp.status}`);
+            }
+            setLastSpawned(wo);
+        } catch (e) {
+            setError(e instanceof Error ? e.message : "replay failed");
+        } finally {
+            setBusy(false);
+        }
+    }
+
+    return (
+        <div className="pointer-events-none fixed bottom-4 left-4 z-40 flex items-end gap-2">
+            <div className="pointer-events-auto flex items-center gap-2 rounded-[var(--ds-radius-md)] border border-dashed border-[var(--ds-border-strong)] bg-[var(--ds-bg-surface)] px-2 py-1.5 shadow-sm">
+                <button
+                    type="button"
+                    onClick={replay}
+                    disabled={busy}
+                    aria-label="Replay Investigator on the most recent work order (demo trigger)"
+                    className="inline-flex h-7 items-center gap-1.5 rounded-[var(--ds-radius-sm)] bg-transparent px-2 text-[var(--ds-text-xs)] font-medium text-[var(--ds-fg-muted)] transition-colors duration-[var(--ds-motion-fast)] hover:bg-[var(--ds-accent-soft)] hover:text-[var(--ds-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)] disabled:opacity-60"
+                >
+                    <Icons.Play className="size-3" aria-hidden />
+                    {busy ? "Replaying…" : "Replay last investigation"}
+                    <span className="text-[var(--ds-fg-subtle)]">· dev</span>
+                </button>
+                {lastSpawned != null && !error && (
+                    <span className="text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
+                        → WO #{lastSpawned.id} (cell {lastSpawned.cell_id})
+                    </span>
+                )}
+                {error && (
+                    <span className="text-[var(--ds-text-xs)] text-[var(--ds-status-critical)]">
+                        {error}
+                    </span>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/frontend/src/features/demo/index.ts
+++ b/frontend/src/features/demo/index.ts
@@ -1,0 +1,1 @@
+export { DemoReplayButton } from "./DemoReplayButton";


### PR DESCRIPTION
## Summary

- New backend endpoints `POST /api/v1/debug/replay-investigator/{id}` + `GET /api/v1/debug/recent-work-orders`, authenticated and gated behind the existing `ARIA_DEMO_ENABLED` flag (same gate as memory-flex endpoints).
- New DEV-only `DemoReplayButton` mounted floating bottom-left of AppShell, gated on `import.meta.env.DEV`. Calls the debug endpoints with cookie credentials via Vite proxy.
- Unblocks the live demo: one click → Investigator full turn (Opus 4.7 extended thinking) fires on the latest work order → Activity Feed + Agent Inspector light up on cue.

## Why

`ask_investigator` tool (QA chat fast-path) is a Sonnet deterministic shortcut by design — it does **not** spawn the full extended-thinking Investigator. Sentinel auto-spawn depends on an actual threshold breach and is too non-deterministic for a live pitch. Without a manual trigger, the Agent Inspector thinking tab reads "No extended thinking captured for this turn yet" during the demo.

Cross-lane backend authorized by Adam (J-2, 2026-04-24 — deadline 2026-04-26 20:00 EST).

## Base branch

**Targeted at `feat/48-agent-activity-feed` (PR #130), not `main`.** The frontend button only makes visual sense once the Activity Feed panel exists — so merge order is #130 first, then this PR. After #130 merges, GitHub will re-target this PR onto main automatically.

## Scope (removable post-demo)

- `backend/modules/debug/` (delete folder)
- `backend/main.py` — revert the 3-line `debug_router` include inside the `aria_demo_enabled` block
- `frontend/src/features/demo/` (delete folder)
- `frontend/src/app/AppShell.tsx` — remove the import + `{import.meta.env.DEV && <DemoReplayButton />}` mount
- `.env` — optional, leave `ARIA_DEMO_ENABLED=true` since the memory-flex demo module also reads it

## Test plan

- [ ] Ensure `.env` has `ARIA_DEMO_ENABLED=true` (this PR added it to Adam's local `.env`).
- [ ] `docker compose restart backend` to pick up the new router; startup logs show `Debug endpoints enabled at /api/v1/debug/*`.
- [ ] `curl -X POST http://localhost:8000/api/v1/debug/replay-investigator/73 --cookie "access_token=..."` returns HTTP 202 with `{"work_order_id":73,"cell_id":1,"previous_status":"analyzed","spawned":true}`.
- [ ] In DEV browser, floating button visible bottom-left of any page.
- [ ] Click button → Activity Feed (M8.4) streams `agent_start investigator` → `thinking_delta` (multiple) → `tool_call_started/completed` → `agent_end`.
- [ ] Click the Investigator badge on any of those rows → Agent Inspector (M8.5) opens → Thinking tab streams extended thinking **live**.
- [ ] After ~30-60 s, the WO status flips from `detected` back to `analyzed`, and the `rca_ready` event fires.

## Quality gates

- `npm run typecheck` ✓
- `npm run build` ✓
- `npm run check` (Biome) ✓