### PR TITLE
feat(demo): replay the full multi-agent flow on a single click

### DIFF
--- a/backend/modules/debug/router.py
+++ b/backend/modules/debug/router.py
@@ -1,27 +1,41 @@
 """Debug endpoints for the hackathon demo (J-2).
 
-Exposes a single trigger that re-spawns the Investigator agent on an
-existing work order so Adam can showcase Opus 4.7 extended thinking
-live during the pitch without waiting for a natural Sentinel detection.
-Also exposes a tiny listing endpoint so the frontend can grab the most
-recent work order to replay.
+Exposes a demo trigger that re-plays the full multi-agent flow on an
+existing work order:
 
-Scope is intentionally throwaway — keep this module out of production
-imports and remove post-demo. Auth stays on via `get_current_user` so
-the existing cookie/session path is reused (the frontend calls through
-Vite proxy with `credentials: "include"`).
+1. ``Sentinel`` broadcasts an ``anomaly_detected`` + ``ui_render(alert_banner)``
+   — the operator console lights up with the red banner.
+2. After a short dramatic pause, the ``Investigator`` agent spawns (Opus 4.7
+   extended thinking + tool loop), streaming ``thinking_delta`` chunks + tool
+   calls + render artifacts.
+3. On ``submit_rca``, the Investigator auto-chains the ``Work Order Generator``
+   which enriches the work order with recommended actions, parts, and skills.
+4. Optionally the Investigator hands off to the KB Builder via ``ask_kb_builder``
+   when it needs a threshold lookup — that handoff is already wired upstream,
+   we don't force it.
+
+The demo button on the frontend calls ``POST /api/v1/debug/replay-full-flow/{id}``
+to trigger the whole chain on cue. Also exposes a listing endpoint so the UI can
+pick the most recent WO to replay.
+
+Scope is intentionally throwaway — keep this module out of production imports
+and remove post-demo. Auth stays on via ``get_current_user`` so the existing
+cookie/session path is reused (the frontend calls through Vite proxy with
+``credentials: "include"``).
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import uuid
 from typing import Any
 
 import asyncpg
 from agents.investigator.service import run_investigator
 from core.database import get_db
 from core.security import get_current_user
+from core.ws_manager import ws_manager
 from fastapi import APIRouter, Depends, HTTPException
 
 log = logging.getLogger("aria.debug")
@@ -33,19 +47,142 @@ router = APIRouter(
 )
 
 
+async def _replay_full_flow(work_order_id: int, cell_id: int, cell_name: str) -> None:
+    """Background task running the full demo choreography.
+
+    Done as a separate coroutine so the HTTP endpoint returns 202 immediately
+    while the dramatic Sentinel → Investigator → Work Order Generator chain
+    plays out for the audience.
+    """
+    try:
+        # Replay the Sentinel banner as if a fresh anomaly just fired. The
+        # turn_id here is cosmetic — it correlates the anomaly_detected and
+        # alert_banner frames for the Activity Feed row.
+        sentinel_turn = uuid.uuid4().hex
+        await ws_manager.broadcast(
+            "anomaly_detected",
+            {
+                "cell_id": cell_id,
+                "signal_def_id": 0,
+                "value": 0.0,
+                "threshold": 0.0,
+                "work_order_id": work_order_id,
+                "time": "",
+                "severity": "alert",
+                "direction": "high",
+            },
+        )
+        await ws_manager.broadcast(
+            "ui_render",
+            {
+                "agent": "sentinel",
+                "component": "alert_banner",
+                "props": {
+                    "cell_id": cell_id,
+                    "severity": "alert",
+                    "message": (
+                        f"{cell_name}: anomaly replay triggered "
+                        f"— investigator dispatched"
+                    ),
+                    "anomaly_id": work_order_id,
+                },
+                "turn_id": sentinel_turn,
+            },
+        )
+        # Dramatic pause so the operator console can register the banner +
+        # activity feed row before the Investigator starts typing.
+        await asyncio.sleep(1.5)
+
+        # Spawn the full Investigator loop. It will:
+        #  - broadcast agent_start(investigator)
+        #  - stream thinking_delta chunks (Opus 4.7 extended thinking)
+        #  - tool_call_started / completed for get_signal_trend, get_equipment_kb,
+        #    get_failure_history, get_signal_anomalies, render_*, submit_rca…
+        #  - on submit_rca, auto-chain spawn_work_order_generator which drives
+        #    its own turn (agent_start(work_order_generator) → tool loop →
+        #    submit_work_order → agent_end)
+        #  - optionally agent_handoff to kb_builder via ask_kb_builder
+        await run_investigator(work_order_id)
+    except Exception:  # noqa: BLE001 — this is a background task, never re-raise
+        log.exception("debug replay full flow failed for WO %d", work_order_id)
+
+
+@router.post("/replay-full-flow/{work_order_id}", status_code=202)
+async def replay_full_flow(
+    work_order_id: int,
+    conn: asyncpg.Connection = Depends(get_db),
+) -> dict[str, Any]:
+    """Re-play the full demo flow on an existing work order.
+
+    Resets the WO status to ``detected`` first so the agent pipeline can walk
+    through the full broadcast sequence. Returns 202 immediately; the actual
+    choreography (Sentinel banner → Investigator thinking+tools → Work Order
+    Generator) runs in the background.
+    """
+    wo = await conn.fetchrow(
+        """
+        SELECT wo.id, wo.cell_id, wo.status, wo.title, c.name AS cell_name
+        FROM work_order wo
+        JOIN cell c ON c.id = wo.cell_id
+        WHERE wo.id = $1
+        """,
+        work_order_id,
+    )
+    if wo is None:
+        raise HTTPException(
+            status_code=404, detail=f"work_order {work_order_id} not found"
+        )
+
+    # Wipe prior RCA + enrichment so the agents have fresh work to do and the
+    # audience sees the work order populate from scratch during the demo.
+    await conn.execute(
+        """
+        UPDATE work_order
+        SET status = 'detected',
+            rca_summary = NULL,
+            recommended_actions = NULL,
+            required_parts = NULL,
+            required_skills = NULL,
+            estimated_duration_min = NULL
+        WHERE id = $1
+        """,
+        work_order_id,
+    )
+
+    asyncio.create_task(
+        _replay_full_flow(
+            work_order_id=work_order_id,
+            cell_id=wo["cell_id"],
+            cell_name=wo["cell_name"],
+        ),
+        name=f"debug-full-flow-wo-{work_order_id}",
+    )
+    log.info(
+        "debug replay-full-flow: spawned for WO %d (cell %d %s, prior status %s)",
+        work_order_id,
+        wo["cell_id"],
+        wo["cell_name"],
+        wo["status"],
+    )
+    return {
+        "work_order_id": work_order_id,
+        "cell_id": wo["cell_id"],
+        "cell_name": wo["cell_name"],
+        "previous_status": wo["status"],
+        "title": wo["title"],
+        "spawned": True,
+    }
+
+
+# Kept for backward compatibility with the previous button wiring — it still
+# does the core Investigator replay without the Sentinel pre-roll. The frontend
+# is expected to use /replay-full-flow/{id} for the demo pitch.
 @router.post("/replay-investigator/{work_order_id}", status_code=202)
 async def replay_investigator(
     work_order_id: int,
     conn: asyncpg.Connection = Depends(get_db),
 ) -> dict[str, Any]:
-    """Re-spawn the full Investigator agent on an existing work order.
-
-    Resets the WO status to ``detected`` first so the agent re-emits the
-    full broadcast sequence (``agent_start`` → ``thinking_delta`` →
-    ``tool_call_*`` → ``submit_rca`` → ``agent_end``). Returns 202 with
-    the scheduled task identifier; the actual run happens in the
-    background task.
-    """
+    """Re-spawn the full Investigator agent on an existing work order (legacy)."""
     wo = await conn.fetchrow(
         "SELECT id, cell_id, status FROM work_order WHERE id = $1",
         work_order_id,
@@ -60,8 +197,6 @@ async def replay_investigator(
         work_order_id,
     )
 
-    # Fire-and-forget — the endpoint returns immediately so the UI can
-    # start rendering `agent_start` as soon as the Investigator emits it.
     asyncio.create_task(
         run_investigator(work_order_id),
         name=f"debug-investigator-wo-{work_order_id}",

--- a/backend/modules/debug/router.py
+++ b/backend/modules/debug/router.py
@@ -81,8 +81,7 @@ async def _replay_full_flow(work_order_id: int, cell_id: int, cell_name: str) ->
                     "cell_id": cell_id,
                     "severity": "alert",
                     "message": (
-                        f"{cell_name}: anomaly replay triggered "
-                        f"— investigator dispatched"
+                        f"{cell_name}: anomaly replay triggered " f"— investigator dispatched"
                     ),
                     "anomaly_id": work_order_id,
                 },
@@ -129,9 +128,7 @@ async def replay_full_flow(
         work_order_id,
     )
     if wo is None:
-        raise HTTPException(
-            status_code=404, detail=f"work_order {work_order_id} not found"
-        )
+        raise HTTPException(status_code=404, detail=f"work_order {work_order_id} not found")
 
     # Wipe prior RCA + enrichment so the agents have fresh work to do and the
     # audience sees the work order populate from scratch during the demo.
@@ -188,9 +185,7 @@ async def replay_investigator(
         work_order_id,
     )
     if wo is None:
-        raise HTTPException(
-            status_code=404, detail=f"work_order {work_order_id} not found"
-        )
+        raise HTTPException(status_code=404, detail=f"work_order {work_order_id} not found")
 
     await conn.execute(
         "UPDATE work_order SET status = 'detected' WHERE id = $1",

--- a/frontend/src/features/demo/DemoReplayButton.tsx
+++ b/frontend/src/features/demo/DemoReplayButton.tsx
@@ -1,22 +1,25 @@
 /**
  * DEV-only demo trigger (hackathon J-2).
  *
- * Calls the backend debug endpoint `/api/v1/debug/replay-investigator/{id}`
- * to re-spawn the Investigator agent on an existing work order — unblocks
- * the demo pitch by firing Opus 4.7 extended thinking + Agent Inspector +
- * Activity Feed on cue, instead of waiting for a natural Sentinel
- * detection.
+ * Calls the backend debug endpoint `/api/v1/debug/replay-full-flow/{id}`
+ * to replay the full multi-agent choreography on an existing work order:
+ *
+ * 1. Sentinel broadcasts `anomaly_detected` + `ui_render(alert_banner)` —
+ *    the operator console lights up with the red banner.
+ * 2. Investigator spawns (Opus 4.7 extended thinking) — streaming
+ *    `thinking_delta` + tool calls + render artifacts + `submit_rca`.
+ * 3. Work Order Generator auto-chains post-RCA — enriches the WO with
+ *    recommended actions, required parts, skills, scheduling hints.
+ * 4. Optional handoff to KB Builder if the Investigator needs a threshold
+ *    lookup.
  *
  * Gated on `import.meta.env.DEV` so production builds strip the button
  * entirely (Vite tree-shakes the consumer when the gate is false). The
- * backend endpoint itself is gated server-side behind `ARIA_DEMO_ENABLED`,
- * so even a leaked bundle can't trigger it in prod.
+ * backend endpoint itself is gated server-side behind `ARIA_DEMO_ENABLED`.
  *
- * Mounted as a fixed floating control in the bottom-right of the viewport
- * so it is reachable from any page (Control Room, Work Orders, etc.)
- * without collision with TopBar / Chat drawer / Agent Inspector.
- *
- * Remove post-demo along with `backend/modules/debug/`.
+ * Mounted as a fixed floating control in the bottom-left of the viewport
+ * so it is reachable from any page without collision with TopBar / Chat
+ * drawer / Agent Inspector.
  */
 
 import { useState } from "react";
@@ -29,10 +32,19 @@ interface RecentWorkOrder {
     title: string;
 }
 
+interface FullFlowResponse {
+    work_order_id: number;
+    cell_id: number;
+    cell_name: string;
+    previous_status: string;
+    title: string;
+    spawned: boolean;
+}
+
 export function DemoReplayButton() {
     const [busy, setBusy] = useState(false);
     const [error, setError] = useState<string | null>(null);
-    const [lastSpawned, setLastSpawned] = useState<RecentWorkOrder | null>(null);
+    const [lastSpawned, setLastSpawned] = useState<FullFlowResponse | null>(null);
 
     async function replay() {
         setBusy(true);
@@ -50,14 +62,15 @@ export function DemoReplayButton() {
             }
             const wo = wos[0];
 
-            const replayResp = await fetch(`/api/v1/debug/replay-investigator/${wo.id}`, {
+            const replayResp = await fetch(`/api/v1/debug/replay-full-flow/${wo.id}`, {
                 method: "POST",
                 credentials: "include",
             });
             if (!replayResp.ok) {
                 throw new Error(`replay ${replayResp.status}`);
             }
-            setLastSpawned(wo);
+            const spawned = (await replayResp.json()) as FullFlowResponse;
+            setLastSpawned(spawned);
         } catch (e) {
             setError(e instanceof Error ? e.message : "replay failed");
         } finally {
@@ -72,16 +85,16 @@ export function DemoReplayButton() {
                     type="button"
                     onClick={replay}
                     disabled={busy}
-                    aria-label="Replay Investigator on the most recent work order (demo trigger)"
+                    aria-label="Replay the full multi-agent flow on the most recent work order (demo trigger)"
                     className="inline-flex h-7 items-center gap-1.5 rounded-[var(--ds-radius-sm)] bg-transparent px-2 text-[var(--ds-text-xs)] font-medium text-[var(--ds-fg-muted)] transition-colors duration-[var(--ds-motion-fast)] hover:bg-[var(--ds-accent-soft)] hover:text-[var(--ds-accent)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ds-accent-ring)] disabled:opacity-60"
                 >
                     <Icons.Play className="size-3" aria-hidden />
-                    {busy ? "Replaying…" : "Replay last investigation"}
+                    {busy ? "Replaying full flow…" : "Replay full agent flow"}
                     <span className="text-[var(--ds-fg-subtle)]">· dev</span>
                 </button>
                 {lastSpawned != null && !error && (
                     <span className="text-[var(--ds-text-xs)] text-[var(--ds-fg-subtle)]">
-                        → WO #{lastSpawned.id} (cell {lastSpawned.cell_id})
+                        → WO #{lastSpawned.work_order_id} ({lastSpawned.cell_name})
                     </span>
                 )}
                 {error && (


### PR DESCRIPTION
## Summary

Upgrade the demo trigger to replay the **full multi-agent choreography** on one click, instead of just the Investigator. The pitch is "watch our agents collaborate" — the button now lights up the whole chain.

## What the button does now

Clicking **Replay full agent flow** (bottom-left, DEV-only, gated on `ARIA_DEMO_ENABLED`):

1. **Sentinel** broadcasts `anomaly_detected` + `ui_render(alert_banner)` — red banner at the top, Sentinel row in the Activity Feed.
2. Short **1.5 s dramatic pause** so the audience sees the alert register.
3. **Investigator** spawns (Opus 4.7 extended thinking, `display: "summarized"` so the Agent Inspector Thinking tab streams live):
   - `agent_start(investigator)`
   - Many `thinking_delta` chunks
   - Tool calls: `get_signal_trend`, `get_equipment_kb`, `get_failure_history`, `get_signal_anomalies`, `render_signal_chart`, `render_diagnostic_card`, `render_pattern_match`…
   - `submit_rca` with structured RCA
   - `agent_end(investigator)`
4. **Work Order Generator** auto-chains (existing in-process hook `spawn_work_order_generator`):
   - `agent_start(work_order_generator)`
   - Tool calls to enrich the WO with `recommended_actions`, `required_parts`, `required_skills`, `estimated_duration_min`
   - `submit_work_order`
   - `agent_end(work_order_generator)`
5. **KB Builder** handoff if the Investigator calls `ask_kb_builder` during its loop (already wired upstream, not forced).

The server also resets `rca_summary`, `recommended_actions`, `required_parts`, `required_skills`, `estimated_duration_min` on the WO before replaying, so the audience sees the work order populate from scratch on the `/work-orders/:id` page.

## Changes

- `backend/modules/debug/router.py`: new `POST /api/v1/debug/replay-full-flow/{id}` endpoint with Sentinel-then-Investigator choreography in a background task. Legacy `/replay-investigator/{id}` kept for backward compat.
- `frontend/src/features/demo/DemoReplayButton.tsx`: calls the new endpoint, updated copy to "Replay full agent flow".

Both layers remain gated (server: `ARIA_DEMO_ENABLED=true`; client: `import.meta.env.DEV`).

## Test plan

- [ ] `curl -X POST http://localhost:8000/api/v1/debug/replay-full-flow/73 --cookie …` → 202 with `{work_order_id, cell_id, cell_name, previous_status, title, spawned}`.
- [ ] In DEV browser, open the chat drawer + Activity Feed and click the button bottom-left.
- [ ] Anomaly banner appears at the top (Sentinel alert).
- [ ] Activity Feed fills: Sentinel row → pause → Investigator thinking → many Investigator tool rows → handoff? → submit_rca → Work Order Generator tool rows → submit_work_order → done.
- [ ] Click the Investigator badge on any of its rows → Agent Inspector Thinking tab streams extended thinking live.
- [ ] After a minute, open `/work-orders/{id}` → status is `analyzed`, `rca_summary`, recommended actions, parts, skills all populated.
- [ ] Close + reopen the Inspector at any point → buffer is preserved (M8.5 persistence fix from #131).

## Quality gates

- Frontend: `npm run typecheck` ✓ · `npm run check` ✓ · `npm run build` ✓ · `npm run test` ✓ (112 passed)
- Backend: no route conflicts (new path + legacy path both mounted behind `ARIA_DEMO_ENABLED`)

## Removable post-demo

Delete `backend/modules/debug/` and `frontend/src/features/demo/`, revert the two mount points (`backend/main.py`, `frontend/src/app/AppShell.tsx`). Same scope as the original demo trigger.